### PR TITLE
[docs] README / auth 아키텍처 / provider 메모 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,110 +2,160 @@
 
 여러 AI 서비스의 사용량과 인증 상태를 로컬에서 관리하는 CLI agent + provider adapter + schema 패키지 모음.
 
-## 현재 구현 범위
+외부 auth store(OpenClaw 등)에 의존하지 않고 자체 auth broker / credential store를 사용한다.
 
-이 repo의 핵심은 로컬에서 동작하는 CLI agent와 그 구성 패키지이다.
-
-- **`packages/agent`** — CLI 에이전트. `status`, `usage`, `doctor`, `config init`, `auth login/list/logout` 명령 제공
-- **`packages/provider-adapters`** — provider별 인증/endpoint 연결 및 usage 정규화
-- **`packages/schemas`** — 공통 데이터 계약 (usage snapshot, usage event JSON Schema)
-
-### 현재 동작하는 것
-
-- Codex OAuth 독립 인증 (localhost callback + PKCE S256)
-- `--manual` paste fallback
-- `--live-exchange` 실제 token exchange 및 저장
-- refresh token 재발급 및 rotation 반영
-- agent-store 기반 real token으로 usage 조회
-- id_token/access_token JWT claims 기반 계정 식별
-- multi-account resolver (`lastUsedAt` 자동 선택 + `--account` override)
-- `auth list`, `auth logout` 명령
-- `doctor`, `doctor codex`, `doctor codex --refresh-live` 명령
-
-### 아직 구현되지 않은 것
-
-- Claude provider 인증 및 usage 조회
-- device code fallback
-- keychain 연동
-
-## 에이전트 실행
+## 빠른 시작
 
 ```bash
+# 상태 확인 (설정 / provider별 인증 / usage)
 npm run agent:status
+
+# usage만 집중해서 보기
 npm run agent:usage
+
+# 환경 점검 (credential 경로, token 상태, refresh 가능 여부)
 npm run agent:doctor
+
+# 최초 설정 파일 생성
 npm run agent:config:init
 ```
 
-## 프로젝트 구조
+## 현재 지원 범위
 
-```text
-packages/
-  agent/             # CLI 에이전트
-  provider-adapters/ # provider별 인증/usage 어댑터
-  schemas/           # 공통 JSON Schema
-docs/                # 아키텍처, 인증, provider 문서
-scripts/
-  poc/
-```
+### Provider
 
-## 확인된 endpoint
+| Provider | Auth (독립 OAuth) | Auth (credential import) | Usage 조회 | Refresh | Status |
+| --- | --- | --- | --- | --- | --- |
+| Codex (OpenAI) | ✓ `auth login codex --live-exchange` | `auth import openclaw` | ✓ `wham/usage` live | ✓ `doctor codex --refresh-live` | 운영 중 |
+| Claude (Anthropic) | ✓ `auth login claude --live-exchange` | `auth import claude` (CLI 재사용) | ✓ `oauth/usage` live | ✓ `doctor claude --refresh-live` | 운영 중 |
+
+### 검증된 endpoint
 
 - Codex: `https://chatgpt.com/backend-api/wham/usage`
 - Claude OAuth: `https://api.anthropic.com/api/oauth/usage`
-- Claude web fallback:
-  - `https://claude.ai/api/organizations`
-  - `https://claude.ai/api/organizations/{orgId}/usage`
+- Claude web fallback (옵션, 미구현): `https://claude.ai/api/organizations/{orgId}/usage`
 
-## 공통 스키마
+### 공통 기능
 
-`packages/schemas`에 JSON Schema 정의:
+- PKCE S256 + state 검증 localhost OAuth callback
+- multi-account resolver (`lastUsedAt` 자동 선택 + `--account` override)
+- refresh token rotation 반영
+- `--live-exchange` guard (실수로 실제 token 호출이 반복되는 것 방지)
+- CLI / status-service / provider adapter 3계층 분리
+
+## 패키지 구조
+
+```text
+packages/
+  agent/               CLI 에이전트 (auth / status / doctor / config 명령)
+  provider-adapters/   provider별 인증·usage 로직
+    codex/
+    claude/
+  schemas/             공통 JSON Schema (usage snapshot / event)
+docs/                  architecture / auth / provider 문서
+scripts/poc/           experimental scripts (저위험 실험)
+```
+
+## CLI 커맨드
+
+### status / usage
+
+```bash
+ai-usage-agent status
+ai-usage-agent usage
+```
+
+provider별 credential 상태, 선택된 계정, live usage window, 로컬 캐시 요약을 출력한다.
+
+### auth
+
+```bash
+ai-usage-agent auth login codex   [--live-exchange] [--port N] [--timeout SEC] [--manual] [--no-open]
+ai-usage-agent auth login claude  [--live-exchange] [--port N] [--timeout SEC]
+ai-usage-agent auth list
+ai-usage-agent auth logout <provider> [--account <id>]
+ai-usage-agent auth import openclaw    # 기존 OpenClaw auth-profiles 흡수
+ai-usage-agent auth import claude      # ~/.claude/.credentials.json 흡수
+```
+
+`--live-exchange` 없이 호출하면 mock 저장만 수행한다.
+
+### doctor
+
+```bash
+ai-usage-agent doctor                        # 공통 환경 점검
+ai-usage-agent doctor codex                  # Codex 계정·refresh 가능성 점검
+ai-usage-agent doctor codex  --refresh-live  # 실제 refresh POST
+ai-usage-agent doctor codex  --account <id>
+ai-usage-agent doctor claude                 # Claude credential·live usage 점검
+ai-usage-agent doctor claude --refresh-live  # 실제 refresh POST
+```
+
+### config
+
+```bash
+ai-usage-agent config init
+```
+
+`~/.config/ai-usage-agent/config.json`에 기본 설정을 생성한다.
+
+## Credential source 우선순위
+
+### Codex
+`agent-store` (live-exchange 실토큰) → `openclaw-import` (마이그레이션)
+
+### Claude
+`agent-store` (live-exchange 또는 `auth import claude` 저장분) → `claude-cli-import` (`~/.claude/.credentials.json` 실시간 reader)
+
+## 스키마
+
+`packages/schemas`에 JSON Schema 정의.
 
 - `usage-snapshot.schema.json`
 - `usage-event.schema.json`
-- 핵심 필드: `source`, `authType`, `confidence`, `usageWindows`, `status.bucket` / `reason.bucket`
-
-## 상태 버킷
-
-- `ok` / `rate_limit` / `usage_window` / `billing` / `auth` / `overloaded` / `unknown`
+- 핵심 필드: `source`, `authType`, `confidence`, `usageWindows`, `status.bucket`
+- `status.bucket` 값: `ok` / `rate_limit` / `usage_window` / `billing` / `auth` / `overloaded` / `unknown`
 
 ## 보안 원칙
 
-- refresh token / session cookie / sessionKey는 서버에 저장하지 않음
-- raw prompt / raw response / 전체 transcript 업로드 금지
 - callback 서버는 `127.0.0.1`에만 bind
-- access token / refresh token 로그 출력 금지
+- state 검증 + PKCE S256
+- refresh token / session cookie / sessionKey는 외부 서버 업로드 금지
+- access/refresh token을 로그에 출력하지 않음
+- raw prompt / raw response / 전체 transcript 업로드 금지
 
-## 인증 독립화
+## observed vs verified
 
-agent는 OpenClaw auth store에 의존하지 않고 자체 auth broker를 갖는다.
+바이너리 strings / 로컬 JWT에서 관찰한 값들(`client_id`, endpoint 등)은 **observed** 레벨로 구분하고 공식 확정된 값이 아님을 명시한다. provider 측 변경에 대비해 guard(`allowLiveExchange`) 뒤에서만 실 호출이 일어나도록 설계.
 
-- 기본: localhost callback OAuth
-- fallback: manual paste
-- 후순위: device code (미구현)
-- credential source 우선순위: `agent-store` > `openclaw-import`
+자세한 내용은 `docs/auth-architecture.md` 참고.
 
-상세는 `docs/auth-architecture.md` 참조.
+## 개발 / 테스트
 
-## Codex OAuth 검증 현황
+```bash
+npm test              # 전체 테스트
+npm run test:agent    # agent 패키지만
+npm run test:adapters # provider adapters만
+```
 
-- authorize/token endpoint, callback URL, PKCE S256: 검증 완료
-- token exchange, refresh, usage 조회: 동작 확인
-- `client_id`는 관찰값 — 공식 확정 아님
-- `client_secret` 요구 여부, refresh rotation 정책: 미확정
+CI: push / pull_request에서 자동 실행 (`.github/workflows/ci.yml`).
 
 ## 작업 / 협업 규칙
 
-- 브랜치 흐름: `작업 브랜치 -> dev -> main`
-- 커밋 형식: `type(scope): 한글 설명`
-- PR 제목 형식: `[feat] 한글 요약`
+- 브랜치 흐름: `작업 브랜치 → dev → main`
+- 커밋: `type(scope): 한글 설명` (type: feat / fix / refactor / docs / chore / ci / test / perf)
+- PR 제목: `[type] 한글 요약`
+- PR 본문: 요약 / 변경 내용 / 이유 / 영향 범위 / 테스트 / 리뷰 포인트
 
-## 다음 작업
+상세: `CONTRIBUTING.md` 참고.
 
-1. agent-store 기반 real token으로 usage 조회 연결 점검
-2. Claude 인증 경로 확장
-3. `auth import openclaw` 경로 정리
+## 다음 작업 후보
+
+- Codex/Claude 네트워크 호출 timeout/abort (이슈 #7)
+- Claude Phase 4 — session cookie fallback (이슈 #14, 옵션)
+- code-base 구조 리팩터 (중복되는 provider adapter shape 통합)
+- keychain 연동 / device code flow / revoke endpoint 조사
 
 ## 라이선스
 
-추후 결정
+추후 결정.

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -4,211 +4,165 @@
 
 CLI agent가 외부 auth store(OpenClaw 등)에 의존하지 않고 독립적으로 인증, 토큰 저장, 갱신, 사용을 처리한다.
 
-## 현재 문제
-
-현재 Codex adapter는 OpenClaw auth store를 직접 읽는다.
-
-- 결합도가 높음
-- OpenClaw 미설치 환경에서 단독 동작 불가
-- 향후 배포형 CLI 패키지로 사용할 때 UX가 제한됨
-
-## 목표 상태
-
-로컬 에이전트가 자체 auth broker를 가진다.
+## 현재 구성
 
 ```text
 [ai-usage-agent CLI]
-  ├─ Auth Commands
+  ├─ Auth Commands (login / list / logout / import)
   ├─ Auth Broker
-  │   ├─ OAuth localhost callback flow
-  │   ├─ Manual callback/paste fallback
-  │   └─ Device code fallback (후순위)
-  ├─ Credential Store
-  ├─ Provider Adapters
+  │   ├─ OAuth localhost callback flow (Codex / Claude 공통)
+  │   ├─ Manual paste fallback (Codex)
+  │   └─ Device code fallback (미구현, 후순위)
+  ├─ Credential Store (~/.config/ai-usage-agent/auth.json, 0600)
+  ├─ Provider Adapters (codex / claude)
   └─ Usage / Event Pipeline
 ```
 
-## 권장 인증 흐름
+runtime 기본 경로는 agent 자체 store이며, OpenClaw 의존은 제거되었다. 기존 auth-profiles는 `auth import openclaw`로 migration만 가능하다.
 
-### 1. 기본: localhost callback OAuth
+## 인증 흐름
 
-기본 경로는 브라우저 로그인 + localhost callback 방식이다.
+### 1. Localhost callback OAuth (기본)
 
-흐름:
-1. `ai-usage-agent auth login codex`
-2. 로컬 임시 서버 실행 (`127.0.0.1` 기반)
-3. PKCE/state 생성
-4. 로그인 URL 생성 후 브라우저 열기
-5. 사용자가 로그인 완료
-6. provider가 localhost callback으로 code 전달
-7. agent가 token exchange 수행
-8. access/refresh token을 자체 저장소에 저장
+1. `ai-usage-agent auth login <codex|claude>`
+2. 로컬 임시 서버 실행 (`127.0.0.1:<port>`)
+3. PKCE(S256) / state 생성
+4. 브라우저용 authorize URL 출력 (자동 오픈은 하지 않음)
+5. 사용자 로그인 완료 → provider가 localhost callback으로 code 전달
+6. `--live-exchange` 지정 시 token endpoint에 authorization_code grant POST
+7. access/refresh token을 agent-store에 저장
 
-장점:
-- UX가 가장 자연스러움
-- 사용자가 기존 웹 로그인 흐름에 익숙함
-- refresh token 기반 재사용 설계가 쉬움
+provider별 callback path:
+- Codex: `http://localhost:<port>/auth/callback`
+- Claude: `http://localhost:<port>/callback`
 
-### 2. 우선 fallback: manual paste
+### 2. Manual paste (Codex 전용 fallback)
 
-현 시점 우선 fallback은 manual paste 방식이다.
-
-지원해야 할 흐름:
 - callback URL 전체를 붙여넣기
-- authorization code를 수동 입력
-- 브라우저는 사용자 쪽에서 직접 열기 (`--no-open`)
+- `--no-open`으로 브라우저 자동 오픈 방지
+- localhost 접근이 제한된 원격/SSH 환경에서 사용
 
-이 방식이면 localhost callback이 실패하는 데스크톱/SSH 환경도 우선 커버할 수 있다.
+### 3. Claude CLI credential import (Claude 전용)
 
-### 3. 후순위 조사: device code flow
+`ai-usage-agent auth import claude`로 `~/.claude/.credentials.json`의 OAuth 토큰을 agent-store에 복사한다. 네트워크 호출 없이 사용 가능한 빠른 경로.
 
-provider가 device code를 안정적으로 지원하는지 확인되면 이후 단계에서 추가한다.
+### 4. Device code flow (미구현, 후순위)
 
-현재는 구현 우선순위를 낮춘다.
+## Credential source 우선순위
 
-## Credential Source 추상화
+### Codex
+1. `agent-store` (live-exchange로 받은 real token)
+2. `openclaw-import` (기존 OpenClaw auth-profiles.json)
 
-현재의 OpenClaw reader는 최종 형태가 아니라 migration source 중 하나로 내려가야 한다.
-
-권장 추상화:
-- `agent-store`
-- `openclaw-import`
-- `manual`
-
-현재 구현된 우선순위:
-1. `agent-store`
-2. `openclaw-import` (명시적 import 또는 migration 용도)
-
-후속 작업 후보:
-- `env` — 환경 변수 기반 credential source (미구현)
-
-즉 런타임 기본 경로는 OpenClaw 의존이 아니어야 한다.
+### Claude
+1. `agent-store` (`auth login claude --live-exchange` 또는 `auth import claude`로 저장된 항목)
+2. `claude-cli-import` (`~/.claude/.credentials.json` 실시간 reader)
 
 ## 저장소 설계 원칙
 
-- normalized auth metadata와 민감 토큰은 논리적으로 분리 가능해야 함
-- 초기 버전은 `auth.json` + `0600` 파일 저장으로 시작
-- 이후 keychain으로 확장 가능해야 함
-- 서버로 refresh token / session cookie / sessionKey 업로드 금지
+- `~/.config/ai-usage-agent/auth.json`, 권한 `0600`
+- normalized auth metadata와 민감 토큰은 논리적으로 분리 가능하게 설계
+- 이후 keychain으로 확장 가능
+- refresh token / session cookie는 외부 서버에 업로드 금지
 
 ## 보안 원칙
 
-- callback 서버는 기본적으로 `127.0.0.1`에만 bind
-- state 검증 필수
-- PKCE 사용 권장
+- callback 서버는 `127.0.0.1`에만 bind
+- state 검증 필수 (CSRF)
+- PKCE S256
 - refresh token은 필요 최소 범위로 저장
-- 로그에 access token / refresh token 출력 금지
-- raw provider 응답에서 민감 auth 값은 저장 금지
+- 로그에 access/refresh token 출력 금지
+- raw provider 응답에서 민감 auth 값 저장 금지
 
 ## Provider adapter 역할
 
-auth broker는 공통이지만, provider별 전략은 adapter가 정의한다.
+auth broker는 공통이지만, provider별 전략은 adapter가 정의한다:
 
-예:
-- auth URL 생성 규칙
-- token exchange endpoint
-- refresh endpoint
-- 지원 가능한 fallback 종류
-- account 식별 방식
+- authorize / token endpoint
+- observed client_id
+- scopes / extra params
+- redirect_uri 형식 (callback path)
+- refresh rotation 정책
+- account 식별 규칙
 
-## CLI와의 연결
+## CLI
 
-예상 명령:
-- `ai-usage-agent auth login codex`
-- `ai-usage-agent auth list`
-- `ai-usage-agent auth logout codex`
-- `ai-usage-agent doctor` / `doctor codex` / `doctor codex --refresh-live`
-- `ai-usage-agent auth import openclaw`
-
-## 단계별 구현 제안
-
-### Phase 1
-- auth architecture 문서화
-- credential store schema 정의
-- CLI 인터페이스 초안 정의
-
-### 현재까지 구현/검증 완료
-- auth store 저장/조회 로직 구현
-- multi-account resolver 구현
-- `auth login codex` CLI 기본 경로 (authorize → callback → mock 저장)
-- localhost callback 서버 구현 및 code/state 수신 동작 검증
-- manual paste fallback의 mock 저장 흐름 구현
-- Codex token exchange 함수 구현 (guarded real fetch)
-- `--live-exchange` 경로: 실제 token exchange 및 real token 저장 동작 검증됨 (실험적)
-- agent-store real token 우선으로 usage 조회 연결
-- account 식별: id_token/access_token JWT claims 기반 추출 (email → preferred_username → sub 순, fallback: code prefix)
-
-### Claude CLI credential reuse — read/display 단계 (완료)
-- `~/.claude/.credentials.json` reader 추가
-- OAuth credential → internal account 매핑 구현
-- Claude account resolver 추가 (agent-store → claude-cli-import 우선순위)
-- `status`, `doctor claude`, `auth list claude`에서 selectedAccount 흐름 정리
-- 수동 CLI 검증 완료: `doctor claude`, `auth list claude` 정상 출력 확인
-- 아직 live network 호출 없음, write/import 미구현
-
-### 다음 단계
-- Claude auth-store import/write 경로 설계 및 구현
-- `auth import openclaw` 경로 정리
-- revoke endpoint 지원 여부 확인
-
-### 후순위 단계
-- device code fallback 조사/도입
-- keychain 연동
+```text
+ai-usage-agent auth login <codex|claude> [--live-exchange] [--port N] [--timeout SEC] [--manual] [--no-open]
+ai-usage-agent auth list
+ai-usage-agent auth logout <provider> [--account <id>]
+ai-usage-agent auth import <openclaw|claude>
+ai-usage-agent doctor
+ai-usage-agent doctor codex [--refresh-live] [--account <id>]
+ai-usage-agent doctor claude [--refresh-live]
+ai-usage-agent status | usage
+```
 
 ## Codex OAuth endpoint 검증 현황
 
-아래는 OpenClaw 로컬 문서/코드 및 JWT 관찰값으로부터 확인된 사실이다.
-
-### 검증됨 (출처: OpenClaw docs/concepts/oauth.md, provider-openai-codex-oauth-tls-*.js)
+### 검증됨
 - authorize: `https://auth.openai.com/oauth/authorize`
-- token: `https://auth.openai.com/oauth/token`
-- callback: `http://localhost:1455/auth/callback` (host는 `localhost` — OpenClaw 관찰 기준)
-- JWT issuer: `https://auth.openai.com` (로컬 ~/.codex/auth.json 관찰)
+- token:     `https://auth.openai.com/oauth/token`
+- callback:  `http://localhost:1455/auth/callback`
+- JWT issuer: `https://auth.openai.com`
+- PKCE S256, state 검증, refresh rotation 반영: 실 토큰으로 동작 확인
 
-### 관찰됨 — 미확정
-- client_id `app_EMoamEEZ73f0CkXaXp7hrann` — 로컬 JWT payload에서 관찰. 공식 문서로 확정된 값이 아니므로 변경 가능성 있음.
+### observed (공식 확정 아님)
+- client_id: `app_EMoamEEZ73f0CkXaXp7hrann` (로컬 JWT payload 관찰)
+- extra authorize params: `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`, `originator=pi`
 
-### 구현 완료
-- PKCE S256 code_challenge 생성 (plain에서 S256으로 교체)
-- redirect_uri 경로를 `/auth/callback`으로 통일
-- 기본 콜백 포트를 1455로 변경 (OpenClaw 문서 기준)
-- redirect_uri host를 `localhost`로 변경 (OpenClaw 관찰 기준)
-- scopes를 `openid profile email offline_access`로 정렬 (OpenClaw 관찰 기준)
-- extra authorize params 반영: `id_token_add_organizations`, `codex_cli_simplified_flow`, `originator`
+### 미확정
+- client_secret 필요 여부 (현재 public client로 가정)
+- refresh token rotation 정책의 일반 규칙
+- 네트워크 호출 timeout/abort 처리 (이슈 #7)
 
-### observed alignment 참고
-현재는 OpenClaw가 실제로 생성하는 authorize URL과 최대한 동일하게 정렬했다.
-단, 이것은 OpenClaw 동작 관찰 기반 정렬(observed alignment)이며, OpenAI 공식 문서에
-의한 확정이 아니다. provider 측 변경이 있으면 재정렬이 필요할 수 있다.
+## Claude OAuth endpoint 검증 현황
 
-### 검증 완료
-- 실제 refresh token 재발급 성공
-- refresh token rotation 발생 시 store 반영 성공
-- refresh 직후 agent-store 기준 usage 조회 `OK (200)` 재확인
+### 검증됨 (실 네트워크 호출)
+- usage:     `GET https://api.anthropic.com/api/oauth/usage` (Bearer + anthropic-version + anthropic-beta) → 200 OK
+- refresh:   `POST https://platform.claude.com/v1/oauth/token` (grant_type=refresh_token, JSON body) → 표준 OAuth 에러 응답 구조 확인
+- 독립 OAuth 전체 플로우: 브라우저 로그인 → callback → token exchange(authorization_code) → agent-store 저장 → usage endpoint 200 OK까지 end-to-end 확인
 
-### 여전히 미확정
-- client_secret 필요 여부
-- refresh token rotation 정책의 일반 규칙 (매번 rotation되는지 여부 등)
+### observed (Claude Code v2.1.107 바이너리 strings에서 추출)
+- authorize: `https://claude.com/cai/oauth/authorize` (claude.ai 사용자 OAuth 경로)
+- token:     `https://platform.claude.com/v1/oauth/token`
+- manual redirect: `https://platform.claude.com/oauth/code/callback`
+- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+- scopes:    `org:create_api_key user:profile user:inference`
 
-### token exchange 구현 상태 (guarded real fetch)
+### Claude 관찰 기반 알림
+- authorize URL에 `code=true` 파라미터가 추가로 필요 (OAuth 스펙 외 확장)
+- token endpoint는 JSON body를 요구 (form-urlencoded는 Claude API 에러)
+- authorization_code grant는 body에 `state`를 포함해야 함
+- redirect_uri 경로는 `/callback` (Codex의 `/auth/callback`과 다름)
 
-`exchangeCodexAuthorizationCode()`와 `refreshCodexToken()`은 실제 fetch 경로가 구현되어 있으나
-**기본 동작은 guarded** 상태이다.
+### 미확정
+- client_secret 필요 여부 (public client 가정)
+- refresh token rotation 정책
+- 다른 client_id 값이 존재하는지 (`22422756-...`는 local-oauth 전용인 것으로 보임)
 
-- `allowLiveExchange` 옵션이 `false`(기본값)이면 기존처럼 에러를 던진다.
-- `allowLiveExchange: true`를 명시적으로 전달해야 실제 POST가 수행된다.
-- `clientId` 기본값은 관찰된 `app_EMoamEEZ73f0CkXaXp7hrann`을 사용하되,
-  이 값이 공식 확정이 아니라는 점은 에러 메시지와 문서 양쪽에서 명시한다.
+## Guard 패턴
 
-이 guard는 다음 조건이 모두 확인될 때까지 유지한다:
-1. client_id 공식 확정
-2. client_secret 요구사항 확인
+Codex/Claude의 token exchange와 refresh 함수는 **기본적으로 guard**되어 있다.
 
-guard를 해제할 때는 기본값을 `true`로 바꾸거나 옵션 자체를 제거하면 된다.
+- `allowLiveExchange: false` (기본값)이면 설명적 에러를 던진다
+- `allowLiveExchange: true`를 명시적으로 전달해야 실제 POST가 수행된다
+- CLI에서는 `--live-exchange` 플래그로 opt-in
 
-## 현재 확정된 운영 방안
+이 guard는 관찰값(observed client_id, endpoint 등)이 변경될 때 실수로 live 호출이 반복되는 것을 막기 위함이다.
 
-- 토큰 저장은 초기 버전에서 `auth.json` + `0600`으로 시작
-- device code는 후순위 조사 항목으로 둠
-- multi-account는 `lastUsedAt` 자동 선택 + `--account` override 사용
-- callback 포트 충돌 시 기본 포트(1455)부터 최대 3회 대체 포트 시도 후 manual paste로 전환
+## 운영 방안
+
+- 토큰 저장: `auth.json` + `0600` (기본 경로 `~/.config/ai-usage-agent/`)
+- multi-account: `lastUsedAt` 자동 선택 + `--account` override
+- callback 포트 충돌 시: 기본 포트부터 최대 3회 대체 포트 시도 → 실패 시 manual paste로 전환 (Codex)
+- timeout: `--timeout <seconds>` (기본 120초)
+- device code는 후순위 조사 항목
+
+## 다음 단계 후보
+
+- 네트워크 호출 timeout/abort (Codex/Claude 공통, 이슈 #7)
+- revoke endpoint 지원 여부 조사 (logout 시 서버측 무효화)
+- Claude Phase 4 — session cookie fallback (옵션, 이슈 #14)
+- keychain 연동
+- device code flow

--- a/docs/auth-cli.md
+++ b/docs/auth-cli.md
@@ -1,54 +1,39 @@
-# Auth CLI 인터페이스 초안
+# Auth CLI 인터페이스
 
-## 목표
+`ai-usage-agent`의 인증 관련 CLI 명령 집합과 운영 정책을 정리한다.
 
-`ai-usage-agent`가 OpenClaw 없이도 자체 인증을 수행할 수 있도록 auth 관련 CLI 명령 집합을 정의한다.
-
-## 기본 명령 구조
+## 명령 구조
 
 ```text
 ai-usage-agent auth <subcommand> [provider] [options]
+ai-usage-agent doctor [provider] [options]
 ```
 
-## 우선 구현 후보
-
-### 1. login
+## login
 
 ```bash
-ai-usage-agent auth login codex
+ai-usage-agent auth login codex   [--live-exchange] [--manual] [--no-open] [--port N] [--timeout SEC]
+ai-usage-agent auth login claude  [--live-exchange] [--port N] [--timeout SEC]
 ```
 
-현재 구현 상태:
-- authorize → localhost callback → code/state 수신까지 동작 검증됨
-- authorization URL은 OpenClaw observed alignment 기준으로 생성됨
-- 기본 경로는 token exchange 없이 mock 저장으로 끝남
-- `--live-exchange` 옵션으로 실제 token exchange 수행 가능 (동작 검증됨, 실험적)
-- 브라우저 자동 열기는 아직 미구현
-- `--manual`에서는 mock 저장 흐름이 동작
+동작:
+- localhost callback OAuth (PKCE S256 + state) 기반
+- 기본 경로는 token exchange 없이 **mock 저장**
+- `--live-exchange` 시 provider token endpoint에 실제 POST (실험적, guard 해제)
+- 성공 시 agent-store(`auth.json`)에 access/refresh token 저장
 
-옵션 예시:
+옵션:
+- `--live-exchange`: 실제 token 교환 시도. 실패 시 mock fallback 없이 에러 표시
+- `--manual` (Codex): callback URL/code 수동 붙여넣기
+- `--no-open` (Codex): 브라우저 자동 실행 안 함
+- `--port N`: localhost callback 포트 지정
+- `--timeout SEC`: callback 대기 시간 (기본 120초)
 
-```bash
-ai-usage-agent auth login codex --no-open
-ai-usage-agent auth login codex --manual
-ai-usage-agent auth login codex --device
-ai-usage-agent auth login codex --port 38123
-ai-usage-agent auth login codex --live-exchange
-```
+provider별 callback 경로:
+- Codex: `/auth/callback`
+- Claude: `/callback`
 
-옵션 의미:
-- `--no-open`: 브라우저 자동 실행 안 함
-- `--manual`: callback URL 또는 code 수동 입력 흐름 강제
-- `--device`: 후순위 실험용 옵션, provider 지원 확인 전까지는 기본 경로로 사용하지 않음
-- `--port`: localhost callback 포트 지정
-- `--live-exchange`: **실험적** — callback에서 수신한 code로 실제 token endpoint에 POST를 시도.
-  기본 동작(mock 저장)을 대체하며, 실패 시 mock fallback 없이 에러를 표시.
-  주의: PKCE S256이 적용되어 있으나, client_id는 관찰값(observed)이므로 성공이 보장되지 않음.
-  성공 시 account 식별은 id_token → access_token JWT claims에서 추출을 시도하며,
-  claims를 얻을 수 없으면 code prefix 기반 임시값으로 fallback한다.
-  어떤 claim source가 사용되었는지는 저장된 raw의 `identityClaimSource`에 기록된다.
-
-### 2. list
+## list
 
 ```bash
 ai-usage-agent auth list
@@ -56,140 +41,114 @@ ai-usage-agent auth list openai-codex
 ai-usage-agent auth list claude
 ```
 
-Claude 구현 상태:
-- `auth list claude`는 `~/.claude/.credentials.json` 기준으로 account 표시
-- 수동 CLI 검증 완료 (live network 호출 없음)
-- write/import 경로는 미구현 (다음 단계)
+출력 필드: provider, accountKey, email, source, authType, status, mock 여부, liveToken 여부, refresh 가능 여부, expiresAt, createdAt, updatedAt.
 
-현재 출력 필드:
-- provider
-- accountKey
-- email
-- source
-- authType
-- expiresAt
-- mock 여부
-- refresh 가능 여부
+Claude는 agent-store에 저장된 계정과 `~/.claude/.credentials.json` import source 양쪽을 표시한다.
 
-### 3. logout
+## logout
 
 ```bash
-ai-usage-agent auth logout codex
-ai-usage-agent auth logout codex --account choonarm3@gmail.com
+ai-usage-agent auth logout <provider>
+ai-usage-agent auth logout <provider> --account <email|accountKey>
 ```
 
-동작:
 - 로컬 auth store에서 해당 계정 제거
-- provider 측 revoke endpoint 호출은 아직 미구현
+- provider 측 revoke endpoint 호출은 미구현 (후속)
 
-### 4. doctor
+## import
 
 ```bash
-ai-usage-agent doctor
-ai-usage-agent doctor codex
-ai-usage-agent doctor codex --refresh-live
-ai-usage-agent doctor claude
+ai-usage-agent auth import openclaw   # OpenClaw auth-profiles.json → agent-store
+ai-usage-agent auth import claude     # ~/.claude/.credentials.json → agent-store
 ```
 
-Claude 구현 상태:
-- `doctor claude`는 `~/.claude/.credentials.json` 기준으로 selectedAccount 표시
-- 수동 CLI 검증 완료 (live network 호출 없음)
+- runtime 기본 경로가 아닌 **migration/흡수** 용도
+- Claude import는 CLI credential을 그대로 복사하는 빠른 경로 (네트워크 호출 없음)
+
+## doctor
+
+```bash
+ai-usage-agent doctor                        # 공통 상태 점검
+ai-usage-agent doctor codex                  # Codex 계정/refresh 가능성 점검
+ai-usage-agent doctor codex  --refresh-live  # 실제 refresh POST
+ai-usage-agent doctor codex  --account <id>  # 특정 계정 지정
+ai-usage-agent doctor claude                 # Claude credential + live usage 점검
+ai-usage-agent doctor claude --refresh-live  # Claude refresh POST
+```
 
 점검 항목:
-- auth store 존재 여부
-- provider 계정 존재 여부
-- expiresAt 만료 여부
-- refresh 가능 여부
-- callback 포트/환경 문제 힌트
-- 현재 기본 선택될 계정이 무엇인지
-- `--refresh-live` 시 실제 refresh token 재발급 시도 및 store 갱신
+- auth store / credential 파일 존재 여부
+- 선택될 계정 (agent-store > import 우선순위)
+- expiresAt 만료 임박 여부
+- refresh 가능 여부 (refreshToken 존재 + mock 아님)
+- live usage endpoint 응답 요약
+- `--refresh-live` 시 실제 refresh 호출 + 결과 표시
 
-### 5. import
+## Guard 정책 (`allowLiveExchange`)
 
-```bash
-ai-usage-agent auth import openclaw
-```
+- `exchangeCodexAuthorizationCode`, `refreshCodexToken`, `exchangeClaudeAuthorizationCode`, `refreshClaudeToken` 모두 기본 guarded
+- CLI의 `--live-exchange` / `--refresh-live`를 통해서만 guard 해제
+- 실패 시 mock fallback 없이 에러 노출 (사용자 혼동 방지)
+- 관찰값(observed client_id, endpoint)이 변경될 때 자동 재시도로 피해가 커지는 것 방지
 
-목적:
-- 기존 OpenClaw 사용자의 migration 지원
-- 런타임 기본 의존이 아니라 초기 전환 도구로만 제공
+guard를 해제할 시점:
+1. client_id 공식 확정
+2. client_secret 요구사항 명확화
+3. 장기 안정성 확인
 
-## 추천 UX 원칙
+## 포트 충돌 정책 (Codex)
+
+- 기본 포트: `1455`
+- 충돌 시 `1456`, `1457` 순으로 최대 3회 시도
+- 3회 모두 실패 → manual paste 모드 자동 전환
+- `--port` 명시 시 해당 포트만 시도, 실패 시 에러
+
+Claude는 동일한 `resolveCallbackPort` 로직을 사용하되 callback path가 다르다.
+
+## Multi-account 정책
+
+- 계정 1개: 자동 선택
+- 계정 여러 개: `lastUsedAt`이 가장 최근인 active 계정 선택
+- `--account`로 명시 override 가능 (email 또는 accountKey)
+
+## UX 원칙
 
 - 기본 명령은 최대한 짧게
 - 세부 제어는 옵션으로 열기
 - 실패 시 단순한 에러 대신 다음 행동을 안내
-- headless 환경을 위한 fallback 경로를 명확히 제공
-- multi-account는 자동 선택 + 명시 override 방식으로 단순하게 유지
+- headless/원격 환경용 fallback 경로를 명확히 제공
+- multi-account는 자동 + 명시 override
 
 ## 예시 시나리오
 
-### 일반 데스크톱 환경
+### 데스크톱: Claude 독립 OAuth
 
 ```bash
-ai-usage-agent auth login codex
+ai-usage-agent auth login claude --live-exchange
+# authorize URL 출력 → 브라우저에서 직접 열기
+# 로그인 완료 → localhost callback 수신 → token 저장
+ai-usage-agent status
 ```
 
-출력:
-1. 브라우저를 여는 중...
-2. 로그인 완료 후 callback 수신 대기...
-3. 저장 완료
+### 데스크톱: Claude 빠른 import
 
-### SSH / 원격 환경
+```bash
+# Claude CLI로 이미 로그인된 상태에서
+ai-usage-agent auth import claude
+ai-usage-agent status
+```
+
+### SSH/원격: Codex manual
 
 ```bash
 ai-usage-agent auth login codex --manual --no-open
+# 안내에 따라 brower로 URL 수동 오픈 → 반환 URL 전체 붙여넣기
 ```
-
-현재 출력/동작:
-1. callback URL 전체 또는 code 입력 요청
-2. mock 계정을 auth store에 저장 (manual 경로는 token exchange 미수행)
-
-## 포트 충돌 정책
-
-- 기본 포트: `1455` (OpenClaw 문서 기준)
-- 포트 충돌 시 `1456`, `1457` 순으로 최대 3회 자동 재시도
-- 3회 모두 실패하면 manual paste 모드로 자동 전환
-- 사용자가 `--port`를 명시한 경우는 해당 포트만 시도하고 실패 시 에러 반환
-
-## multi-account 정책
-
-- 계정이 1개면 자동 선택
-- 계정이 여러 개면 `lastUsedAt`이 가장 최근인 active 계정 사용
-- `--account`로 명시 지정 가능
-
-## Codex OAuth endpoint 검증 현황
-
-아래 endpoint는 OpenClaw 로컬 문서/코드로부터 검증됨:
-- authorize: `https://auth.openai.com/oauth/authorize`
-- token: `https://auth.openai.com/oauth/token`
-- callback: `http://localhost:1455/auth/callback` (host는 `localhost` — OpenClaw 관찰 기준)
-
-client_id `app_EMoamEEZ73f0CkXaXp7hrann`은 로컬 JWT에서 관찰된 값이며, 공식 확정이 아님.
-
-현재 authorize URL은 OpenClaw가 실제로 생성하는 URL과 최대한 동일하게 정렬했다 (observed alignment).
-- scopes: `openid profile email offline_access`
-- extra params: `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`, `originator=pi`
-
-이 정렬은 관찰 기반이며 공식 문서 확정이 아니므로, provider 변경 시 재정렬이 필요할 수 있다.
-
-## token exchange guard 정책
-
-`exchangeCodexAuthorizationCode()`와 `refreshCodexToken()`은 실제 fetch 코드가 포함되어 있지만,
-기본 동작은 `allowLiveExchange: false`로 보호되어 외부 호출을 하지 않는다.
-
-- CLI에서 `--live-exchange` 옵션을 명시하면 `allowLiveExchange: true`로 실제 token endpoint POST가 수행된다.
-- `--live-exchange` 없이 실행하면 기존과 동일한 mock 저장 흐름을 유지한다.
-- live exchange 실패 시 mock fallback 없이 에러를 표시한다 (사용자 혼동 방지).
-- `doctor codex --refresh-live`로 실제 refresh POST를 명시적으로 검증할 수 있다.
-- refresh 성공 시 accessToken, refreshToken, expiresAt를 store에 반영하고, 실패 시 저장값은 유지한다.
-- PKCE S256은 구현 완료됨. 이 guard는 client_id 공식 확정 시점까지 유지한다.
 
 ## 아직 미정인 부분
 
-- client_id 공식 확정 (현재는 관찰값만 존재)
-- client_secret 요구사항
-- revoke endpoint를 각 provider에서 어디까지 지원할지
-- `auth import openclaw`를 기본 노출할지 숨길지
-- device code를 실제로 도입할 provider 범위
-- claims에서 실제 email/sub가 얼마나 안정적으로 오는지 추가 관찰
+- client_secret 요구 여부 (Codex / Claude 모두)
+- revoke endpoint 지원 범위 (logout 시 서버측 무효화)
+- device code flow 도입 여부
+- keychain 연동
+- `auth import openclaw` 기본 노출 여부 (현재는 보조 명령으로 유지)

--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -14,43 +14,74 @@
   - 포트 충돌 시 자동 fallback (최대 3회) → manual paste 전환
 - fallback: `--manual` 플래그로 callback URL / code 직접 붙여넣기
 - token exchange: `--live-exchange` 플래그로 실 endpoint POST
-  - `client_id`는 observed 값 기반 (공식 확정 아님)
 - auth store 우선순위: `agent-store > openclaw-import`
+
+### OAuth endpoints
+
+- authorize: `https://auth.openai.com/oauth/authorize`
+- token:     `https://auth.openai.com/oauth/token`
+- callback:  `http://localhost:1455/auth/callback`
+- client_id: `app_EMoamEEZ73f0CkXaXp7hrann` (observed, 공식 확정 아님)
+- extra authorize params: `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`, `originator=pi`
 
 ### 알려진 제한
 
 - `auth logout`은 로컬 store 제거만 수행 (provider revoke endpoint 미호출)
-- 네트워크 호출에 timeout/AbortController 없음 → `#7` 참고
+- 네트워크 호출에 timeout/AbortController 없음 → 이슈 #7
+- client_secret 요구 여부 미확정
 
 ---
 
 ## Anthropic / Claude
 
-### 인증 (local import)
+### auth 흐름
 
-- credential 파일: `~/.claude/.credentials.json`
-- 구조: `{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier } }`
-- 상태: **local credential reuse 검증 완료**
-- `auth import claude`로 agent-store에 저장 가능
+두 경로가 공존한다.
 
-### OAuth endpoints (observed)
+- `auth login claude --live-exchange`: 독립 OAuth (브라우저 로그인) → agent-store에 live token 저장
+- `auth import claude`: `~/.claude/.credentials.json` reader → agent-store에 복사
 
-Claude Code 바이너리(`~/.local/share/claude/versions/<v>`) strings에서 관찰한 값.
-공식 문서 기재 없음 — observed 레벨.
+credential source 우선순위: `agent-store > claude-cli-import`
 
-- authorize: `https://platform.claude.com/oauth/authorize`
+### live usage endpoint
+
+- `GET https://api.anthropic.com/api/oauth/usage`
+- 헤더: `Authorization: Bearer <token>`, `anthropic-version: 2023-06-01`, `anthropic-beta: oauth-2025-04-20`
+- 상태: **실작동 검증 완료** (live 200 OK, 사용률 수치 반환)
+- 응답 shape (observed):
+  - `five_hour: { utilization, resets_at }` — 5시간 window
+  - `seven_day: { utilization, resets_at }` — 주간 window
+  - `seven_day_sonnet / seven_day_opus: { utilization }` — 모델별 주간
+
+### OAuth endpoints (observed — Claude Code v2.1.107 바이너리에서 추출)
+
+- authorize: `https://claude.com/cai/oauth/authorize` (claude.ai 사용자 OAuth)
 - token:     `https://platform.claude.com/v1/oauth/token`
+- redirect_uri: `http://localhost:<port>/callback` (Codex와 경로 다름)
 - manual redirect: `https://platform.claude.com/oauth/code/callback`
 - success page: `https://platform.claude.com/oauth/code/success?app=claude-code`
-- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e` (production claude-code)
+- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+- scopes: `org:create_api_key user:profile user:inference`
+
+### 관찰 기반 주의사항 (Claude 전용)
+
+- authorize URL에 `code=true` 파라미터를 추가로 보낸다 (OAuth 스펙 외 확장)
+- token endpoint는 **JSON body**를 요구. form-urlencoded는 Claude API 에러(`invalid_request_error`) 응답
+- `authorization_code` grant는 body에 `state` 필드를 포함해야 함
+- `https://platform.claude.com/oauth/authorize`는 API key 발급용 별도 흐름 → claude.ai 경로와 혼동 금지
+
+### credential 파일 (claude-cli-import)
+
+- 경로: `~/.claude/.credentials.json`
+- 구조: `{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier } }`
 
 ### refresh token
 
-- `refreshClaudeToken` 구현 (Codex와 동일한 guard 패턴)
+- `refreshClaudeToken` 구현 (Codex와 동일한 `allowLiveExchange` guard)
 - `doctor claude --refresh-live`로 수동 검증 가능
-- store 반영은 Phase 3 claude login 이후 연결
+- rotation 반영: 응답에 새 `refresh_token`이 오면 교체, 없으면 기존 유지
 
-### usage (로컬 stats-cache)
+### 로컬 usage (stats-cache)
 
 - 파일: `~/.claude/stats-cache.json`
 - Claude Code가 실행될 때 자동 갱신
@@ -73,10 +104,12 @@ Claude Code 바이너리(`~/.local/share/claude/versions/<v>`) strings에서 관
     }
   }
   ```
-- 상태: **감지 및 최소 파싱 완료** (totalSessions, totalMessages, modelUsage/dailyModelTokens 유무)
-- 상세 토큰 수치 파싱은 다음 단계
+- 상태: 감지 및 최소 파싱 완료 (totalSessions, totalMessages, modelUsage/dailyModelTokens 유무)
+- 상세 토큰 수치 파싱은 후속 작업
 
-### 알려진 제한
+### 알려진 제한 / 미확정
 
-- 네트워크 기반 usage API (`/api/oauth/usage` 등) 실호출 검증 미완료
-- stats-cache는 로컬 캐시 — 실시간 서버 데이터와 다를 수 있음
+- client_secret 요구 여부 (현재 public client로 가정)
+- refresh token rotation 정책 상세
+- 네트워크 호출 timeout/AbortController 미적용 (이슈 #7)
+- web session cookie fallback은 미구현 (이슈 #14)


### PR DESCRIPTION
## 요약

Claude OAuth Phase 1~3 완료 후 실제 코드 상태와 문서 사이에 벌어진 gap을 좁힌다.
리팩터 브랜치의 첫 커밋으로, 이후 구조 리팩터 작업 전에 문서부터 정리한다.

## 변경 내용

### README.md

- provider 지원 범위 표 (Codex / Claude 각각 auth · usage · refresh 상태)
- CLI 명령 블록에 `auth login claude`, `auth import claude`, `doctor claude` 추가
- credential source 우선순위를 provider별로 분리 표기
- observed vs verified 구분 원칙 설명 추가
- 다음 작업 후보 목록을 현재 상태 기준으로 갱신

### docs/auth-architecture.md

- "현재 문제"(OpenClaw 결합) 섹션 제거 — 이미 해소된 상태
- Codex / Claude OAuth endpoint 검증 현황 섹션 분리
- Claude 전용 관찰 사항(`code=true` 파라미터, JSON body, `state` 필드) 명시
- guard 패턴(`allowLiveExchange`) 정책 설명

### docs/auth-cli.md

- `auth login claude`, `auth import claude`, `doctor claude --refresh-live` 반영
- `--timeout` 옵션 추가
- provider별 callback path 차이(`/auth/callback` vs `/callback`) 명시
- guard / 포트 충돌 / multi-account 정책 재정리
- 예시 시나리오에 Claude 경로 추가

### docs/provider-notes.md

- Claude authorize endpoint를 `claude.com/cai/oauth/authorize`로 정정 (`platform.claude.com/oauth/authorize`는 API key 발급용)
- token endpoint가 JSON body + body.state 요구하는 관찰 사항 추가
- refresh / usage 실검증 완료 반영 (`store 반영 Phase 3 이후` 같은 stale 문구 제거)

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `repo`
- [x] `docs`

## 테스트 / 확인

- 코드 변경 없음 → 기존 테스트 유지
- docs만 읽어서 일관성 검토

## 리뷰 포인트

- 문서와 실제 동작 사이에 빠진 항목이 있는지
- 용어 일관성(`agent-store` / `claude-cli-import` / `observed` / `verified`)

## 참고 사항

- 이 브랜치는 이후 구조 리팩터(중복 provider shape 통합 등) 작업도 예정.
- 관련 이슈: #10 close, #7 / #14 유지.