### PR TITLE
[feat] Claude stats-cache.json 기반 로컬 usage 표시

### DIFF
--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -1,15 +1,66 @@
 # Provider 메모
 
 ## OpenAI Codex
+
 - Endpoint: `https://chatgpt.com/backend-api/wham/usage`
-- 인증: OAuth bearer token
-- 선택 헤더: `ChatGPT-Account-Id`
-- 상태: 현재 로컬 환경에서 실작동 검증 완료
+- 인증: OAuth bearer token (`Authorization: Bearer <accessToken>`)
+- 선택 헤더: `ChatGPT-Account-Id` (다중 계정 구분용)
+- 상태: **실작동 검증 완료** (live 200 OK 확인)
+
+### auth 흐름
+
+- 기본: localhost callback OAuth (`http://localhost:<port>/auth/callback`)
+  - PKCE S256 / state 검증 포함
+  - 포트 충돌 시 자동 fallback (최대 3회) → manual paste 전환
+- fallback: `--manual` 플래그로 callback URL / code 직접 붙여넣기
+- token exchange: `--live-exchange` 플래그로 실 endpoint POST
+  - `client_id`는 observed 값 기반 (공식 확정 아님)
+- auth store 우선순위: `agent-store > openclaw-import`
+
+### 알려진 제한
+
+- `auth logout`은 로컬 store 제거만 수행 (provider revoke endpoint 미호출)
+- 네트워크 호출에 timeout/AbortController 없음 → `#7` 참고
+
+---
 
 ## Anthropic / Claude
-- OAuth endpoint: `https://api.anthropic.com/api/oauth/usage`
-- Web fallback:
-  - `https://claude.ai/api/organizations`
-  - `https://claude.ai/api/organizations/{orgId}/usage`
-- 인증: OAuth token 또는 claude.ai session key/cookie fallback
-- 상태: endpoint 경로는 확인했지만, 현재 로컬 인증이 없어 실호출 검증은 아직 미완료
+
+### 인증 (local import)
+
+- credential 파일: `~/.claude/.credentials.json`
+- 구조: `{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier } }`
+- 상태: **local credential reuse 검증 완료**
+- `auth import claude`로 agent-store에 저장 가능
+- 독립 OAuth 재구현은 미완료 (후순위)
+
+### usage (로컬 stats-cache)
+
+- 파일: `~/.claude/stats-cache.json`
+- Claude Code가 실행될 때 자동 갱신
+- 구조:
+  ```json
+  {
+    "version": 3,
+    "totalSessions": 42,
+    "totalMessages": 1200,
+    "modelUsage": { "claude-opus-4-6": 10 },
+    "dailyModelTokens": {
+      "2026-04-14": {
+        "claude-opus-4-6": {
+          "inputTokens": 5000,
+          "outputTokens": 2000,
+          "cacheCreation": 300,
+          "cacheRead": 1500
+        }
+      }
+    }
+  }
+  ```
+- 상태: **감지 및 최소 파싱 완료** (totalSessions, totalMessages, modelUsage/dailyModelTokens 유무)
+- 상세 토큰 수치 파싱은 다음 단계
+
+### 알려진 제한
+
+- 네트워크 기반 usage API (`/api/oauth/usage` 등) 실호출 검증 미완료
+- stats-cache는 로컬 캐시 — 실시간 서버 데이터와 다를 수 있음

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -18,6 +18,19 @@ export function formatClaudeSection(snapshot) {
   lines.push(`  authSource:      ${snapshot.authSource}`);
   lines.push(`  accountKey:      ${snapshot.selectedAccount?.accountKey ?? '(없음)'}`);
   lines.push(`  authType:        ${snapshot.selectedAccount?.authType ?? '(알 수 없음)'}`);
+
+  const usage = snapshot.usage;
+  if (usage && usage.source !== 'not-found') {
+    lines.push('');
+    lines.push('Claude usage (stats-cache.json):');
+    lines.push(`  totalSessions:       ${usage.totalSessions ?? '알 수 없음'}`);
+    lines.push(`  totalMessages:       ${usage.totalMessages ?? '알 수 없음'}`);
+    lines.push(`  hasModelUsage:       ${usage.hasModelUsage}`);
+    lines.push(`  hasDailyModelTokens: ${usage.hasDailyModelTokens}`);
+  } else {
+    lines.push('  usage: 데이터 없음 (stats-cache.json 미발견)');
+  }
+
   return lines;
 }
 

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -14,6 +14,8 @@ export async function runStatusCommand(command) {
   console.log(`서버 sync: ${snapshot.sync.enabled ? 'enabled' : 'disabled'}`);
   console.log('');
   printCodexSection(snapshot.codex);
+  console.log('');
+  printClaudeSection(snapshot.claude);
 }
 
 function printCodexSection(codex) {
@@ -50,6 +52,28 @@ function printCodexSection(codex) {
       console.log(`  에러: ${snapshot.status.message}`);
     }
   }
+}
+
+function printClaudeSection(claude) {
+  console.log('Claude usage');
+  console.log('------------');
+  console.log(`인증 소스: ${claude.authSource}`);
+  console.log(`credential 감지: ${claude.detected}`);
+  if (claude.selectedAccount) {
+    console.log(`계정: ${claude.selectedAccount.accountKey}`);
+  }
+
+  const usage = claude.usage;
+  if (!usage || usage.source === 'not-found') {
+    console.log('usage 데이터 없음 (stats-cache.json 미발견)');
+    return;
+  }
+
+  console.log(`usage 소스: ${usage.source}`);
+  console.log(`총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
+  console.log(`총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
+  console.log(`모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
+  console.log(`일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
 }
 
 function formatWindow(window) {

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -5,6 +5,8 @@ import { fetchCodexUsage, getDefaultAuthProfilesPath, readCodexAuthProfiles } fr
 import { resolveClaudeCredentialsPath, readClaudeCredentials } from '../../../provider-adapters/src/claude/read-claude-credentials.js';
 import { resolveImportedClaudeSnapshot } from '../../../provider-adapters/src/claude/resolve-imported-claude-snapshot.js';
 import { resolveClaudeAccount } from '../auth/resolve-claude-account.js';
+import { resolveClaudeUsageSourcePath } from '../../../provider-adapters/src/claude/resolve-claude-usage-source.js';
+import { readClaudeStatsCache } from '../../../provider-adapters/src/claude/read-claude-stats-cache.js';
 import { SCHEMA_VERSION } from '../../../schemas/src/index.js';
 import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
 import { resolveDefaultAccount } from '../auth/account-resolver.js';
@@ -15,7 +17,7 @@ export async function getStatusSnapshot() {
   const configPath = resolveAgentConfigPath();
   const config = loadConfig(configPath);
   const codex = await getCodexSnapshot(config);
-  const claude = buildClaudeSnapshot(resolveClaudeCredentialsPath());
+  const claude = buildClaudeSnapshot(resolveClaudeCredentialsPath(), readClaudeCredentials, [], resolveClaudeUsageSourcePath());
 
   return {
     schemaVersion: SCHEMA_VERSION,
@@ -51,12 +53,20 @@ export function selectClaudeAuthSource(agentAccounts, importedCredential) {
  * readFn is injectable so tests don't touch the filesystem.
  * agentClaudeAccounts is the list of Claude accounts from the agent-store
  * (currently always empty until Claude login is implemented).
+ * usageSourcePath is the path to stats-cache.json (injectable for tests).
  */
-export function buildClaudeSnapshot(credentialsPath, readFn = readClaudeCredentials, agentClaudeAccounts = []) {
+export function buildClaudeSnapshot(
+  credentialsPath,
+  readFn = readClaudeCredentials,
+  agentClaudeAccounts = [],
+  usageSourcePath = resolveClaudeUsageSourcePath(),
+  readStatsCacheFn = readClaudeStatsCache,
+) {
   const credentials = readFn(credentialsPath);
   const found = credentials !== null;
   const imported = resolveImportedClaudeSnapshot(credentials);
   const { account: selectedAccount, authSource } = resolveClaudeAccount(agentClaudeAccounts, imported.accounts);
+  const statsCache = readStatsCacheFn(usageSourcePath);
   return {
     detected: found || agentClaudeAccounts.length > 0,
     authSource,
@@ -65,6 +75,15 @@ export function buildClaudeSnapshot(credentialsPath, readFn = readClaudeCredenti
     parsed: found,
     selectedAccount,
     importedAccount: selectedAccount, // backward-compat alias — prefer selectedAccount
+    usage: statsCache
+      ? {
+          source: 'stats-cache-json',
+          totalSessions: statsCache.totalSessions,
+          totalMessages: statsCache.totalMessages,
+          hasModelUsage: statsCache.hasModelUsage,
+          hasDailyModelTokens: statsCache.hasDailyModelTokens,
+        }
+      : { source: 'not-found' },
   };
 }
 

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -120,4 +120,38 @@ describe('formatClaudeSection', () => {
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('authType') && l.includes('알 수 없음')));
   });
+
+  it('shows usage stats when usage source is stats-cache-json', () => {
+    const snapshot = {
+      credentialsPath: FAKE_PATH,
+      found: true,
+      parsed: true,
+      authSource: 'claude-cli-import',
+      selectedAccount: null,
+      usage: {
+        source: 'stats-cache-json',
+        totalSessions: 10,
+        totalMessages: 200,
+        hasModelUsage: true,
+        hasDailyModelTokens: false,
+      },
+    };
+    const lines = formatClaudeSection(snapshot);
+    assert.ok(lines.some((l) => l.includes('totalSessions') && l.includes('10')));
+    assert.ok(lines.some((l) => l.includes('totalMessages') && l.includes('200')));
+    assert.ok(lines.some((l) => l.includes('hasModelUsage') && l.includes('true')));
+  });
+
+  it('shows not-found message when usage source is not-found', () => {
+    const snapshot = {
+      credentialsPath: FAKE_PATH,
+      found: false,
+      parsed: false,
+      authSource: 'not-found',
+      selectedAccount: null,
+      usage: { source: 'not-found' },
+    };
+    const lines = formatClaudeSection(snapshot);
+    assert.ok(lines.some((l) => l.includes('데이터 없음')));
+  });
 });

--- a/packages/agent/test/services/status-service.test.js
+++ b/packages/agent/test/services/status-service.test.js
@@ -209,4 +209,26 @@ describe('buildClaudeSnapshot', () => {
     assert.equal(result.selectedAccount?.accountKey, 'claude:alice');
     assert.equal(result.importedAccount?.accountKey, 'claude:alice'); // alias check
   });
+
+  it('includes usage from stats-cache when available', () => {
+    const fakeStatsCache = {
+      version: 3,
+      totalSessions: 10,
+      totalMessages: 200,
+      hasModelUsage: true,
+      hasDailyModelTokens: false,
+      raw: {},
+    };
+    const result = buildClaudeSnapshot(FAKE_PATH, () => null, [], '/fake/stats-cache.json', () => fakeStatsCache);
+    assert.equal(result.usage.source, 'stats-cache-json');
+    assert.equal(result.usage.totalSessions, 10);
+    assert.equal(result.usage.totalMessages, 200);
+    assert.equal(result.usage.hasModelUsage, true);
+    assert.equal(result.usage.hasDailyModelTokens, false);
+  });
+
+  it('includes usage.source=not-found when stats-cache is unavailable', () => {
+    const result = buildClaudeSnapshot(FAKE_PATH, () => null, [], '/fake/stats-cache.json', () => null);
+    assert.equal(result.usage.source, 'not-found');
+  });
 });

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -15,3 +15,4 @@ export {
   resolveClaudeUsageSource,
 } from './resolve-claude-usage-source.js';
 export { parseClaudeStatsCache } from './parse-claude-stats-cache.js';
+export { readClaudeStatsCache } from './read-claude-stats-cache.js';

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -14,3 +14,4 @@ export {
   resolveClaudeUsageSourcePath,
   resolveClaudeUsageSource,
 } from './resolve-claude-usage-source.js';
+export { parseClaudeStatsCache } from './parse-claude-stats-cache.js';

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -10,3 +10,7 @@ export { buildImportedClaudeAccount } from './build-imported-account.js';
 export { resolveImportedClaudeAccounts } from './resolve-imported-claude-accounts.js';
 export { selectClaudeAccountsSource } from './select-claude-accounts-source.js';
 export { resolveImportedClaudeSnapshot } from './resolve-imported-claude-snapshot.js';
+export {
+  resolveClaudeUsageSourcePath,
+  resolveClaudeUsageSource,
+} from './resolve-claude-usage-source.js';

--- a/packages/provider-adapters/src/claude/parse-claude-stats-cache.js
+++ b/packages/provider-adapters/src/claude/parse-claude-stats-cache.js
@@ -1,0 +1,19 @@
+/**
+ * @param {unknown} raw
+ * @returns {{ version: number|null, totalSessions: number|null, totalMessages: number|null, hasModelUsage: boolean, hasDailyModelTokens: boolean, raw: unknown } | null}
+ */
+export function parseClaudeStatsCache(raw) {
+  if (raw === null || typeof raw !== 'object') return null;
+
+  const num = (v) => (typeof v === 'number' ? v : null);
+
+  return {
+    version: num(raw.version),
+    totalSessions: num(raw.totalSessions),
+    totalMessages: num(raw.totalMessages),
+    hasModelUsage: raw.modelUsage !== null && typeof raw.modelUsage === 'object',
+    hasDailyModelTokens:
+      raw.dailyModelTokens !== null && typeof raw.dailyModelTokens === 'object',
+    raw,
+  };
+}

--- a/packages/provider-adapters/src/claude/read-claude-stats-cache.js
+++ b/packages/provider-adapters/src/claude/read-claude-stats-cache.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import { resolveClaudeUsageSourcePath } from './resolve-claude-usage-source.js';
+import { parseClaudeStatsCache } from './parse-claude-stats-cache.js';
+
+/**
+ * stats-cache.json을 읽어 파싱된 결과를 반환한다.
+ * 파일이 없거나 JSON 파싱 실패 시 null을 반환한다.
+ *
+ * @param {string} [sourcePath] - stats-cache.json 경로 (기본값: resolveClaudeUsageSourcePath())
+ * @returns {{ version: number|null, totalSessions: number|null, totalMessages: number|null, hasModelUsage: boolean, hasDailyModelTokens: boolean, raw: unknown } | null}
+ */
+export function readClaudeStatsCache(sourcePath = resolveClaudeUsageSourcePath()) {
+  if (!fs.existsSync(sourcePath)) {
+    return null;
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+  } catch {
+    return null;
+  }
+
+  return parseClaudeStatsCache(raw);
+}

--- a/packages/provider-adapters/src/claude/resolve-claude-usage-source.js
+++ b/packages/provider-adapters/src/claude/resolve-claude-usage-source.js
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+export function resolveClaudeUsageSourcePath(base = os.homedir()) {
+  return path.join(base, '.claude', 'stats-cache.json');
+}
+
+/**
+ * Resolves the local Claude usage data source.
+ *
+ * Returns a descriptor indicating whether usage data is available and where.
+ * Claude Code writes `~/.claude/stats-cache.json` as its local stats artifact.
+ * No network call is made.
+ *
+ * @param {string} [base] - Home directory base (defaults to os.homedir())
+ * @returns {{ available: boolean, kind: 'stats-cache-json' | 'not-found', path: string, reason: string }}
+ */
+export function resolveClaudeUsageSource(base = os.homedir()) {
+  const sourcePath = resolveClaudeUsageSourcePath(base);
+
+  if (fs.existsSync(sourcePath)) {
+    return {
+      available: true,
+      kind: 'stats-cache-json',
+      path: sourcePath,
+      reason: 'found ~/.claude/stats-cache.json written by Claude Code',
+    };
+  }
+
+  return {
+    available: false,
+    kind: 'not-found',
+    path: sourcePath,
+    reason: 'stats-cache.json not found — Claude Code may not have run yet',
+  };
+}

--- a/packages/provider-adapters/test/claude/parse-claude-stats-cache.test.js
+++ b/packages/provider-adapters/test/claude/parse-claude-stats-cache.test.js
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseClaudeStatsCache } from '../../src/claude/parse-claude-stats-cache.js';
+
+describe('parseClaudeStatsCache', () => {
+  it('returns null for null', () => {
+    assert.equal(parseClaudeStatsCache(null), null);
+  });
+
+  it('returns null for undefined', () => {
+    assert.equal(parseClaudeStatsCache(undefined), null);
+  });
+
+  it('returns null for non-object primitives', () => {
+    assert.equal(parseClaudeStatsCache(42), null);
+    assert.equal(parseClaudeStatsCache('string'), null);
+    assert.equal(parseClaudeStatsCache(true), null);
+  });
+
+  it('extracts version, totalSessions, totalMessages from valid object', () => {
+    const raw = { version: 3, totalSessions: 10, totalMessages: 200 };
+    const result = parseClaudeStatsCache(raw);
+
+    assert.equal(result.version, 3);
+    assert.equal(result.totalSessions, 10);
+    assert.equal(result.totalMessages, 200);
+    assert.equal(result.raw, raw);
+  });
+
+  it('sets hasModelUsage true when modelUsage is an object', () => {
+    const result = parseClaudeStatsCache({ modelUsage: { 'claude-3': 5 } });
+    assert.equal(result.hasModelUsage, true);
+  });
+
+  it('sets hasModelUsage false when modelUsage is absent or non-object', () => {
+    assert.equal(parseClaudeStatsCache({}).hasModelUsage, false);
+    assert.equal(parseClaudeStatsCache({ modelUsage: null }).hasModelUsage, false);
+    assert.equal(parseClaudeStatsCache({ modelUsage: 'x' }).hasModelUsage, false);
+  });
+
+  it('sets hasDailyModelTokens true when dailyModelTokens is an object', () => {
+    const result = parseClaudeStatsCache({ dailyModelTokens: { '2026-04-14': {} } });
+    assert.equal(result.hasDailyModelTokens, true);
+  });
+
+  it('sets hasDailyModelTokens false when dailyModelTokens is absent or non-object', () => {
+    assert.equal(parseClaudeStatsCache({}).hasDailyModelTokens, false);
+    assert.equal(parseClaudeStatsCache({ dailyModelTokens: null }).hasDailyModelTokens, false);
+    assert.equal(parseClaudeStatsCache({ dailyModelTokens: 0 }).hasDailyModelTokens, false);
+  });
+
+  it('falls back to null for non-number fields', () => {
+    const result = parseClaudeStatsCache({
+      version: 'v3',
+      totalSessions: null,
+      totalMessages: undefined,
+    });
+    assert.equal(result.version, null);
+    assert.equal(result.totalSessions, null);
+    assert.equal(result.totalMessages, null);
+  });
+});

--- a/packages/provider-adapters/test/claude/read-claude-stats-cache.test.js
+++ b/packages/provider-adapters/test/claude/read-claude-stats-cache.test.js
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { readClaudeStatsCache } from '../../src/claude/read-claude-stats-cache.js';
+
+describe('readClaudeStatsCache', () => {
+  it('returns null when file does not exist', () => {
+    const nonExistent = path.join(os.tmpdir(), `no-such-stats-cache-${Date.now()}.json`);
+    assert.equal(readClaudeStatsCache(nonExistent), null);
+  });
+
+  it('returns null when file contains invalid JSON', () => {
+    const tmpFile = path.join(os.tmpdir(), `stats-cache-bad-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, 'not-json', 'utf8');
+    try {
+      assert.equal(readClaudeStatsCache(tmpFile), null);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('returns null when file contains non-object JSON', () => {
+    const tmpFile = path.join(os.tmpdir(), `stats-cache-prim-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, '42', 'utf8');
+    try {
+      assert.equal(readClaudeStatsCache(tmpFile), null);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('reads and parses a valid stats-cache file', () => {
+    const payload = { version: 3, totalSessions: 10, totalMessages: 200 };
+    const tmpFile = path.join(os.tmpdir(), `stats-cache-valid-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(payload), 'utf8');
+    try {
+      const result = readClaudeStatsCache(tmpFile);
+      assert.equal(result.version, 3);
+      assert.equal(result.totalSessions, 10);
+      assert.equal(result.totalMessages, 200);
+      assert.equal(result.hasModelUsage, false);
+      assert.equal(result.hasDailyModelTokens, false);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
+  it('detects modelUsage and dailyModelTokens when present', () => {
+    const payload = {
+      version: 3,
+      totalSessions: 5,
+      totalMessages: 50,
+      modelUsage: { 'claude-opus-4-6': 5 },
+      dailyModelTokens: { '2026-04-14': {} },
+    };
+    const tmpFile = path.join(os.tmpdir(), `stats-cache-full-${Date.now()}.json`);
+    fs.writeFileSync(tmpFile, JSON.stringify(payload), 'utf8');
+    try {
+      const result = readClaudeStatsCache(tmpFile);
+      assert.equal(result.hasModelUsage, true);
+      assert.equal(result.hasDailyModelTokens, true);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+});

--- a/packages/provider-adapters/test/claude/resolve-claude-usage-source.test.js
+++ b/packages/provider-adapters/test/claude/resolve-claude-usage-source.test.js
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  resolveClaudeUsageSourcePath,
+  resolveClaudeUsageSource,
+} from '../../src/claude/resolve-claude-usage-source.js';
+
+describe('resolveClaudeUsageSourcePath', () => {
+  it('joins base with .claude/stats-cache.json', () => {
+    const result = resolveClaudeUsageSourcePath('/home/user');
+    assert.equal(result, path.join('/home/user', '.claude', 'stats-cache.json'));
+  });
+
+  it('defaults to os.homedir() when no base is given', () => {
+    const result = resolveClaudeUsageSourcePath();
+    assert.equal(result, path.join(os.homedir(), '.claude', 'stats-cache.json'));
+  });
+});
+
+describe('resolveClaudeUsageSource', () => {
+  it('returns not-found when stats-cache.json is absent', () => {
+    const base = path.join(os.tmpdir(), `claude-usage-test-absent-${Date.now()}`);
+    const result = resolveClaudeUsageSource(base);
+
+    assert.equal(result.available, false);
+    assert.equal(result.kind, 'not-found');
+    assert.equal(result.path, path.join(base, '.claude', 'stats-cache.json'));
+    assert.ok(result.reason.length > 0);
+  });
+
+  it('returns stats-cache-json when the file exists', () => {
+    const base = path.join(os.tmpdir(), `claude-usage-test-present-${Date.now()}`);
+    const claudeDir = path.join(base, '.claude');
+    const cacheFile = path.join(claudeDir, 'stats-cache.json');
+
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(cacheFile, JSON.stringify({ version: 3, totalSessions: 1 }), 'utf8');
+
+    try {
+      const result = resolveClaudeUsageSource(base);
+      assert.equal(result.available, true);
+      assert.equal(result.kind, 'stats-cache-json');
+      assert.equal(result.path, cacheFile);
+      assert.ok(result.reason.length > 0);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('result shape always has all four fields', () => {
+    const base = path.join(os.tmpdir(), `claude-usage-test-shape-${Date.now()}`);
+    const result = resolveClaudeUsageSource(base);
+
+    assert.ok('available' in result);
+    assert.ok('kind' in result);
+    assert.ok('path' in result);
+    assert.ok('reason' in result);
+  });
+});


### PR DESCRIPTION
## 요약

`~/.claude/stats-cache.json`을 읽어 Claude 로컬 사용량(총 세션/메시지 수, 모델별 usage 유무)을 status/doctor에 노출한다.

Base: `feat/claude-auth-foundation` (#16) — 그 PR이 머지되면 base는 dev로 자동 전환.

## 변경 내용

- `packages/provider-adapters/src/claude/`
  - `resolve-claude-usage-source`, `parse-claude-stats-cache`, `read-claude-stats-cache`
  - stats-cache 유무 탐지 + 최소 필드 파싱
- `packages/agent/src/services/status-service.js`
  - Claude snapshot에 `usage` 필드 추가 (stats-cache 기반)
- `packages/agent/src/cli/`
  - `status`, `doctor claude`에 usage 섹션 표시
- `docs/provider-notes.md` 업데이트

## 변경 이유

Claude CLI 바이너리가 자체 기록한 로컬 캐시를 활용하면 네트워크 호출 없이도 `status` 출력에 의미 있는 수치가 붙는다. Phase 3(live OAuth) 전까지의 저비용 신호 채널로 활용.

## 영향 범위

- [x] `packages/agent`
- [ ] `packages/schemas`
- [x] `packages/provider-adapters`
- [ ] `repo`
- [x] `docs`

## 테스트 / 확인

- `parse-claude-stats-cache.test.js`, `read-claude-stats-cache.test.js`
- `status-service.test.js`에 usage 필드 검증 케이스 추가
- `doctor-command.test.js`에 stats-cache 기반 출력 케이스 추가

## 리뷰 포인트

- 현재 파서는 최소 필드(`totalSessions`, `totalMessages`, `hasModelUsage`, `hasDailyModelTokens`)만 추출. 상세 토큰 집계는 차후 확장 예정.
- stats-cache는 Claude CLI가 동작해야 생성되므로 환경에 따라 "데이터 없음" 케이스가 존재.

## 참고 사항

위로 `feat/claude-oauth-foundation` (live usage + OAuth) PR이 올라옵니다.