### PR TITLE
[feat] Claude live OAuth 로그인 + 실시간 usage 조회

### DIFF
--- a/docs/claude-oauth-plan.md
+++ b/docs/claude-oauth-plan.md
@@ -1,0 +1,158 @@
+# Claude OAuth + usage 기능 개발 계획
+
+Codex OAuth(OpenClaw 참고) 구조를 기반으로 Claude 쪽에도 동등한 auth + usage 체계를 구축한다.
+본 문서는 feat/claude-oauth-foundation 브랜치의 작업 단위와 우선순위를 정의한다.
+
+## 배경 / 확인된 사실
+
+1. Claude Code는 `~/.claude/.credentials.json`에 OAuth token을 저장한다.
+   - 구조: `claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier }`
+
+2. 검증된 usage endpoint:
+   ```
+   GET https://api.anthropic.com/api/oauth/usage
+   Authorization: Bearer <accessToken>
+   anthropic-version: 2023-06-01
+   anthropic-beta: oauth-2025-04-20
+   ```
+
+3. Web fallback:
+   - `GET https://claude.ai/api/organizations`
+   - `GET https://claude.ai/api/organizations/{orgId}/usage`
+   - `Cookie: sessionKey=<claude.ai session>`
+
+4. 현재 구현 범위:
+   - credential import (`auth import claude`)
+   - status/auth list/doctor에서 계정 노출
+   - stats-cache.json 기반 로컬 usage 파싱 (최소 필드)
+
+5. 아직 없는 것:
+   - 실제 네트워크 호출 (usage endpoint, token endpoint 모두)
+   - 독립 OAuth code flow
+   - refresh 경로
+
+## Phase 1 — live usage 호출 (저위험, 즉시 가치)
+
+### 목표
+기존 CLI-import 토큰으로 `api.anthropic.com/api/oauth/usage`를 호출하여
+실시간 사용량 수치를 snapshot으로 노출한다.
+
+### 선택 근거
+토큰은 이미 `~/.claude/.credentials.json`에 존재하므로 OAuth flow 없이도
+live 데이터가 확보된다. stats-cache와 비교 검증도 가능하다.
+
+### 구현 범위
+- `packages/provider-adapters/src/claude/fetch-claude-usage.js`
+  - Codex의 `fetchCodexUsage` 구조와 맞춤
+  - `SCHEMA_VERSION` 기반 공통 snapshot 반환
+  - fetchImpl 주입 가능 (테스트용)
+- `status-service.js`의 Claude snapshot에 `networkUsage` 필드 추가
+  - 기존 stats-cache 기반 `usage` 필드는 유지
+  - live 우선, 실패 시 stats-cache fallback 가능하도록 구조화
+- CLI에서 live usage 노출 (`status`, `doctor claude`)
+- 테스트: mock fetchImpl로 snapshot 정규화 검증
+
+### 완료 조건
+- 실제 Claude CLI 토큰으로 200 OK 응답을 받아 snapshot 변환 확인
+- 네트워크 실패 시에도 전체 status가 깨지지 않음 (per-provider isolation)
+- Unit test로 성공/실패 snapshot 변환 검증
+
+### 영향 범위
+- `packages/provider-adapters`
+- `packages/agent`
+
+---
+
+## Phase 2 — refresh token 재발급 (안정성)
+
+### 목표
+`accessToken` 만료 시 `refreshToken`으로 재발급하여 장기 운영 안정성을 확보한다.
+
+### 미해결 항목
+- Claude OAuth token endpoint URL (공식 문서 없음)
+  - Claude CLI 바이너리 / OpenClaw 코드에서 관찰 필요
+- client_id 관찰값 확인
+
+### 조사 단계 (구현 전)
+- `~/.local/share/claude/versions/<v>` 바이너리 strings 추출
+  - `oauth/token`, `client_id`, `token_endpoint` 후보
+- OpenClaw `dist/*.js`에서 Claude OAuth refresh 흔적 탐색
+
+### 구현 범위
+- `refresh-claude-token.js` (Codex 패턴 모방, `allowLiveExchange` guard 포함)
+- `doctor claude --refresh-live` 커맨드
+- 성공 시 store 갱신 (rotation 대응)
+
+### 완료 조건
+- refresh 호출이 성공적으로 새 토큰 반환
+- store가 올바르게 갱신됨 (rotation 시 기존 refreshToken 교체)
+- 실패 시 기존 store 유지 + 에러 메시지 명확
+
+### 영향 범위
+- `packages/provider-adapters`
+- `packages/agent`
+
+---
+
+## Phase 3 — 독립 OAuth flow (ambitious, 후순위)
+
+### 목표
+Claude CLI 의존 없이 직접 OAuth authorization code flow로 로그인한다.
+
+### 구현 범위 (Codex 패턴 동일)
+- `build-claude-authorization-url.js`
+- `exchange-claude-authorization-code.js` (`allowLiveExchange` guard)
+- `claude-auth-constants.js` (authorize/token endpoint, client_id, scopes)
+- `auth login claude` 커맨드 (기존 `localhost-callback.js` 재사용)
+
+### 미해결 항목
+- Claude authorize endpoint URL
+- Claude OAuth 허용 client_id
+- PKCE 정책 (S256 지원 여부)
+- 허용 redirect_uri 포트/호스트 제약
+
+### 완료 조건
+- 브라우저에서 실제 로그인 후 localhost callback으로 code 수신
+- live token exchange 성공 및 store 저장
+- 독립 토큰으로 usage endpoint 200 OK 확인
+
+### 영향 범위
+- `packages/provider-adapters`
+- `packages/agent`
+
+---
+
+## Phase 4 — web session fallback (옵션)
+
+### 목표
+OAuth 토큰이 없거나 실패할 때 `claude.ai` session cookie로 usage 조회.
+
+### 우선순위
+낮음. OAuth 경로가 안정화되면 굳이 필요한지 재평가 후 결정한다.
+세션 키 관리 보안 이슈가 있으므로 신중히 접근.
+
+### 구현 시 고려
+- cookie 입력 UX (CLI paste? file? env?)
+- 세션 만료 처리
+- organizations endpoint로 orgId 자동 획득
+
+### 영향 범위
+- `packages/provider-adapters`
+- `packages/agent`
+
+---
+
+## 실행 순서
+
+1. Phase 1만 먼저 PR → merge
+2. Phase 2 조사 → 구현 → PR
+3. Phase 3 조사 → 구현 → PR
+4. Phase 4는 별도 판단
+
+각 Phase는 별도 GitHub 이슈로 추적한다.
+
+## 참고
+
+- Codex auth 구현 (`packages/provider-adapters/src/codex/`, `packages/agent/src/auth/`)
+- `docs/provider-notes.md` — Claude/Codex provider 메모
+- `docs/auth-architecture.md` — 전체 auth 아키텍처

--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -32,7 +32,23 @@
 - 구조: `{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier } }`
 - 상태: **local credential reuse 검증 완료**
 - `auth import claude`로 agent-store에 저장 가능
-- 독립 OAuth 재구현은 미완료 (후순위)
+
+### OAuth endpoints (observed)
+
+Claude Code 바이너리(`~/.local/share/claude/versions/<v>`) strings에서 관찰한 값.
+공식 문서 기재 없음 — observed 레벨.
+
+- authorize: `https://platform.claude.com/oauth/authorize`
+- token:     `https://platform.claude.com/v1/oauth/token`
+- manual redirect: `https://platform.claude.com/oauth/code/callback`
+- success page: `https://platform.claude.com/oauth/code/success?app=claude-code`
+- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e` (production claude-code)
+
+### refresh token
+
+- `refreshClaudeToken` 구현 (Codex와 동일한 guard 패턴)
+- `doctor claude --refresh-live`로 수동 검증 가능
+- store 반영은 Phase 3 claude login 이후 연결
 
 ### usage (로컬 stats-cache)
 

--- a/packages/agent/src/auth/localhost-callback.js
+++ b/packages/agent/src/auth/localhost-callback.js
@@ -38,9 +38,12 @@ export function generatePkce(bytes = 32) {
 
 /**
  * Build the localhost callback URL for a given port.
+ * @param {number} port
+ * @param {string} [path='/auth/callback'] - Callback path (provider-specific).
+ *   Codex는 `/auth/callback`, Claude는 `/callback`을 기본으로 사용한다.
  */
-export function buildCallbackUrl(port) {
-  return `http://localhost:${port}/auth/callback`;
+export function buildCallbackUrl(port, path = '/auth/callback') {
+  return `http://localhost:${port}${path}`;
 }
 
 /**
@@ -50,7 +53,10 @@ export function buildCallbackUrl(port) {
  * @param {number|null} options.preferredPort - --port flag value (null = auto)
  * @returns {Promise<{ ready: boolean, params: object|null, reason: string|null }>}
  */
-export async function prepareLocalhostCallback({ preferredPort = null } = {}) {
+export async function prepareLocalhostCallback({
+  preferredPort = null,
+  callbackPath = '/auth/callback',
+} = {}) {
   const { port, fallbackExhausted } = await resolveCallbackPort({ preferredPort });
 
   if (port == null) {
@@ -62,11 +68,11 @@ export async function prepareLocalhostCallback({ preferredPort = null } = {}) {
 
   const state = generateState();
   const pkce = generatePkce();
-  const callbackUrl = buildCallbackUrl(port);
+  const callbackUrl = buildCallbackUrl(port, callbackPath);
 
   return {
     ready: true,
-    params: { port, callbackUrl, state, ...pkce },
+    params: { port, callbackUrl, callbackPath, state, ...pkce },
     reason: null,
     fallbackExhausted: false,
   };
@@ -89,7 +95,12 @@ export async function prepareLocalhostCallback({ preferredPort = null } = {}) {
  * @param {number} [options.timeoutMs=120000]
  * @returns {Promise<{ code: string, state: string }>}
  */
-export function startLocalhostCallbackServer({ port, expectedState, timeoutMs = 120_000 }) {
+export function startLocalhostCallbackServer({
+  port,
+  expectedState,
+  timeoutMs = 120_000,
+  callbackPath = '/auth/callback',
+}) {
   return new Promise((resolve, reject) => {
     let settled = false;
     let timer;
@@ -97,7 +108,7 @@ export function startLocalhostCallbackServer({ port, expectedState, timeoutMs = 
     const server = createServer((req, res) => {
       const url = new URL(req.url, `http://127.0.0.1:${port}`);
 
-      if (url.pathname !== '/auth/callback') {
+      if (url.pathname !== callbackPath) {
         res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
         res.end('Not found');
         return;

--- a/packages/agent/src/auth/localhost-callback.js
+++ b/packages/agent/src/auth/localhost-callback.js
@@ -1,13 +1,14 @@
 /**
- * Localhost callback preparation for OAuth login flow.
+ * Localhost callback support for OAuth login flow.
  *
- * This module provides the scaffolding for:
- * - Callback URL construction
- * - PKCE S256 code_verifier / code_challenge generation
- * - OAuth state parameter generation
- * - Localhost callback server that receives code/state from browser redirect
+ * Codex / Claude 양쪽 auth login 플로우에서 공유하는 헬퍼 모음:
+ *   - PKCE S256 code_verifier / code_challenge 생성
+ *   - OAuth state 파라미터 생성
+ *   - 콜백 URL 조립 (provider별 path 차이를 callbackPath 인자로 흡수)
+ *   - 일회용 localhost 콜백 서버 (code/state 수신 + state 검증 + timeout)
  *
- * NOTE: This is still a placeholder/mock flow — no real token exchange occurs.
+ * 실제 token 교환은 호출자가 별도로 수행한다. 본 모듈은 transport 계층만
+ * 책임진다.
  */
 
 import { randomBytes, createHash } from 'node:crypto';
@@ -118,18 +119,18 @@ export function startLocalhostCallbackServer({
       const state = url.searchParams.get('state');
 
       if (!code) {
-        respond(res, 400, '[placeholder/mock] 오류: code 파라미터가 없습니다.');
+        respond(res, 400, '오류: code 파라미터가 없습니다.');
         finish(new Error('callback에 code 파라미터가 없습니다.'));
         return;
       }
 
       if (state !== expectedState) {
-        respond(res, 400, '[placeholder/mock] 오류: state 값이 일치하지 않습니다.');
+        respond(res, 400, '오류: state 값이 일치하지 않습니다.');
         finish(new Error('state mismatch — CSRF 검증 실패'));
         return;
       }
 
-      respond(res, 200, '[placeholder/mock] code/state 수신 완료. 이 창을 닫아도 됩니다.');
+      respond(res, 200, 'code/state 수신 완료. 이 창을 닫아도 됩니다.');
       finish(null, { code, state });
     });
 

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -410,7 +410,7 @@ async function runClaudeLiveExchange({ code, callbackUrl, codeVerifier, state })
     account.expiresAt = expiresAt;
 
     const store = await loadAuthStore();
-    const nextStore = upsertProviderAccount(store, CLAUDE_AUTH.provider, account);
+    const nextStore = upsertProviderAccount(store, CLAUDE_AUTH.storeProvider, account);
     await saveAuthStore(nextStore);
 
     console.log('');

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -87,7 +87,7 @@ async function runCodexLogin(args) {
     const result = await startLocalhostCallbackServer({
       port,
       expectedState: state,
-      timeoutMs: 120_000,
+      timeoutMs: options.timeoutMs,
     });
     console.log('');
     console.log(`code 수신 완료: ${result.code}`);
@@ -240,6 +240,7 @@ function parseLoginOptions(args) {
     device: false,
     liveExchange: false,
     port: null,
+    timeoutMs: 120_000,
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -252,6 +253,13 @@ function parseLoginOptions(args) {
       const value = args[index + 1];
       if (value) {
         options.port = Number(value);
+        index += 1;
+      }
+    }
+    if (arg === '--timeout') {
+      const value = args[index + 1];
+      if (value) {
+        options.timeoutMs = Number(value) * 1000;
         index += 1;
       }
     }
@@ -318,7 +326,7 @@ async function runClaudeLogin(args) {
     const result = await startLocalhostCallbackServer({
       port,
       expectedState: state,
-      timeoutMs: 120_000,
+      timeoutMs: options.timeoutMs,
       callbackPath: CLAUDE_CALLBACK_PATH,
     });
     console.log('');

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -5,6 +5,11 @@ import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/aut
 import { createAccount } from '../auth/auth-store-schema.js';
 import { extractAccountIdentity } from '../auth/token-claims.js';
 import { buildCodexAuthorizationUrl, exchangeCodexAuthorizationCode } from '../../../provider-adapters/src/codex/index.js';
+import {
+  buildClaudeAuthorizationUrl,
+  exchangeClaudeAuthorizationCode,
+  CLAUDE_AUTH,
+} from '../../../provider-adapters/src/claude/index.js';
 
 export async function runAuthLoginCommand(provider, args = []) {
   if (!provider) {
@@ -12,11 +17,20 @@ export async function runAuthLoginCommand(provider, args = []) {
     return;
   }
 
-  if (provider !== 'codex') {
-    console.log(`아직 login은 codex만 골격이 준비되어 있어. 입력된 provider: ${provider}`);
+  if (provider === 'codex') {
+    await runCodexLogin(args);
     return;
   }
 
+  if (provider === 'claude') {
+    await runClaudeLogin(args);
+    return;
+  }
+
+  console.log(`지원되지 않는 provider: ${provider} (사용 가능: codex, claude)`);
+}
+
+async function runCodexLogin(args) {
   const options = parseLoginOptions(args);
 
   if (options.device) {
@@ -244,4 +258,156 @@ function parseLoginOptions(args) {
   }
 
   return options;
+}
+
+// ─── Claude login flow ───────────────────────────────────────────────────────
+
+const CLAUDE_CALLBACK_PATH = '/callback';
+
+async function runClaudeLogin(args) {
+  const options = parseLoginOptions(args);
+
+  if (options.device) {
+    console.log('device code flow는 후순위 항목이라 아직 구현되지 않았어.');
+    return;
+  }
+
+  if (options.manual) {
+    console.log('claude manual paste 경로는 아직 제공하지 않습니다.');
+    console.log('대신 로컬 callback 경로를 사용하세요: ai-usage-agent auth login claude');
+    return;
+  }
+
+  const prepared = await prepareLocalhostCallback({
+    preferredPort: options.port,
+    callbackPath: CLAUDE_CALLBACK_PATH,
+  });
+
+  console.log('ai-usage-agent auth login claude');
+  console.log('---------------------------------');
+
+  if (!prepared.ready) {
+    console.log(prepared.reason);
+    return;
+  }
+
+  const { port, callbackUrl, state, codeChallenge, codeChallengeMethod, codeVerifier } =
+    prepared.params;
+  const authorizationUrl = buildClaudeAuthorizationUrl({
+    callbackUrl,
+    state,
+    codeChallenge,
+    codeChallengeMethod,
+  });
+
+  console.log(`콜백 URL 준비됨: ${callbackUrl}`);
+  console.log(`선택된 포트: ${port}`);
+  console.log('OAuth state/PKCE 생성 완료 (S256)');
+  console.log('');
+  console.log('참고:');
+  console.log('- client_id는 Claude Code 바이너리 관찰값입니다 (공식 확정 아님).');
+  console.log('- 기본 경로는 --live-exchange 없이 실제 token 저장을 수행하지 않습니다.');
+  console.log('- 브라우저 자동 실행은 하지 않습니다.');
+  console.log('');
+  console.log('브라우저에서 열 URL:');
+  console.log(`  ${authorizationUrl}`);
+  console.log('');
+  console.log('로그인 완료 후 localhost callback 서버가 code/state 수신을 대기 중입니다...');
+
+  try {
+    const result = await startLocalhostCallbackServer({
+      port,
+      expectedState: state,
+      timeoutMs: 120_000,
+      callbackPath: CLAUDE_CALLBACK_PATH,
+    });
+    console.log('');
+    console.log(`code 수신 완료: ${result.code}`);
+
+    if (options.liveExchange) {
+      await runClaudeLiveExchange({ code: result.code, callbackUrl, codeVerifier });
+    } else {
+      console.log('');
+      console.log('--live-exchange가 없으므로 token 교환을 생략합니다.');
+      console.log('실제 토큰 저장이 필요하면 --live-exchange 옵션을 추가해 재실행하세요.');
+    }
+  } catch (err) {
+    console.log('');
+    console.log(`콜백 수신 실패: ${err.message}`);
+  }
+}
+
+async function runClaudeLiveExchange({ code, callbackUrl, codeVerifier }) {
+  console.log('');
+  console.log('⚠ --live-exchange 모드: Claude token endpoint에 POST를 시도합니다.');
+  console.log(`  endpoint: ${CLAUDE_AUTH.tokenEndpoint}`);
+  console.log('');
+
+  try {
+    const tokenResponse = await exchangeClaudeAuthorizationCode({
+      code,
+      callbackUrl,
+      codeVerifier,
+      allowLiveExchange: true,
+    });
+
+    console.log('token exchange 성공!');
+    console.log(`  token_type: ${tokenResponse.tokenType}`);
+    console.log(`  expires_in: ${tokenResponse.expiresIn}`);
+    console.log(`  scope: ${tokenResponse.scope ?? '(없음)'}`);
+
+    const identity = extractAccountIdentity({
+      idToken: tokenResponse.idToken,
+      accessToken: tokenResponse.accessToken,
+      fallbackCode: code,
+    });
+
+    console.log(`  identity source: ${identity.claimSource}`);
+
+    const now = new Date();
+    const expiresAt = tokenResponse.expiresIn
+      ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
+      : null;
+
+    const accountKeySource = identity.accountId ?? identity.email ?? 'live';
+    const account = createAccount({
+      accountKey: `${CLAUDE_AUTH.provider}:${accountKeySource}`,
+      email: identity.email,
+      displayName: identity.displayName,
+      accountId: identity.accountId,
+      authType: 'oauth',
+      source: 'agent-store',
+      tokens: {
+        accessToken: tokenResponse.accessToken,
+        refreshToken: tokenResponse.refreshToken ?? null,
+      },
+      raw: {
+        provider: CLAUDE_AUTH.provider,
+        mock: false,
+        liveExchange: true,
+        tokenType: tokenResponse.tokenType,
+        scope: tokenResponse.scope ?? null,
+        idToken: tokenResponse.idToken ?? null,
+        exchangedAt: now.toISOString(),
+        identityClaimSource: identity.claimSource,
+        note: 'live token exchange — observed client_id + S256 PKCE',
+      },
+    });
+    account.expiresAt = expiresAt;
+
+    const store = await loadAuthStore();
+    const nextStore = upsertProviderAccount(store, CLAUDE_AUTH.provider, account);
+    await saveAuthStore(nextStore);
+
+    console.log('');
+    console.log('실제 토큰을 auth store에 저장했습니다.');
+    console.log(`  accountKey: ${account.accountKey}`);
+    if (expiresAt) console.log(`  expiresAt: ${expiresAt}`);
+    console.log('');
+    console.log('⚠ client_id / scope는 observed 값이므로 검증 전까지 실험적으로만 사용하세요.');
+  } catch (err) {
+    console.log('');
+    console.log(`❌ live token exchange 실패: ${err.message}`);
+    console.log('토큰을 저장하지 않습니다.');
+  }
 }

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -333,7 +333,12 @@ async function runClaudeLogin(args) {
     console.log(`code 수신 완료: ${result.code}`);
 
     if (options.liveExchange) {
-      await runClaudeLiveExchange({ code: result.code, callbackUrl, codeVerifier });
+      await runClaudeLiveExchange({
+        code: result.code,
+        callbackUrl,
+        codeVerifier,
+        state,
+      });
     } else {
       console.log('');
       console.log('--live-exchange가 없으므로 token 교환을 생략합니다.');
@@ -345,7 +350,7 @@ async function runClaudeLogin(args) {
   }
 }
 
-async function runClaudeLiveExchange({ code, callbackUrl, codeVerifier }) {
+async function runClaudeLiveExchange({ code, callbackUrl, codeVerifier, state }) {
   console.log('');
   console.log('⚠ --live-exchange 모드: Claude token endpoint에 POST를 시도합니다.');
   console.log(`  endpoint: ${CLAUDE_AUTH.tokenEndpoint}`);
@@ -356,6 +361,7 @@ async function runClaudeLiveExchange({ code, callbackUrl, codeVerifier }) {
       code,
       callbackUrl,
       codeVerifier,
+      state,
       allowLiveExchange: true,
     });
 

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -129,7 +129,7 @@ async function runManualPasteFlow() {
   const nextStore = upsertProviderAccount(store, 'openai-codex', account);
   await saveAuthStore(nextStore);
 
-  console.log('placeholder/mock 계정을 auth store에 저장했어.');
+  console.log('mock 계정을 auth store에 저장했어.');
   console.log(`저장 accountKey: ${account.accountKey}`);
   console.log('이 저장 결과는 실제 OAuth 인증이 아니라 이후 흐름 연결을 위한 임시 구현이야.');
 }
@@ -228,7 +228,7 @@ async function saveMockAccountFromCallback(code) {
   const nextStore = upsertProviderAccount(store, 'openai-codex', account);
   await saveAuthStore(nextStore);
 
-  console.log('placeholder/mock 계정을 auth store에 저장했어.');
+  console.log('mock 계정을 auth store에 저장했어.');
   console.log(`저장 accountKey: ${account.accountKey}`);
   console.log('기본 경로는 token exchange 없이 mock 저장만 수행. 실제 exchange는 --live-exchange 사용.');
 }

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -4,6 +4,7 @@ import { resolveAccount } from '../auth/account-resolver.js';
 import { refreshCodexToken } from '../../../provider-adapters/src/codex/index.js';
 import { buildClaudeSnapshot } from '../services/status-service.js';
 import { resolveClaudeCredentialsPath } from '../../../provider-adapters/src/claude/read-claude-credentials.js';
+import { refreshClaudeToken } from '../../../provider-adapters/src/claude/refresh-claude-token.js';
 
 /**
  * Pure helper: format Claude credential snapshot as display lines.
@@ -62,7 +63,7 @@ export async function runDoctorCommand(subcommand, args = []) {
   }
 
   if (subcommand === 'claude') {
-    runDoctorClaude();
+    await runDoctorClaude(args);
     return;
   }
 
@@ -80,10 +81,12 @@ export async function runDoctorCommand(subcommand, args = []) {
   console.log('  ai-usage-agent doctor codex                 codex 계정 상태 점검');
   console.log('  ai-usage-agent doctor codex --refresh-live  실제 refresh token 재발급 시도');
   console.log('  ai-usage-agent doctor codex --account <id>  특정 계정 지정');
-  console.log('  ai-usage-agent doctor claude                claude credential 상태 점검');
+  console.log('  ai-usage-agent doctor claude                  claude credential 상태 점검');
+  console.log('  ai-usage-agent doctor claude --refresh-live   Claude OAuth refresh token으로 실제 재발급 시도');
 }
 
-function runDoctorClaude() {
+async function runDoctorClaude(args = []) {
+  const options = parseDoctorClaudeOptions(args);
   const snapshot = buildClaudeSnapshot(resolveClaudeCredentialsPath());
   console.log('ai-usage-agent doctor claude');
   console.log('----------------------------');
@@ -95,7 +98,61 @@ function runDoctorClaude() {
     console.log('⚠ Claude credential을 찾지 못했습니다.');
     console.log(`  예상 경로: ${snapshot.credentialsPath}`);
     console.log('  Claude CLI로 먼저 로그인했는지 확인하세요.');
+    return;
   }
+
+  if (!options.refreshLive) return;
+  await runDoctorClaudeRefreshLive(snapshot);
+}
+
+/**
+ * 관찰값 기반 Claude OAuth token endpoint로 refresh POST를 시도한다.
+ * agent-store 연결은 Phase 3에서 claude login이 붙은 뒤 붙인다 — 이번 라운드는
+ * claude-cli-import credential의 refreshToken으로 호출 결과만 확인한다.
+ * Exported for testing via named import of refreshClaudeToken.
+ */
+async function runDoctorClaudeRefreshLive(snapshot) {
+  const account = snapshot.selectedAccount;
+  const refreshToken = account?.refreshToken ?? account?.tokens?.refreshToken ?? null;
+
+  console.log('');
+  console.log('⚠ --refresh-live: 실제 token endpoint에 refresh POST를 시도합니다.');
+  console.log('  주의: client_id는 Claude Code 바이너리 관찰값 기반이며 성공이 보장되지 않습니다.');
+
+  if (!refreshToken) {
+    console.log('');
+    console.log('selectedAccount에서 refreshToken을 찾을 수 없습니다.');
+    console.log('Claude CLI에서 최신 로그인 상태인지 확인하세요.');
+    return;
+  }
+
+  try {
+    const tokenResponse = await refreshClaudeToken({
+      refreshToken,
+      allowLiveExchange: true,
+    });
+    console.log('');
+    console.log('✓ refresh 성공');
+    console.log(`  token_type: ${tokenResponse.tokenType}`);
+    console.log(`  expires_in: ${tokenResponse.expiresIn}`);
+    console.log(`  scope: ${tokenResponse.scope ?? '(없음)'}`);
+    console.log(
+      `  refreshToken 변경: ${tokenResponse.refreshToken !== refreshToken ? '예 (rotation)' : '아니오 (기존 유지)'}`,
+    );
+    console.log('');
+    console.log('ℹ 현재는 결과만 표시합니다. Claude agent-store 연결은 Phase 3에서 붙입니다.');
+  } catch (err) {
+    console.log('');
+    console.log(`❌ refresh 실패: ${err.message}`);
+  }
+}
+
+export function parseDoctorClaudeOptions(args) {
+  const options = { refreshLive: false };
+  for (const arg of args ?? []) {
+    if (arg === '--refresh-live') options.refreshLive = true;
+  }
+  return options;
 }
 
 async function runDoctorCodex(args) {

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -2,7 +2,7 @@ import { resolveAgentConfigPath } from '../config/config-path.js';
 import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
 import { resolveAccount } from '../auth/account-resolver.js';
 import { refreshCodexToken } from '../../../provider-adapters/src/codex/index.js';
-import { buildClaudeSnapshot } from '../services/status-service.js';
+import { buildClaudeSnapshot, getClaudeSnapshot } from '../services/status-service.js';
 import { resolveClaudeCredentialsPath } from '../../../provider-adapters/src/claude/read-claude-credentials.js';
 import { refreshClaudeToken } from '../../../provider-adapters/src/claude/refresh-claude-token.js';
 
@@ -67,7 +67,7 @@ export async function runDoctorCommand(subcommand, args = []) {
     return;
   }
 
-  const claudeSnapshot = buildClaudeSnapshot(resolveClaudeCredentialsPath());
+  const claudeSnapshot = await getClaudeSnapshot();
 
   console.log('ai-usage-agent doctor');
   console.log('---------------------');
@@ -87,7 +87,7 @@ export async function runDoctorCommand(subcommand, args = []) {
 
 async function runDoctorClaude(args = []) {
   const options = parseDoctorClaudeOptions(args);
-  const snapshot = buildClaudeSnapshot(resolveClaudeCredentialsPath());
+  const snapshot = await getClaudeSnapshot();
   console.log('ai-usage-agent doctor claude');
   console.log('----------------------------');
   for (const line of formatClaudeSection(snapshot)) {

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -31,6 +31,27 @@ export function formatClaudeSection(snapshot) {
     lines.push('  usage: 데이터 없음 (stats-cache.json 미발견)');
   }
 
+  const network = snapshot.networkUsage;
+  lines.push('');
+  lines.push('Claude live usage (api.anthropic.com/api/oauth/usage):');
+  if (!network) {
+    lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
+  } else if (network.status?.ok) {
+    lines.push(`  상태: OK (${network.status.httpStatus})`);
+    lines.push(`  usageWindows: ${network.usageWindows.length}개`);
+    for (const window of network.usageWindows) {
+      const reset = window.resetAt ? ` reset=${window.resetAt}` : '';
+      lines.push(`    - ${window.kind}: ${window.usedPercent ?? 'unknown'}%${reset}`);
+    }
+  } else {
+    const http = network.status?.httpStatus ?? 'network/error';
+    const bucket = network.status?.bucket ?? 'unknown';
+    lines.push(`  상태: 실패 (${http}, bucket=${bucket})`);
+    if (network.status?.message) {
+      lines.push(`  메시지: ${network.status.message}`);
+    }
+  }
+
   return lines;
 }
 

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -63,17 +63,49 @@ function printClaudeSection(claude) {
     console.log(`계정: ${claude.selectedAccount.accountKey}`);
   }
 
-  const usage = claude.usage;
-  if (!usage || usage.source === 'not-found') {
-    console.log('usage 데이터 없음 (stats-cache.json 미발견)');
+  printClaudeNetworkUsage(claude.networkUsage);
+  printClaudeLocalUsage(claude.usage);
+}
+
+function printClaudeNetworkUsage(networkUsage) {
+  console.log('');
+  console.log('[live] api.anthropic.com/api/oauth/usage');
+  if (!networkUsage) {
+    console.log('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
     return;
   }
 
-  console.log(`usage 소스: ${usage.source}`);
-  console.log(`총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
-  console.log(`총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
-  console.log(`모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
-  console.log(`일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
+  if (networkUsage.status?.ok) {
+    console.log(`  상태: OK (${networkUsage.status.httpStatus})`);
+    if (networkUsage.usageWindows.length === 0) {
+      console.log('  usageWindows 없음 (응답에 기대한 필드가 없었음)');
+    }
+    for (const window of networkUsage.usageWindows) {
+      console.log(`  ${window.kind}: ${formatWindow(window)}`);
+    }
+    return;
+  }
+
+  const http = networkUsage.status?.httpStatus ?? 'network/error';
+  const bucket = networkUsage.status?.bucket ?? 'unknown';
+  console.log(`  상태: 실패 (${http}, bucket=${bucket})`);
+  if (networkUsage.status?.message) {
+    console.log(`  메시지: ${networkUsage.status.message}`);
+  }
+}
+
+function printClaudeLocalUsage(usage) {
+  console.log('');
+  console.log('[local] stats-cache.json');
+  if (!usage || usage.source === 'not-found') {
+    console.log('  데이터 없음 (stats-cache.json 미발견)');
+    return;
+  }
+
+  console.log(`  총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
+  console.log(`  총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
+  console.log(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
+  console.log(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
 }
 
 function formatWindow(window) {

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -7,6 +7,7 @@ import { resolveImportedClaudeSnapshot } from '../../../provider-adapters/src/cl
 import { resolveClaudeAccount } from '../auth/resolve-claude-account.js';
 import { resolveClaudeUsageSourcePath } from '../../../provider-adapters/src/claude/resolve-claude-usage-source.js';
 import { readClaudeStatsCache } from '../../../provider-adapters/src/claude/read-claude-stats-cache.js';
+import { fetchClaudeUsage } from '../../../provider-adapters/src/claude/fetch-claude-usage.js';
 import { SCHEMA_VERSION } from '../../../schemas/src/index.js';
 import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
 import { resolveDefaultAccount } from '../auth/account-resolver.js';
@@ -17,7 +18,7 @@ export async function getStatusSnapshot() {
   const configPath = resolveAgentConfigPath();
   const config = loadConfig(configPath);
   const codex = await getCodexSnapshot(config);
-  const claude = buildClaudeSnapshot(resolveClaudeCredentialsPath(), readClaudeCredentials, [], resolveClaudeUsageSourcePath());
+  const claude = await getClaudeSnapshot(config);
 
   return {
     schemaVersion: SCHEMA_VERSION,
@@ -26,6 +27,90 @@ export async function getStatusSnapshot() {
     sync: config.sync,
     codex,
     claude,
+  };
+}
+
+async function getClaudeSnapshot(config) {
+  const base = buildClaudeSnapshot(
+    resolveClaudeCredentialsPath(),
+    readClaudeCredentials,
+    [],
+    resolveClaudeUsageSourcePath(),
+  );
+
+  if (!config.providers?.claude?.enabled) {
+    return { ...base, networkUsage: null };
+  }
+
+  const profile = resolveClaudeProfileFromSnapshot(base);
+  if (!profile) {
+    return { ...base, networkUsage: null };
+  }
+
+  try {
+    const networkUsage = await fetchClaudeUsage(profile);
+    return { ...base, networkUsage };
+  } catch (error) {
+    return {
+      ...base,
+      networkUsage: createClaudeNetworkFailureSnapshot(profile, error),
+    };
+  }
+}
+
+/**
+ * Extract fetchClaudeUsage-compatible profile from a Claude snapshot's
+ * selectedAccount. Handles both claude-cli-import (top-level accessToken) and
+ * agent-store (tokens.accessToken) shapes.
+ * Exported for testing.
+ */
+export function resolveClaudeProfileFromSnapshot(snapshot) {
+  const account = snapshot?.selectedAccount;
+  if (!account) return null;
+
+  const accessToken = account.accessToken ?? account.tokens?.accessToken ?? null;
+  if (!accessToken) return null;
+
+  return {
+    id: account.accountKey ?? 'claude',
+    accessToken,
+    accountId: account.accountId ?? null,
+    email: account.email ?? null,
+  };
+}
+
+function createClaudeNetworkFailureSnapshot(profile, error) {
+  const capturedAt = new Date().toISOString();
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    snapshotId: `claude:${profile.id}:${capturedAt}`,
+    capturedAt,
+    provider: {
+      id: 'anthropic-claude',
+      displayName: 'Claude',
+      region: null,
+    },
+    account: {
+      profileId: profile.id,
+      accountId: profile.accountId ?? null,
+      email: profile.email ?? null,
+      plan: null,
+    },
+    source: 'provider_usage_endpoint',
+    authType: 'oauth',
+    confidence: 'low',
+    status: {
+      bucket: 'unknown',
+      ok: false,
+      httpStatus: null,
+      message,
+      lastSuccessAt: null,
+      lastFailureAt: capturedAt,
+    },
+    usageWindows: [],
+    credits: { balance: null, unit: null },
+    raw: { provider: 'anthropic-claude', rawError: message },
   };
 }
 

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -31,7 +31,7 @@ export async function getStatusSnapshot() {
   };
 }
 
-async function getClaudeSnapshot(config) {
+export async function getClaudeSnapshot(config = { providers: { claude: { enabled: true } } }) {
   const agentClaudeAccounts = await loadAgentStoreClaudeAccounts();
   const base = buildClaudeSnapshot(
     resolveClaudeCredentialsPath(),

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -8,6 +8,7 @@ import { resolveClaudeAccount } from '../auth/resolve-claude-account.js';
 import { resolveClaudeUsageSourcePath } from '../../../provider-adapters/src/claude/resolve-claude-usage-source.js';
 import { readClaudeStatsCache } from '../../../provider-adapters/src/claude/read-claude-stats-cache.js';
 import { fetchClaudeUsage } from '../../../provider-adapters/src/claude/fetch-claude-usage.js';
+import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-constants.js';
 import { SCHEMA_VERSION } from '../../../schemas/src/index.js';
 import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
 import { resolveDefaultAccount } from '../auth/account-resolver.js';
@@ -31,10 +32,11 @@ export async function getStatusSnapshot() {
 }
 
 async function getClaudeSnapshot(config) {
+  const agentClaudeAccounts = await loadAgentStoreClaudeAccounts();
   const base = buildClaudeSnapshot(
     resolveClaudeCredentialsPath(),
     readClaudeCredentials,
-    [],
+    agentClaudeAccounts,
     resolveClaudeUsageSourcePath(),
   );
 
@@ -77,6 +79,38 @@ export function resolveClaudeProfileFromSnapshot(snapshot) {
     accountId: account.accountId ?? null,
     email: account.email ?? null,
   };
+}
+
+/**
+ * agent-store(`auth.json`)에 저장된 Claude 계정 중 live token을 가진 것만
+ * resolveClaudeAccount가 받을 수 있는 모양으로 변환한다.
+ */
+async function loadAgentStoreClaudeAccounts() {
+  let store;
+  try {
+    store = await loadAuthStore();
+  } catch {
+    return [];
+  }
+
+  const provider = store.providers?.[CLAUDE_AUTH.storeProvider];
+  if (!provider?.accounts?.length) return [];
+
+  return provider.accounts
+    .filter((a) => {
+      if (a.status === 'disabled') return false;
+      if (a.raw?.mock === true) return false;
+      const accessToken = a.tokens?.accessToken ?? a.accessToken ?? null;
+      if (!accessToken) return false;
+      // 기존 import 계정(`claude-cli-import`)은 base snapshot이 별도로 처리하므로 제외
+      if (a.source === 'claude-cli-import') return false;
+      return true;
+    })
+    .map((a) => ({
+      ...a,
+      provider: a.provider ?? 'claude',
+      source: a.source ?? 'agent-store',
+    }));
 }
 
 function createClaudeNetworkFailureSnapshot(profile, error) {

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -154,4 +154,61 @@ describe('formatClaudeSection', () => {
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('데이터 없음')));
   });
+
+  it('shows live usage OK with usageWindows when networkUsage succeeded', () => {
+    const snapshot = {
+      credentialsPath: FAKE_PATH,
+      found: true,
+      parsed: true,
+      authSource: 'claude-cli-import',
+      selectedAccount: null,
+      networkUsage: {
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [
+          { kind: 'five_hour', usedPercent: 25, resetAt: '2026-04-14T14:00:00.000Z' },
+          { kind: 'seven_day', usedPercent: 80, resetAt: null },
+        ],
+      },
+    };
+    const lines = formatClaudeSection(snapshot);
+    assert.ok(lines.some((l) => l.includes('Claude live usage')));
+    assert.ok(lines.some((l) => l.includes('OK (200)')));
+    assert.ok(lines.some((l) => l.includes('five_hour') && l.includes('25%')));
+    assert.ok(lines.some((l) => l.includes('seven_day') && l.includes('80%')));
+  });
+
+  it('shows live usage failure bucket and message when networkUsage failed', () => {
+    const snapshot = {
+      credentialsPath: FAKE_PATH,
+      found: true,
+      parsed: true,
+      authSource: 'claude-cli-import',
+      selectedAccount: null,
+      networkUsage: {
+        status: {
+          ok: false,
+          httpStatus: 403,
+          bucket: 'auth_scope',
+          message: 'missing scope requirement user:profile',
+        },
+        usageWindows: [],
+      },
+    };
+    const lines = formatClaudeSection(snapshot);
+    assert.ok(lines.some((l) => l.includes('실패') && l.includes('403') && l.includes('auth_scope')));
+    assert.ok(lines.some((l) => l.includes('user:profile')));
+  });
+
+  it('shows "호출 안 함" when networkUsage is null', () => {
+    const snapshot = {
+      credentialsPath: FAKE_PATH,
+      found: false,
+      parsed: false,
+      authSource: 'not-found',
+      selectedAccount: null,
+      networkUsage: null,
+    };
+    const lines = formatClaudeSection(snapshot);
+    assert.ok(lines.some((l) => l.includes('호출 안 함')));
+  });
 });

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { formatClaudeSection } from '../../src/cli/doctor-command.js';
+import { formatClaudeSection, parseDoctorClaudeOptions } from '../../src/cli/doctor-command.js';
 
 // ---------------------------------------------------------------------------
 // formatClaudeSection — pure display helper
@@ -210,5 +210,28 @@ describe('formatClaudeSection', () => {
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('호출 안 함')));
+  });
+});
+
+describe('parseDoctorClaudeOptions', () => {
+  it('returns refreshLive=false by default', () => {
+    assert.deepEqual(parseDoctorClaudeOptions([]), { refreshLive: false });
+  });
+
+  it('sets refreshLive=true when --refresh-live is present', () => {
+    assert.deepEqual(parseDoctorClaudeOptions(['--refresh-live']), {
+      refreshLive: true,
+    });
+  });
+
+  it('handles mixed / unknown args gracefully', () => {
+    assert.deepEqual(parseDoctorClaudeOptions(['--foo', '--refresh-live', 'bar']), {
+      refreshLive: true,
+    });
+  });
+
+  it('handles null/undefined args', () => {
+    assert.deepEqual(parseDoctorClaudeOptions(undefined), { refreshLive: false });
+    assert.deepEqual(parseDoctorClaudeOptions(null), { refreshLive: false });
   });
 });

--- a/packages/agent/test/services/status-service.test.js
+++ b/packages/agent/test/services/status-service.test.js
@@ -6,6 +6,7 @@ import {
   filterRealCodexAccounts,
   buildClaudeSnapshot,
   selectClaudeAuthSource,
+  resolveClaudeProfileFromSnapshot,
 } from '../../src/services/status-service.js';
 
 // ---------------------------------------------------------------------------
@@ -230,5 +231,50 @@ describe('buildClaudeSnapshot', () => {
   it('includes usage.source=not-found when stats-cache is unavailable', () => {
     const result = buildClaudeSnapshot(FAKE_PATH, () => null, [], '/fake/stats-cache.json', () => null);
     assert.equal(result.usage.source, 'not-found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveClaudeProfileFromSnapshot — extract usage profile from Claude snapshot
+// ---------------------------------------------------------------------------
+
+describe('resolveClaudeProfileFromSnapshot', () => {
+  it('returns null when selectedAccount is absent', () => {
+    assert.equal(resolveClaudeProfileFromSnapshot({ selectedAccount: null }), null);
+    assert.equal(resolveClaudeProfileFromSnapshot({}), null);
+    assert.equal(resolveClaudeProfileFromSnapshot(null), null);
+  });
+
+  it('returns null when selectedAccount has no accessToken anywhere', () => {
+    const snapshot = { selectedAccount: { accountKey: 'claude-cli-import' } };
+    assert.equal(resolveClaudeProfileFromSnapshot(snapshot), null);
+  });
+
+  it('extracts accessToken from top-level (claude-cli-import shape)', () => {
+    const snapshot = {
+      selectedAccount: {
+        accountKey: 'claude-cli-import',
+        accessToken: 'sk-ant-import-token',
+        email: 'user@example.com',
+      },
+    };
+    const profile = resolveClaudeProfileFromSnapshot(snapshot);
+    assert.equal(profile.id, 'claude-cli-import');
+    assert.equal(profile.accessToken, 'sk-ant-import-token');
+    assert.equal(profile.email, 'user@example.com');
+  });
+
+  it('extracts accessToken from tokens.accessToken (agent-store shape)', () => {
+    const snapshot = {
+      selectedAccount: {
+        accountKey: 'claude:alice',
+        tokens: { accessToken: 'sk-ant-store-token' },
+        accountId: 'acc-42',
+      },
+    };
+    const profile = resolveClaudeProfileFromSnapshot(snapshot);
+    assert.equal(profile.id, 'claude:alice');
+    assert.equal(profile.accessToken, 'sk-ant-store-token');
+    assert.equal(profile.accountId, 'acc-42');
   });
 });

--- a/packages/provider-adapters/src/claude/build-claude-authorization-url.js
+++ b/packages/provider-adapters/src/claude/build-claude-authorization-url.js
@@ -1,0 +1,40 @@
+import { CLAUDE_AUTH } from './claude-auth-constants.js';
+
+/**
+ * Build the Claude (Anthropic) OAuth authorization URL.
+ *
+ * HTTP 호출은 수행하지 않고, 브라우저에서 열 authorize URL만 조립한다.
+ *
+ * 주의:
+ *   - `clientId`와 `scopes` 기본값은 Claude Code 바이너리에서 관찰된 값.
+ *     Anthropic 공식 문서에 기재된 값이 아니므로 성공이 보장되지 않는다.
+ *   - redirect_uri는 localhost callback(기본 `/callback`) 또는 Claude platform
+ *     manual redirect를 모두 받는다.
+ *
+ * @param {object} params
+ * @param {string} params.callbackUrl - The redirect_uri (localhost or manual).
+ * @param {string} params.state - OAuth state parameter.
+ * @param {string} params.codeChallenge - PKCE code_challenge value.
+ * @param {string} params.codeChallengeMethod - PKCE method ('S256' default in caller).
+ * @param {string} [params.clientId] - Override client_id.
+ * @param {string[]} [params.scopes] - Override scopes.
+ * @returns {string} Authorization URL with query parameters.
+ */
+export function buildClaudeAuthorizationUrl({
+  callbackUrl,
+  state,
+  codeChallenge,
+  codeChallengeMethod,
+  clientId = CLAUDE_AUTH.observedClientId,
+  scopes = CLAUDE_AUTH.defaultScopes,
+}) {
+  const url = new URL(CLAUDE_AUTH.authorizationEndpoint);
+  url.searchParams.set('response_type', CLAUDE_AUTH.responseType);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', callbackUrl);
+  url.searchParams.set('state', state);
+  url.searchParams.set('scope', scopes.join(' '));
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', codeChallengeMethod);
+  return url.toString();
+}

--- a/packages/provider-adapters/src/claude/build-claude-authorization-url.js
+++ b/packages/provider-adapters/src/claude/build-claude-authorization-url.js
@@ -29,12 +29,15 @@ export function buildClaudeAuthorizationUrl({
   scopes = CLAUDE_AUTH.defaultScopes,
 }) {
   const url = new URL(CLAUDE_AUTH.authorizationEndpoint);
-  url.searchParams.set('response_type', CLAUDE_AUTH.responseType);
+  // Claude Code 바이너리가 실제로 붙이는 관찰 파라미터.
+  // `code=true`는 OAuth 스펙 외 파라미터지만 Claude authorize 서버가 기대한다.
+  url.searchParams.set('code', 'true');
   url.searchParams.set('client_id', clientId);
+  url.searchParams.set('response_type', CLAUDE_AUTH.responseType);
   url.searchParams.set('redirect_uri', callbackUrl);
-  url.searchParams.set('state', state);
   url.searchParams.set('scope', scopes.join(' '));
   url.searchParams.set('code_challenge', codeChallenge);
   url.searchParams.set('code_challenge_method', codeChallengeMethod);
+  url.searchParams.set('state', state);
   return url.toString();
 }

--- a/packages/provider-adapters/src/claude/claude-auth-constants.js
+++ b/packages/provider-adapters/src/claude/claude-auth-constants.js
@@ -9,8 +9,19 @@
  */
 
 export const CLAUDE_AUTH = {
-  /** OAuth authorization endpoint — observed (production claude-code client) */
-  authorizationEndpoint: 'https://platform.claude.com/oauth/authorize',
+  /**
+   * OAuth authorization endpoint — Claude.ai login flow (observed).
+   *
+   * Claude Code 바이너리에는 두 종류의 authorize URL이 있다:
+   *   - CONSOLE_AUTHORIZE_URL = https://platform.claude.com/oauth/authorize
+   *     → API key 발급용 (org:create_api_key 동의 화면)
+   *   - CLAUDE_AI_AUTHORIZE_URL = https://claude.com/cai/oauth/authorize
+   *     → claude.ai 사용자 OAuth (~/.claude/.credentials.json에 들어가는 토큰 발급)
+   *
+   * usage endpoint (api.anthropic.com/api/oauth/usage)는 후자의 토큰을 받으므로
+   * 우리는 claude.ai 경로를 사용한다.
+   */
+  authorizationEndpoint: 'https://claude.com/cai/oauth/authorize',
 
   /** OAuth token endpoint — observed, used for both code exchange and refresh */
   tokenEndpoint: 'https://platform.claude.com/v1/oauth/token',

--- a/packages/provider-adapters/src/claude/claude-auth-constants.js
+++ b/packages/provider-adapters/src/claude/claude-auth-constants.js
@@ -32,8 +32,15 @@ export const CLAUDE_AUTH = {
   /** Success page URL observed after localhost callback */
   successUrl: 'https://platform.claude.com/oauth/code/success?app=claude-code',
 
-  /** Provider identifier used in agent auth store */
+  /** snapshot.provider.id 와 fetchClaudeUsage가 표시하는 provider id */
   provider: 'anthropic-claude',
+
+  /**
+   * agent-store(`auth.json`)의 providers 키.
+   * 기존 import 경로(`auth import claude`)가 'claude' 키에 저장하므로
+   * live 로그인도 같은 키에 저장해 한 곳에서 관리한다.
+   */
+  storeProvider: 'claude',
 
   /**
    * Observed claude-code production client_id.

--- a/packages/provider-adapters/src/claude/claude-auth-constants.js
+++ b/packages/provider-adapters/src/claude/claude-auth-constants.js
@@ -1,0 +1,39 @@
+/**
+ * Claude (Anthropic) OAuth provider metadata and constants.
+ *
+ * 값들은 Claude Code CLI 바이너리(`~/.local/share/claude/versions/<v>`)에서
+ * observed한 결과를 그대로 옮긴 것이다. 공식 문서에 기재된 값이 아니므로
+ * "observed" 레벨로 간주하고, 실패 시 최신 바이너리 기준으로 재검증해야 한다.
+ *
+ * Source: strings dump of claude-code v2.1.107 (2026-04-14)
+ */
+
+export const CLAUDE_AUTH = {
+  /** OAuth authorization endpoint — observed (production claude-code client) */
+  authorizationEndpoint: 'https://platform.claude.com/oauth/authorize',
+
+  /** OAuth token endpoint — observed, used for both code exchange and refresh */
+  tokenEndpoint: 'https://platform.claude.com/v1/oauth/token',
+
+  /** Manual redirect URL shown after login on platform.claude.com */
+  manualRedirectUrl: 'https://platform.claude.com/oauth/code/callback',
+
+  /** Success page URL observed after localhost callback */
+  successUrl: 'https://platform.claude.com/oauth/code/success?app=claude-code',
+
+  /** Provider identifier used in agent auth store */
+  provider: 'anthropic-claude',
+
+  /**
+   * Observed claude-code production client_id.
+   * Source: strings dump `CLIENT_ID:"9d1c250a-e61b-44d9-88ed-5944d1962f5e"`.
+   * NOT officially documented — treat as observed default.
+   */
+  observedClientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+
+  /** Default scopes (관찰 대상 — 이후 authorize flow 구현 시 실측으로 보정) */
+  defaultScopes: ['org:create_api_key', 'user:profile', 'user:inference'],
+
+  /** Response type for authorization code flow */
+  responseType: 'code',
+};

--- a/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
+++ b/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
@@ -1,0 +1,77 @@
+import { CLAUDE_AUTH } from './claude-auth-constants.js';
+
+/**
+ * Claude OAuth authorization code → token 교환.
+ *
+ * Codex의 exchangeCodexAuthorizationCode와 동일한 guard 패턴.
+ * `allowLiveExchange: true` 없이 호출하면 설명적 에러를 던진다.
+ *
+ * @param {{
+ *   code: string,
+ *   callbackUrl: string,
+ *   codeVerifier: string,
+ *   allowLiveExchange?: boolean,
+ *   clientId?: string,
+ *   clientSecret?: string,
+ *   tokenEndpoint?: string,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ * @returns {Promise<{ accessToken: string, refreshToken: string|null, idToken: string|null, expiresIn: number, tokenType: string, scope: string|null }>}
+ */
+export async function exchangeClaudeAuthorizationCode({
+  code,
+  callbackUrl,
+  codeVerifier,
+  allowLiveExchange = false,
+  clientId = CLAUDE_AUTH.observedClientId,
+  clientSecret = undefined,
+  tokenEndpoint = CLAUDE_AUTH.tokenEndpoint,
+  fetchImpl = fetch,
+}) {
+  if (!code) throw new Error('[exchangeClaudeAuthorizationCode] code가 비어 있습니다.');
+  if (!callbackUrl) throw new Error('[exchangeClaudeAuthorizationCode] callbackUrl이 비어 있습니다.');
+  if (!codeVerifier) throw new Error('[exchangeClaudeAuthorizationCode] codeVerifier가 비어 있습니다.');
+
+  const body = {
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: callbackUrl,
+    client_id: clientId,
+    code_verifier: codeVerifier,
+  };
+
+  if (clientSecret) body.client_secret = clientSecret;
+
+  if (!allowLiveExchange) {
+    throw new Error(
+      '[exchangeClaudeAuthorizationCode] Live exchange is disabled. ' +
+        'Pass { allowLiveExchange: true } to perform a real POST to ' +
+        `${tokenEndpoint} (grant_type=authorization_code). ` +
+        'Note: client_id is an observed value from the Claude Code binary and not officially confirmed.',
+    );
+  }
+
+  const res = await fetchImpl(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `Claude token exchange failed: ${res.status} ${res.statusText} — ${text}`,
+    );
+  }
+
+  const json = await res.json();
+
+  return {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token ?? null,
+    idToken: json.id_token ?? null,
+    expiresIn: json.expires_in,
+    tokenType: json.token_type,
+    scope: json.scope ?? null,
+  };
+}

--- a/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
+++ b/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
@@ -22,6 +22,7 @@ export async function exchangeClaudeAuthorizationCode({
   code,
   callbackUrl,
   codeVerifier,
+  state,
   allowLiveExchange = false,
   clientId = CLAUDE_AUTH.observedClientId,
   clientSecret = undefined,
@@ -32,6 +33,8 @@ export async function exchangeClaudeAuthorizationCode({
   if (!callbackUrl) throw new Error('[exchangeClaudeAuthorizationCode] callbackUrl이 비어 있습니다.');
   if (!codeVerifier) throw new Error('[exchangeClaudeAuthorizationCode] codeVerifier가 비어 있습니다.');
 
+  // Claude token endpoint는 state 필드를 body에 요구한다 (OAuth 스펙 외 확장).
+  // 바이너리 관찰: grant_type / code / redirect_uri / client_id / code_verifier / state.
   const body = {
     grant_type: 'authorization_code',
     code,
@@ -39,6 +42,7 @@ export async function exchangeClaudeAuthorizationCode({
     client_id: clientId,
     code_verifier: codeVerifier,
   };
+  if (state) body.state = state;
 
   if (clientSecret) body.client_secret = clientSecret;
 

--- a/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
+++ b/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
@@ -53,8 +53,11 @@ export async function exchangeClaudeAuthorizationCode({
 
   const res = await fetchImpl(tokenEndpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams(body).toString(),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
   });
 
   if (!res.ok) {

--- a/packages/provider-adapters/src/claude/fetch-claude-usage.js
+++ b/packages/provider-adapters/src/claude/fetch-claude-usage.js
@@ -1,0 +1,174 @@
+import { SCHEMA_VERSION } from '../../../schemas/src/index.js';
+
+/**
+ * Claude OAuth usage endpoint fetcher.
+ *
+ * 확인된 endpoint / header 세트:
+ *   GET https://api.anthropic.com/api/oauth/usage
+ *   Authorization: Bearer <accessToken>
+ *   anthropic-version: 2023-06-01
+ *   anthropic-beta: oauth-2025-04-20
+ *
+ * 응답 shape (관찰값):
+ *   {
+ *     five_hour: { utilization: number, resets_at: ISO string },
+ *     seven_day: { utilization: number, resets_at: ISO string },
+ *     seven_day_sonnet: { utilization: number },
+ *     seven_day_opus: { utilization: number }
+ *   }
+ *
+ * @param {{ id: string, accessToken: string, accountId?: string|null, email?: string|null }} profile
+ * @param {{ fetchImpl?: typeof fetch, capturedAt?: Date }} [options]
+ */
+export async function fetchClaudeUsage(profile, options = {}) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const capturedAt = options.capturedAt ?? new Date();
+
+  const headers = {
+    Authorization: `Bearer ${profile.accessToken}`,
+    Accept: 'application/json',
+    'User-Agent': 'ai-usage-agent',
+    'anthropic-version': '2023-06-01',
+    'anthropic-beta': 'oauth-2025-04-20',
+  };
+
+  const response = await fetchImpl('https://api.anthropic.com/api/oauth/usage', {
+    method: 'GET',
+    headers,
+  });
+
+  const text = await response.text();
+  let data = null;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = null;
+  }
+
+  return createClaudeUsageSnapshot({
+    profile,
+    capturedAt,
+    responseStatus: response.status,
+    ok: response.ok,
+    data,
+    rawText: text,
+  });
+}
+
+function createClaudeUsageSnapshot({ profile, capturedAt, responseStatus, ok, data, rawText }) {
+  const capturedAtIso = toIsoString(capturedAt);
+  const lastSuccessAt = ok ? capturedAtIso : null;
+  const lastFailureAt = ok ? null : capturedAtIso;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    snapshotId: `claude:${profile.id}:${capturedAtIso}`,
+    capturedAt: capturedAtIso,
+    provider: {
+      id: 'anthropic-claude',
+      displayName: 'Claude',
+      region: null,
+    },
+    account: {
+      profileId: profile.id,
+      accountId: profile.accountId ?? null,
+      email: profile.email ?? null,
+      plan: data?.plan ?? null,
+    },
+    source: 'provider_usage_endpoint',
+    authType: 'oauth',
+    confidence: ok ? 'high' : 'medium',
+    status: {
+      bucket: resolveStatusBucket(responseStatus, ok, data),
+      ok,
+      httpStatus: responseStatus,
+      message: ok ? null : safeErrorMessage(data, rawText),
+      lastSuccessAt,
+      lastFailureAt,
+    },
+    usageWindows: ok
+      ? [
+          normalizeWindow('five_hour', '5h', data?.five_hour),
+          normalizeWindow('seven_day', 'Week', data?.seven_day),
+          normalizeModelWindow('seven_day_sonnet', 'Sonnet', data?.seven_day_sonnet),
+          normalizeModelWindow('seven_day_opus', 'Opus', data?.seven_day_opus),
+        ].filter(Boolean)
+      : [],
+    credits: {
+      balance: null,
+      unit: null,
+    },
+    raw: {
+      provider: 'anthropic-claude',
+      five_hour: data?.five_hour ?? null,
+      seven_day: data?.seven_day ?? null,
+      seven_day_sonnet: data?.seven_day_sonnet ?? null,
+      seven_day_opus: data?.seven_day_opus ?? null,
+      rawError: ok ? null : (rawText ?? '').slice(0, 500),
+    },
+  };
+}
+
+function normalizeWindow(kind, label, window) {
+  if (!window || typeof window.utilization !== 'number') return null;
+  return {
+    kind,
+    label: `${label} window`,
+    usedPercent: clampPercent(window.utilization),
+    usedAmount: null,
+    limitAmount: null,
+    remainingAmount: null,
+    windowSeconds: null,
+    resetAt: window.resets_at ? toIsoString(window.resets_at) : null,
+  };
+}
+
+function normalizeModelWindow(kind, label, window) {
+  if (!window || typeof window.utilization !== 'number') return null;
+  return {
+    kind,
+    label: `${label} weekly`,
+    usedPercent: clampPercent(window.utilization),
+    usedAmount: null,
+    limitAmount: null,
+    remainingAmount: null,
+    windowSeconds: null,
+    resetAt: null,
+  };
+}
+
+function clampPercent(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null;
+  const scaled = value <= 1 ? value * 100 : value;
+  if (scaled < 0) return 0;
+  if (scaled > 100) return 100;
+  return scaled;
+}
+
+function resolveStatusBucket(status, ok, data) {
+  if (ok) return 'ok';
+  if (status === 401) return 'auth';
+  if (status === 403) {
+    const message = data?.error?.message;
+    if (typeof message === 'string' && message.includes('scope requirement')) {
+      return 'auth_scope';
+    }
+    return 'auth';
+  }
+  if (status === 429) return 'rate_limit';
+  if (status === 402) return 'billing';
+  if (status >= 500) return 'overloaded';
+  return 'unknown';
+}
+
+function safeErrorMessage(data, rawText) {
+  const apiMessage = data?.error?.message;
+  if (typeof apiMessage === 'string' && apiMessage.trim()) {
+    return apiMessage.trim();
+  }
+  return rawText ? rawText.slice(0, 500) : 'unknown error';
+}
+
+function toIsoString(value) {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -19,3 +19,5 @@ export { readClaudeStatsCache } from './read-claude-stats-cache.js';
 export { fetchClaudeUsage } from './fetch-claude-usage.js';
 export { refreshClaudeToken } from './refresh-claude-token.js';
 export { CLAUDE_AUTH } from './claude-auth-constants.js';
+export { buildClaudeAuthorizationUrl } from './build-claude-authorization-url.js';
+export { exchangeClaudeAuthorizationCode } from './exchange-claude-authorization-code.js';

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -17,3 +17,5 @@ export {
 export { parseClaudeStatsCache } from './parse-claude-stats-cache.js';
 export { readClaudeStatsCache } from './read-claude-stats-cache.js';
 export { fetchClaudeUsage } from './fetch-claude-usage.js';
+export { refreshClaudeToken } from './refresh-claude-token.js';
+export { CLAUDE_AUTH } from './claude-auth-constants.js';

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -16,3 +16,4 @@ export {
 } from './resolve-claude-usage-source.js';
 export { parseClaudeStatsCache } from './parse-claude-stats-cache.js';
 export { readClaudeStatsCache } from './read-claude-stats-cache.js';
+export { fetchClaudeUsage } from './fetch-claude-usage.js';

--- a/packages/provider-adapters/src/claude/refresh-claude-token.js
+++ b/packages/provider-adapters/src/claude/refresh-claude-token.js
@@ -1,0 +1,77 @@
+import { CLAUDE_AUTH } from './claude-auth-constants.js';
+
+/**
+ * Claude OAuth refresh token exchange — guarded real fetch.
+ *
+ * Codex 쪽 `refreshCodexToken`과 동일한 guard/shape를 따른다.
+ * `allowLiveExchange: true` 없이 호출하면 설명적 에러를 던진다.
+ *
+ * ## 미해결
+ *   - client_secret 요구 여부 (현재는 public client로 가정)
+ *   - refresh token rotation 정책 (응답에 새 refresh_token이 오면 교체)
+ *
+ * @param {{
+ *   refreshToken: string,
+ *   allowLiveExchange?: boolean,
+ *   clientId?: string,
+ *   clientSecret?: string,
+ *   tokenEndpoint?: string,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ * @returns {Promise<{ accessToken: string, refreshToken: string|null, idToken: string|null, expiresIn: number, tokenType: string, scope: string|null }>}
+ */
+export async function refreshClaudeToken({
+  refreshToken,
+  allowLiveExchange = false,
+  clientId = CLAUDE_AUTH.observedClientId,
+  clientSecret = undefined,
+  tokenEndpoint = CLAUDE_AUTH.tokenEndpoint,
+  fetchImpl = fetch,
+}) {
+  if (!refreshToken) {
+    throw new Error('[refreshClaudeToken] refreshToken이 비어 있습니다.');
+  }
+
+  const body = {
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+  };
+
+  if (clientSecret) {
+    body.client_secret = clientSecret;
+  }
+
+  if (!allowLiveExchange) {
+    throw new Error(
+      '[refreshClaudeToken] Live exchange is disabled. ' +
+        'Pass { allowLiveExchange: true } to perform a real POST to ' +
+        `${tokenEndpoint} (grant_type=refresh_token). ` +
+        'Note: client_id is an observed value from the Claude Code binary and not officially confirmed.',
+    );
+  }
+
+  const res = await fetchImpl(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(body).toString(),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `Claude token refresh failed: ${res.status} ${res.statusText} — ${text}`,
+    );
+  }
+
+  const json = await res.json();
+
+  return {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token ?? refreshToken, // rotation 시 교체, 아니면 기존 유지
+    idToken: json.id_token ?? null,
+    expiresIn: json.expires_in,
+    tokenType: json.token_type,
+    scope: json.scope ?? null,
+  };
+}

--- a/packages/provider-adapters/src/claude/refresh-claude-token.js
+++ b/packages/provider-adapters/src/claude/refresh-claude-token.js
@@ -53,8 +53,11 @@ export async function refreshClaudeToken({
 
   const res = await fetchImpl(tokenEndpoint, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams(body).toString(),
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
   });
 
   if (!res.ok) {

--- a/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
+++ b/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildClaudeAuthorizationUrl } from '../../src/claude/build-claude-authorization-url.js';
+import { CLAUDE_AUTH } from '../../src/claude/claude-auth-constants.js';
+
+function baseParams(overrides = {}) {
+  return {
+    callbackUrl: 'http://localhost:1455/callback',
+    state: 'state-abc',
+    codeChallenge: 'challenge-xyz',
+    codeChallengeMethod: 'S256',
+    ...overrides,
+  };
+}
+
+describe('buildClaudeAuthorizationUrl', () => {
+  it('targets CLAUDE_AUTH.authorizationEndpoint', () => {
+    const result = buildClaudeAuthorizationUrl(baseParams());
+    const url = new URL(result);
+    assert.equal(`${url.origin}${url.pathname}`, CLAUDE_AUTH.authorizationEndpoint);
+  });
+
+  it('sets required OAuth query parameters', () => {
+    const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
+    assert.equal(url.searchParams.get('response_type'), 'code');
+    assert.equal(url.searchParams.get('client_id'), CLAUDE_AUTH.observedClientId);
+    assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:1455/callback');
+    assert.equal(url.searchParams.get('state'), 'state-abc');
+    assert.equal(url.searchParams.get('code_challenge'), 'challenge-xyz');
+    assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+  });
+
+  it('defaults scope to CLAUDE_AUTH.defaultScopes joined by space', () => {
+    const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
+    assert.equal(url.searchParams.get('scope'), CLAUDE_AUTH.defaultScopes.join(' '));
+  });
+
+  it('allows overriding clientId and scopes', () => {
+    const url = new URL(
+      buildClaudeAuthorizationUrl(
+        baseParams({ clientId: 'custom-client', scopes: ['user:profile'] }),
+      ),
+    );
+    assert.equal(url.searchParams.get('client_id'), 'custom-client');
+    assert.equal(url.searchParams.get('scope'), 'user:profile');
+  });
+});

--- a/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
+++ b/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
@@ -31,6 +31,11 @@ describe('buildClaudeAuthorizationUrl', () => {
     assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
   });
 
+  it('includes observed extra param code=true (claude authorize 요구사항)', () => {
+    const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
+    assert.equal(url.searchParams.get('code'), 'true');
+  });
+
   it('defaults scope to CLAUDE_AUTH.defaultScopes joined by space', () => {
     const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
     assert.equal(url.searchParams.get('scope'), CLAUDE_AUTH.defaultScopes.join(' '));

--- a/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
+++ b/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
@@ -24,6 +24,7 @@ function baseParams(overrides = {}) {
     code: 'code-123',
     callbackUrl: 'http://localhost:1455/callback',
     codeVerifier: 'verifier-abc',
+    state: 'state-xyz',
     ...overrides,
   };
 }
@@ -93,6 +94,7 @@ describe('exchangeClaudeAuthorizationCode — live exchange', () => {
     assert.equal(payload.redirect_uri, 'http://localhost:1455/callback');
     assert.equal(payload.code_verifier, 'verifier-abc');
     assert.equal(payload.client_id, CLAUDE_AUTH.observedClientId);
+    assert.equal(payload.state, 'state-xyz');
   });
 
   it('returns normalized token fields on 200', async () => {

--- a/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
+++ b/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
@@ -86,13 +86,13 @@ describe('exchangeClaudeAuthorizationCode — live exchange', () => {
     });
 
     assert.equal(captured.url, CLAUDE_AUTH.tokenEndpoint);
-    assert.equal(captured.init.headers['Content-Type'], 'application/x-www-form-urlencoded');
-    const params = new URLSearchParams(captured.init.body);
-    assert.equal(params.get('grant_type'), 'authorization_code');
-    assert.equal(params.get('code'), 'code-123');
-    assert.equal(params.get('redirect_uri'), 'http://localhost:1455/callback');
-    assert.equal(params.get('code_verifier'), 'verifier-abc');
-    assert.equal(params.get('client_id'), CLAUDE_AUTH.observedClientId);
+    assert.equal(captured.init.headers['Content-Type'], 'application/json');
+    const payload = JSON.parse(captured.init.body);
+    assert.equal(payload.grant_type, 'authorization_code');
+    assert.equal(payload.code, 'code-123');
+    assert.equal(payload.redirect_uri, 'http://localhost:1455/callback');
+    assert.equal(payload.code_verifier, 'verifier-abc');
+    assert.equal(payload.client_id, CLAUDE_AUTH.observedClientId);
   });
 
   it('returns normalized token fields on 200', async () => {

--- a/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
+++ b/packages/provider-adapters/test/claude/exchange-claude-authorization-code.test.js
@@ -1,0 +1,144 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { exchangeClaudeAuthorizationCode } from '../../src/claude/exchange-claude-authorization-code.js';
+import { CLAUDE_AUTH } from '../../src/claude/claude-auth-constants.js';
+
+function jsonResponse({ status = 200, body = {} } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
+function baseParams(overrides = {}) {
+  return {
+    code: 'code-123',
+    callbackUrl: 'http://localhost:1455/callback',
+    codeVerifier: 'verifier-abc',
+    ...overrides,
+  };
+}
+
+describe('exchangeClaudeAuthorizationCode — argument guards', () => {
+  it('throws when code is empty', async () => {
+    await assert.rejects(
+      () => exchangeClaudeAuthorizationCode(baseParams({ code: '', allowLiveExchange: true })),
+      /code가 비어/,
+    );
+  });
+
+  it('throws when callbackUrl is empty', async () => {
+    await assert.rejects(
+      () =>
+        exchangeClaudeAuthorizationCode(
+          baseParams({ callbackUrl: '', allowLiveExchange: true }),
+        ),
+      /callbackUrl이 비어/,
+    );
+  });
+
+  it('throws when codeVerifier is empty', async () => {
+    await assert.rejects(
+      () =>
+        exchangeClaudeAuthorizationCode(
+          baseParams({ codeVerifier: '', allowLiveExchange: true }),
+        ),
+      /codeVerifier가 비어/,
+    );
+  });
+
+  it('throws when allowLiveExchange is not set', async () => {
+    await assert.rejects(
+      () => exchangeClaudeAuthorizationCode(baseParams()),
+      /Live exchange is disabled/,
+    );
+  });
+});
+
+describe('exchangeClaudeAuthorizationCode — live exchange', () => {
+  it('POSTs authorization_code grant with required fields', async () => {
+    let captured;
+    const fetchImpl = async (url, init) => {
+      captured = { url, init };
+      return jsonResponse({
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      });
+    };
+
+    await exchangeClaudeAuthorizationCode({
+      ...baseParams(),
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(captured.url, CLAUDE_AUTH.tokenEndpoint);
+    assert.equal(captured.init.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    const params = new URLSearchParams(captured.init.body);
+    assert.equal(params.get('grant_type'), 'authorization_code');
+    assert.equal(params.get('code'), 'code-123');
+    assert.equal(params.get('redirect_uri'), 'http://localhost:1455/callback');
+    assert.equal(params.get('code_verifier'), 'verifier-abc');
+    assert.equal(params.get('client_id'), CLAUDE_AUTH.observedClientId);
+  });
+
+  it('returns normalized token fields on 200', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          id_token: 'id',
+          expires_in: 7200,
+          token_type: 'Bearer',
+          scope: 'user:profile',
+        },
+      });
+
+    const result = await exchangeClaudeAuthorizationCode({
+      ...baseParams(),
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(result.accessToken, 'at');
+    assert.equal(result.refreshToken, 'rt');
+    assert.equal(result.idToken, 'id');
+    assert.equal(result.expiresIn, 7200);
+    assert.equal(result.tokenType, 'Bearer');
+    assert.equal(result.scope, 'user:profile');
+  });
+
+  it('throws descriptive error on non-2xx response', async () => {
+    const fetchImpl = async () => ({
+      status: 400,
+      statusText: 'Bad Request',
+      ok: false,
+      async text() {
+        return 'invalid_grant';
+      },
+    });
+    await assert.rejects(
+      () =>
+        exchangeClaudeAuthorizationCode({
+          ...baseParams(),
+          allowLiveExchange: true,
+          fetchImpl,
+        }),
+      /Claude token exchange failed: 400/,
+    );
+  });
+});

--- a/packages/provider-adapters/test/claude/fetch-claude-usage.test.js
+++ b/packages/provider-adapters/test/claude/fetch-claude-usage.test.js
@@ -1,0 +1,176 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchClaudeUsage } from '../../src/claude/fetch-claude-usage.js';
+
+function createMockResponse({ status = 200, body = {}, asText = null } = {}) {
+  const text = asText !== null ? asText : JSON.stringify(body);
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+  };
+}
+
+const BASE_PROFILE = {
+  id: 'claude-cli-import',
+  accessToken: 'sk-ant-test-token',
+  accountId: null,
+  email: null,
+};
+
+describe('fetchClaudeUsage', () => {
+  it('sends required OAuth headers to api.anthropic.com/api/oauth/usage', async () => {
+    let capturedUrl = null;
+    let capturedInit = null;
+    const fetchImpl = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return createMockResponse({ status: 200, body: {} });
+    };
+
+    await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+
+    assert.equal(capturedUrl, 'https://api.anthropic.com/api/oauth/usage');
+    assert.equal(capturedInit.method, 'GET');
+    assert.equal(capturedInit.headers.Authorization, 'Bearer sk-ant-test-token');
+    assert.equal(capturedInit.headers['anthropic-version'], '2023-06-01');
+    assert.equal(capturedInit.headers['anthropic-beta'], 'oauth-2025-04-20');
+    assert.equal(capturedInit.headers.Accept, 'application/json');
+  });
+
+  it('returns a snapshot with provider id anthropic-claude and ok status on 200', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 200,
+        body: {
+          five_hour: { utilization: 0.25, resets_at: '2026-04-14T14:00:00.000Z' },
+          seven_day: { utilization: 0.75, resets_at: '2026-04-20T00:00:00.000Z' },
+        },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+
+    assert.equal(snapshot.provider.id, 'anthropic-claude');
+    assert.equal(snapshot.status.ok, true);
+    assert.equal(snapshot.status.bucket, 'ok');
+    assert.equal(snapshot.status.httpStatus, 200);
+    assert.equal(snapshot.source, 'provider_usage_endpoint');
+    assert.equal(snapshot.authType, 'oauth');
+    assert.equal(snapshot.confidence, 'high');
+  });
+
+  it('normalizes five_hour and seven_day into usageWindows with percent scaled to 0-100', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 200,
+        body: {
+          five_hour: { utilization: 0.25, resets_at: '2026-04-14T14:00:00.000Z' },
+          seven_day: { utilization: 0.75, resets_at: '2026-04-20T00:00:00.000Z' },
+        },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+
+    const fiveHour = snapshot.usageWindows.find((w) => w.kind === 'five_hour');
+    const sevenDay = snapshot.usageWindows.find((w) => w.kind === 'seven_day');
+
+    assert.ok(fiveHour);
+    assert.equal(fiveHour.usedPercent, 25);
+    assert.equal(fiveHour.resetAt, '2026-04-14T14:00:00.000Z');
+
+    assert.ok(sevenDay);
+    assert.equal(sevenDay.usedPercent, 75);
+  });
+
+  it('normalizes sonnet and opus weekly windows when present', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 200,
+        body: {
+          seven_day_sonnet: { utilization: 0.4 },
+          seven_day_opus: { utilization: 0.1 },
+        },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+
+    const sonnet = snapshot.usageWindows.find((w) => w.kind === 'seven_day_sonnet');
+    const opus = snapshot.usageWindows.find((w) => w.kind === 'seven_day_opus');
+
+    assert.ok(sonnet);
+    assert.equal(sonnet.usedPercent, 40);
+    assert.ok(opus);
+    assert.equal(opus.usedPercent, 10);
+  });
+
+  it('accepts utilization values already expressed as 0-100 without double-scaling', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 200,
+        body: {
+          five_hour: { utilization: 50 },
+        },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+    const fiveHour = snapshot.usageWindows[0];
+    assert.equal(fiveHour.usedPercent, 50);
+  });
+
+  it('returns empty usageWindows and error message on 401', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 401,
+        body: { error: { message: 'invalid token' } },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+
+    assert.equal(snapshot.status.ok, false);
+    assert.equal(snapshot.status.httpStatus, 401);
+    assert.equal(snapshot.status.bucket, 'auth');
+    assert.equal(snapshot.status.message, 'invalid token');
+    assert.deepEqual(snapshot.usageWindows, []);
+  });
+
+  it('maps 403 scope errors to auth_scope bucket', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({
+        status: 403,
+        body: { error: { message: 'missing scope requirement user:profile' } },
+      });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+    assert.equal(snapshot.status.bucket, 'auth_scope');
+  });
+
+  it('maps 429 to rate_limit bucket', async () => {
+    const fetchImpl = async () => createMockResponse({ status: 429, body: {} });
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+    assert.equal(snapshot.status.bucket, 'rate_limit');
+  });
+
+  it('handles non-JSON error bodies gracefully', async () => {
+    const fetchImpl = async () =>
+      createMockResponse({ status: 502, asText: 'upstream error page' });
+
+    const snapshot = await fetchClaudeUsage(BASE_PROFILE, { fetchImpl });
+    assert.equal(snapshot.status.ok, false);
+    assert.equal(snapshot.status.bucket, 'overloaded');
+    assert.equal(snapshot.status.message, 'upstream error page');
+  });
+
+  it('includes email and accountId from profile in account section', async () => {
+    const fetchImpl = async () => createMockResponse({ status: 200, body: {} });
+    const snapshot = await fetchClaudeUsage(
+      { ...BASE_PROFILE, email: 'user@example.com', accountId: 'acc-123' },
+      { fetchImpl },
+    );
+    assert.equal(snapshot.account.email, 'user@example.com');
+    assert.equal(snapshot.account.accountId, 'acc-123');
+    assert.equal(snapshot.account.profileId, 'claude-cli-import');
+  });
+});

--- a/packages/provider-adapters/test/claude/refresh-claude-token.test.js
+++ b/packages/provider-adapters/test/claude/refresh-claude-token.test.js
@@ -60,13 +60,13 @@ describe('refreshClaudeToken — live exchange', () => {
 
     assert.equal(capturedUrl, CLAUDE_AUTH.tokenEndpoint);
     assert.equal(capturedInit.method, 'POST');
-    assert.equal(capturedInit.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    assert.equal(capturedInit.headers['Content-Type'], 'application/json');
 
-    const params = new URLSearchParams(capturedInit.body);
-    assert.equal(params.get('grant_type'), 'refresh_token');
-    assert.equal(params.get('refresh_token'), 'old-rt');
-    assert.equal(params.get('client_id'), CLAUDE_AUTH.observedClientId);
-    assert.equal(params.has('client_secret'), false);
+    const payload = JSON.parse(capturedInit.body);
+    assert.equal(payload.grant_type, 'refresh_token');
+    assert.equal(payload.refresh_token, 'old-rt');
+    assert.equal(payload.client_id, CLAUDE_AUTH.observedClientId);
+    assert.equal(payload.client_secret, undefined);
   });
 
   it('includes client_secret when provided', async () => {
@@ -85,7 +85,7 @@ describe('refreshClaudeToken — live exchange', () => {
       fetchImpl,
     });
 
-    assert.equal(new URLSearchParams(captured.body).get('client_secret'), 'secret!');
+    assert.equal(JSON.parse(captured.body).client_secret, 'secret!');
   });
 
   it('returns normalized token fields on 200', async () => {

--- a/packages/provider-adapters/test/claude/refresh-claude-token.test.js
+++ b/packages/provider-adapters/test/claude/refresh-claude-token.test.js
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { refreshClaudeToken } from '../../src/claude/refresh-claude-token.js';
+import { CLAUDE_AUTH } from '../../src/claude/claude-auth-constants.js';
+
+function jsonResponse({ status = 200, body = {} } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
+describe('refreshClaudeToken — guard', () => {
+  it('throws when allowLiveExchange is not set (default guard)', async () => {
+    await assert.rejects(
+      () => refreshClaudeToken({ refreshToken: 'rt-123' }),
+      /Live exchange is disabled/,
+    );
+  });
+
+  it('throws when refreshToken is missing', async () => {
+    await assert.rejects(
+      () => refreshClaudeToken({ refreshToken: '', allowLiveExchange: true }),
+      /refreshToken.*비어/,
+    );
+  });
+});
+
+describe('refreshClaudeToken — live exchange', () => {
+  it('POSTs form-encoded body to the configured token endpoint', async () => {
+    let capturedUrl = null;
+    let capturedInit = null;
+    const fetchImpl = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return jsonResponse({
+        body: {
+          access_token: 'new-at',
+          refresh_token: 'new-rt',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      });
+    };
+
+    await refreshClaudeToken({
+      refreshToken: 'old-rt',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(capturedUrl, CLAUDE_AUTH.tokenEndpoint);
+    assert.equal(capturedInit.method, 'POST');
+    assert.equal(capturedInit.headers['Content-Type'], 'application/x-www-form-urlencoded');
+
+    const params = new URLSearchParams(capturedInit.body);
+    assert.equal(params.get('grant_type'), 'refresh_token');
+    assert.equal(params.get('refresh_token'), 'old-rt');
+    assert.equal(params.get('client_id'), CLAUDE_AUTH.observedClientId);
+    assert.equal(params.has('client_secret'), false);
+  });
+
+  it('includes client_secret when provided', async () => {
+    let captured;
+    const fetchImpl = async (_url, init) => {
+      captured = init;
+      return jsonResponse({
+        body: { access_token: 'x', expires_in: 1, token_type: 'Bearer' },
+      });
+    };
+
+    await refreshClaudeToken({
+      refreshToken: 'rt',
+      allowLiveExchange: true,
+      clientSecret: 'secret!',
+      fetchImpl,
+    });
+
+    assert.equal(new URLSearchParams(captured.body).get('client_secret'), 'secret!');
+  });
+
+  it('returns normalized token fields on 200', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: {
+          access_token: 'at-new',
+          refresh_token: 'rt-new',
+          id_token: 'id-new',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'user:profile',
+        },
+      });
+
+    const result = await refreshClaudeToken({
+      refreshToken: 'rt-old',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(result.accessToken, 'at-new');
+    assert.equal(result.refreshToken, 'rt-new');
+    assert.equal(result.idToken, 'id-new');
+    assert.equal(result.expiresIn, 3600);
+    assert.equal(result.tokenType, 'Bearer');
+    assert.equal(result.scope, 'user:profile');
+  });
+
+  it('keeps existing refreshToken when response omits refresh_token (no rotation)', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: {
+          access_token: 'at-new',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      });
+
+    const result = await refreshClaudeToken({
+      refreshToken: 'rt-kept',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(result.refreshToken, 'rt-kept');
+    assert.equal(result.idToken, null);
+    assert.equal(result.scope, null);
+  });
+
+  it('throws descriptive error on non-2xx response', async () => {
+    const fetchImpl = async () => ({
+      status: 400,
+      statusText: 'Bad Request',
+      ok: false,
+      async text() {
+        return '{"error":"invalid_grant"}';
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        refreshClaudeToken({
+          refreshToken: 'rt',
+          allowLiveExchange: true,
+          fetchImpl,
+        }),
+      /Claude token refresh failed: 400/,
+    );
+  });
+});


### PR DESCRIPTION
## 요약

Claude OAuth 3단계를 한꺼번에 구현한다.

1. **live usage 호출** — CLI import 토큰으로 `api.anthropic.com/api/oauth/usage` 호출 (#11)
2. **refresh token 재발급** — `platform.claude.com/v1/oauth/token`의 refresh grant (#12)
3. **독립 OAuth login** — `auth login claude`로 Claude CLI 없이도 로그인 (#13)

end-to-end 검증 완료: 독립 로그인으로 받은 토큰으로 usage endpoint 200 OK, status/doctor에 실시간 수치 표시.

Base: `feat/claude-usage-foundation` (#17) — 순차 머지 시 base는 dev로 자동 전환.

관련 이슈: #11 #12 #13 close

## 변경 내용

### provider-adapters

- `fetch-claude-usage.js` — usage snapshot 변환 (OpenClaw 관찰 기반 응답 shape)
- `claude-auth-constants.js` — authorize / token endpoint, client_id (바이너리 관찰값)
- `refresh-claude-token.js` — refresh grant + allowLiveExchange guard
- `build-claude-authorization-url.js` — authorize URL 조립 (PKCE S256, `code=true` 확장 파라미터)
- `exchange-claude-authorization-code.js` — authorization_code grant (JSON body, `state` 포함)

### agent

- `auth-login-command.js` — provider 디스패처 + Claude 브랜치 + `--timeout`
- `localhost-callback.js` — `callbackPath` 파라미터화 (`/auth/callback` vs `/callback`)
- `status-service.js` — `getClaudeSnapshot` export, agent-store Claude 계정 우선 사용, `networkUsage` 필드
- `doctor-command.js` — `--refresh-live` 옵션, live usage 섹션

### docs

- `docs/claude-oauth-plan.md` — Phase 1-4 작업 계획
- `docs/provider-notes.md` — 관찰된 endpoint / client_id / scope 값 기록

## 변경 이유

- stats-cache는 로컬 캐시라 정확도 한계
- 실제 사용량 확인이 필요할 때 네트워크 기반 경로가 필요
- Codex처럼 Claude도 agent-store 기반 독립 인증 경로를 갖춰 운영성 확보

## 영향 범위

- [x] `packages/agent`
- [ ] `packages/schemas`
- [x] `packages/provider-adapters`
- [ ] `repo`
- [x] `docs`

## 테스트 / 확인

- fetch/refresh/exchange/auth url builder 단위 테스트 (합계 30+ 신규 테스트)
- status-service / doctor-command 테스트에 live usage / networkUsage 케이스 추가
- 전체 212 테스트 통과
- 실 네트워크 검증:
  - Phase 1 live usage: 200 OK 수치 표시
  - Phase 2 refresh endpoint: invalid_grant 응답으로 endpoint+client_id 정상 수신 확인
  - Phase 3 전체 로그인: 브라우저 로그인 → localhost callback → token exchange → agent-store 저장 → usage endpoint 200 OK 까지 확인

## 리뷰 포인트

- `CLAUDE_AUTH.observedClientId`, authorize/token endpoint 값은 Claude Code 바이너리 strings에서 추출한 observed 값. 공식 문서 없음.
- token endpoint가 JSON body를 요구 + auth code grant에 body.state 필수 (바이너리 관찰 후 반영)
- `authorizationEndpoint`는 Console용(platform.claude.com)이 아니라 claude.ai 흐름(`claude.com/cai/oauth/authorize`) — 전자는 API key 발급 동의 화면을 띄워서 목적과 다름
- `CLAUDE_AUTH`에 snapshot용 `provider='anthropic-claude'`와 store key `storeProvider='claude'`를 분리. 기존 import 경로와 store 위치를 통일.
- live-exchange 없이 호출하면 guard로 에러 던지는 패턴을 Codex와 통일

## 참고 사항

`~/.claude/.credentials.json`은 전 과정에서 수정하지 않음 — Claude CLI 세션 안전.

관련 이슈 #11, #12, #13는 구현 완료 후 이미 close.