### PR TITLE
[test] 테스트 커버리지 1·2차 보강 (Codex 대칭 / services / CLI / smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main, dev]
   pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -2,113 +2,136 @@ import { getStatusSnapshot } from '../services/status-service.js';
 
 export const STATUS_COMMANDS = ['status', 'usage'];
 
+/**
+ * `status` / `usage` 진입점.
+ * 출력 라인 생성은 pure formatter에 위임하고, 본 함수는 console.log만 담당.
+ */
 export async function runStatusCommand(command) {
   const snapshot = await getStatusSnapshot();
-
-  console.log(`명령: ${command}`);
-  console.log('로컬 에이전트 상태 요약');
-  console.log('-----------------------');
-  console.log(`설정 파일: ${snapshot.configPath}`);
-  console.log(`Codex 사용: ${snapshot.providers.codex.enabled ? 'enabled' : 'disabled'}`);
-  console.log(`Claude 사용: ${snapshot.providers.claude.enabled ? 'enabled' : 'disabled'}`);
-  console.log(`서버 sync: ${snapshot.sync.enabled ? 'enabled' : 'disabled'}`);
-  console.log('');
-  printCodexSection(snapshot.codex);
-  console.log('');
-  printClaudeSection(snapshot.claude);
+  for (const line of formatStatusOutput(command, snapshot)) {
+    console.log(line);
+  }
 }
 
-function printCodexSection(codex) {
-  console.log('Codex usage');
-  console.log('-----------');
+/**
+ * 전체 status 출력 라인 배열을 만드는 pure 함수.
+ * @param {string} command
+ * @param {object} snapshot - getStatusSnapshot 결과
+ * @returns {string[]}
+ */
+export function formatStatusOutput(command, snapshot) {
+  return [
+    `명령: ${command}`,
+    '로컬 에이전트 상태 요약',
+    '-----------------------',
+    `설정 파일: ${snapshot.configPath}`,
+    `Codex 사용: ${snapshot.providers.codex.enabled ? 'enabled' : 'disabled'}`,
+    `Claude 사용: ${snapshot.providers.claude.enabled ? 'enabled' : 'disabled'}`,
+    `서버 sync: ${snapshot.sync.enabled ? 'enabled' : 'disabled'}`,
+    '',
+    ...formatCodexSection(snapshot.codex),
+    '',
+    ...formatClaudeSection(snapshot.claude),
+  ];
+}
+
+/** Pure formatter: Codex usage section. */
+export function formatCodexSection(codex) {
+  const lines = ['Codex usage', '-----------'];
 
   if (!codex.enabled) {
-    console.log('비활성화됨');
-    return;
+    lines.push('비활성화됨');
+    return lines;
   }
 
-  console.log(`인증 소스: ${codex.authSource ?? 'unknown'}`);
+  lines.push(`인증 소스: ${codex.authSource ?? 'unknown'}`);
   if (codex.authProfilesPath) {
-    console.log(`Auth profiles 경로: ${codex.authProfilesPath}`);
+    lines.push(`Auth profiles 경로: ${codex.authProfilesPath}`);
   }
 
   if (codex.snapshots.length === 0) {
-    console.log('발견된 Codex OAuth 프로필이 없습니다.');
-    return;
+    lines.push('발견된 Codex OAuth 프로필이 없습니다.');
+    return lines;
   }
 
   for (const snapshot of codex.snapshots) {
-    const label = snapshot.account.email ? `${snapshot.account.profileId} (${snapshot.account.email})` : snapshot.account.profileId;
-    console.log(`- ${label}`);
-    console.log(`  상태: ${snapshot.status.ok ? `OK (${snapshot.status.httpStatus})` : `실패 (${snapshot.status.httpStatus ?? 'network/error'})`}`);
-    console.log(`  source=${snapshot.source}, authType=${snapshot.authType}, confidence=${snapshot.confidence}`);
-    if (snapshot.account.plan) {
-      console.log(`  플랜: ${snapshot.account.plan}`);
-    }
+    const label = snapshot.account.email
+      ? `${snapshot.account.profileId} (${snapshot.account.email})`
+      : snapshot.account.profileId;
+    lines.push(`- ${label}`);
+    lines.push(
+      `  상태: ${
+        snapshot.status.ok
+          ? `OK (${snapshot.status.httpStatus})`
+          : `실패 (${snapshot.status.httpStatus ?? 'network/error'})`
+      }`,
+    );
+    lines.push(
+      `  source=${snapshot.source}, authType=${snapshot.authType}, confidence=${snapshot.confidence}`,
+    );
+    if (snapshot.account.plan) lines.push(`  플랜: ${snapshot.account.plan}`);
     for (const window of snapshot.usageWindows) {
-      console.log(`  ${window.kind}: ${formatWindow(window)}`);
+      lines.push(`  ${window.kind}: ${formatWindow(window)}`);
     }
-    if (snapshot.status.message) {
-      console.log(`  에러: ${snapshot.status.message}`);
-    }
+    if (snapshot.status.message) lines.push(`  에러: ${snapshot.status.message}`);
   }
+  return lines;
 }
 
-function printClaudeSection(claude) {
-  console.log('Claude usage');
-  console.log('------------');
-  console.log(`인증 소스: ${claude.authSource}`);
-  console.log(`credential 감지: ${claude.detected}`);
+/** Pure formatter: Claude usage section. */
+export function formatClaudeSection(claude) {
+  const lines = ['Claude usage', '------------'];
+  lines.push(`인증 소스: ${claude.authSource}`);
+  lines.push(`credential 감지: ${claude.detected}`);
   if (claude.selectedAccount) {
-    console.log(`계정: ${claude.selectedAccount.accountKey}`);
+    lines.push(`계정: ${claude.selectedAccount.accountKey}`);
   }
-
-  printClaudeNetworkUsage(claude.networkUsage);
-  printClaudeLocalUsage(claude.usage);
+  lines.push(...formatClaudeNetworkUsage(claude.networkUsage));
+  lines.push(...formatClaudeLocalUsage(claude.usage));
+  return lines;
 }
 
-function printClaudeNetworkUsage(networkUsage) {
-  console.log('');
-  console.log('[live] api.anthropic.com/api/oauth/usage');
+/** Pure formatter: Claude live network usage block. */
+export function formatClaudeNetworkUsage(networkUsage) {
+  const lines = ['', '[live] api.anthropic.com/api/oauth/usage'];
   if (!networkUsage) {
-    console.log('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
-    return;
+    lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
+    return lines;
   }
 
   if (networkUsage.status?.ok) {
-    console.log(`  상태: OK (${networkUsage.status.httpStatus})`);
+    lines.push(`  상태: OK (${networkUsage.status.httpStatus})`);
     if (networkUsage.usageWindows.length === 0) {
-      console.log('  usageWindows 없음 (응답에 기대한 필드가 없었음)');
+      lines.push('  usageWindows 없음 (응답에 기대한 필드가 없었음)');
     }
     for (const window of networkUsage.usageWindows) {
-      console.log(`  ${window.kind}: ${formatWindow(window)}`);
+      lines.push(`  ${window.kind}: ${formatWindow(window)}`);
     }
-    return;
+    return lines;
   }
 
   const http = networkUsage.status?.httpStatus ?? 'network/error';
   const bucket = networkUsage.status?.bucket ?? 'unknown';
-  console.log(`  상태: 실패 (${http}, bucket=${bucket})`);
-  if (networkUsage.status?.message) {
-    console.log(`  메시지: ${networkUsage.status.message}`);
-  }
+  lines.push(`  상태: 실패 (${http}, bucket=${bucket})`);
+  if (networkUsage.status?.message) lines.push(`  메시지: ${networkUsage.status.message}`);
+  return lines;
 }
 
-function printClaudeLocalUsage(usage) {
-  console.log('');
-  console.log('[local] stats-cache.json');
+/** Pure formatter: Claude local stats-cache block. */
+export function formatClaudeLocalUsage(usage) {
+  const lines = ['', '[local] stats-cache.json'];
   if (!usage || usage.source === 'not-found') {
-    console.log('  데이터 없음 (stats-cache.json 미발견)');
-    return;
+    lines.push('  데이터 없음 (stats-cache.json 미발견)');
+    return lines;
   }
-
-  console.log(`  총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
-  console.log(`  총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
-  console.log(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
-  console.log(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
+  lines.push(`  총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
+  lines.push(`  총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
+  lines.push(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
+  lines.push(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
+  return lines;
 }
 
-function formatWindow(window) {
+export function formatWindow(window) {
   const reset = window.resetAt ? `reset_at=${window.resetAt}` : 'reset_at=unknown';
   const used = window.usedPercent ?? 'unknown';
   return `used_percent=${used}, ${reset}`;

--- a/packages/agent/test/auth/manual-paste.test.js
+++ b/packages/agent/test/auth/manual-paste.test.js
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractCodeFromPaste } from '../../src/auth/manual-paste.js';
+
+describe('extractCodeFromPaste — error envelope', () => {
+  it('propagates error from pasteResult', () => {
+    const out = extractCodeFromPaste({ type: 'code', value: '', error: 'empty-input' });
+    assert.equal(out.code, null);
+    assert.equal(out.state, null);
+    assert.equal(out.error, 'empty-input');
+  });
+});
+
+describe('extractCodeFromPaste — type=code', () => {
+  it('returns the raw code string as-is', () => {
+    const out = extractCodeFromPaste({ type: 'code', value: 'ac_abc123' });
+    assert.equal(out.code, 'ac_abc123');
+    assert.equal(out.state, null);
+    assert.equal(out.error, null);
+  });
+
+  it('handles arbitrary string input (trimmed upstream)', () => {
+    const out = extractCodeFromPaste({ type: 'code', value: 'odd  value 🎉' });
+    assert.equal(out.code, 'odd  value 🎉');
+    assert.equal(out.error, null);
+  });
+});
+
+describe('extractCodeFromPaste — type=url', () => {
+  it('extracts code + state from a valid callback URL', () => {
+    const out = extractCodeFromPaste({
+      type: 'url',
+      value: 'http://localhost:1455/auth/callback?code=abc&state=xyz',
+    });
+    assert.equal(out.code, 'abc');
+    assert.equal(out.state, 'xyz');
+    assert.equal(out.error, null);
+  });
+
+  it('returns no-code-in-url when URL has no code param', () => {
+    const out = extractCodeFromPaste({
+      type: 'url',
+      value: 'http://localhost/auth/callback?state=xyz',
+    });
+    assert.equal(out.code, null);
+    assert.equal(out.state, 'xyz');
+    assert.equal(out.error, 'no-code-in-url');
+  });
+
+  it('returns invalid-url for garbage input labeled as url', () => {
+    const out = extractCodeFromPaste({ type: 'url', value: 'not-a-url' });
+    assert.equal(out.code, null);
+    assert.equal(out.error, 'invalid-url');
+  });
+
+  it('preserves additional query params intact (code still extracted)', () => {
+    const out = extractCodeFromPaste({
+      type: 'url',
+      value:
+        'http://localhost:1455/auth/callback?scope=openid+email&code=ac_42&state=st1',
+    });
+    assert.equal(out.code, 'ac_42');
+    assert.equal(out.state, 'st1');
+    assert.equal(out.error, null);
+  });
+
+  it('treats https URLs equally', () => {
+    const out = extractCodeFromPaste({
+      type: 'url',
+      value: 'https://example.com/cb?code=c',
+    });
+    assert.equal(out.code, 'c');
+    assert.equal(out.error, null);
+  });
+});

--- a/packages/agent/test/auth/mock-auth-exchange.test.js
+++ b/packages/agent/test/auth/mock-auth-exchange.test.js
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMockCodexAccountFromManualInput } from '../../src/auth/mock-auth-exchange.js';
+
+describe('createMockCodexAccountFromManualInput', () => {
+  it('derives accountKey from the sanitized code prefix (email-like)', () => {
+    const account = createMockCodexAccountFromManualInput({
+      code: 'abcDEF12345xyz',
+      rawInput: 'callback-url-or-code',
+    });
+    assert.equal(account.accountKey, 'openai-codex:manual-abcdef12@example.local');
+    assert.equal(account.email, 'manual-abcdef12@example.local');
+  });
+
+  it('falls back to "manual" suffix when code is empty or pure-punctuation', () => {
+    const a = createMockCodexAccountFromManualInput({ code: '', rawInput: 'x' });
+    assert.ok(a.accountKey.includes('manual-manual'));
+    const b = createMockCodexAccountFromManualInput({ code: '!!!@@@###', rawInput: 'x' });
+    assert.ok(b.accountKey.includes('manual-manual'));
+  });
+
+  it('strips non-[a-zA-Z0-9_-] characters from code', () => {
+    const account = createMockCodexAccountFromManualInput({
+      code: 'a b*c!d#e',
+      rawInput: 'x',
+    });
+    assert.ok(account.accountKey.includes('manual-abcde'));
+  });
+
+  it('marks the account as mock with raw.mock=true and source=manual', () => {
+    const account = createMockCodexAccountFromManualInput({
+      code: 'abcd',
+      rawInput: 'x',
+    });
+    assert.equal(account.raw.mock, true);
+    assert.equal(account.source, 'manual');
+    assert.equal(account.raw.provider, 'openai-codex');
+  });
+
+  it('generates mock tokens following the accessToken/refreshToken convention', () => {
+    const account = createMockCodexAccountFromManualInput({
+      code: 'abcd',
+      rawInput: 'x',
+    });
+    assert.match(account.tokens.accessToken, /^mock-access-token-/);
+    assert.match(account.tokens.refreshToken, /^mock-refresh-token-/);
+  });
+
+  it('truncates manualInputPreview to 120 chars', () => {
+    const long = 'x'.repeat(500);
+    const account = createMockCodexAccountFromManualInput({
+      code: 'abcd',
+      rawInput: long,
+    });
+    assert.equal(account.raw.manualInputPreview.length, 120);
+  });
+
+  it('preserves original code case in accountKey via lower-casing', () => {
+    // sanitize lower-cases, so 'AbCd' → 'abcd'
+    const account = createMockCodexAccountFromManualInput({
+      code: 'AbCd1234',
+      rawInput: 'x',
+    });
+    assert.ok(account.accountKey.includes('manual-abcd1234'));
+  });
+});

--- a/packages/agent/test/cli/auth-logout-command.test.js
+++ b/packages/agent/test/cli/auth-logout-command.test.js
@@ -1,0 +1,147 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runAuthLogoutCommand } from '../../src/cli/auth-logout-command.js';
+import { saveAuthStore } from '../../src/auth/auth-store.js';
+import { createEmptyAuthStore } from '../../src/auth/auth-store-schema.js';
+
+let tmpHome;
+let originalHome;
+let originalLog;
+let originalErr;
+let logs;
+let errs;
+
+function withTmpHome() {
+  before(() => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-usage-logout-'));
+    process.env.HOME = tmpHome;
+    originalLog = console.log;
+    originalErr = console.error;
+    logs = [];
+    errs = [];
+    console.log = (...a) => logs.push(a.join(' '));
+    console.error = (...a) => errs.push(a.join(' '));
+    process.exitCode = 0;
+  });
+  after(() => {
+    console.log = originalLog;
+    console.error = originalErr;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+    process.exitCode = 0;
+  });
+}
+
+async function seedStore(providers = {}) {
+  const store = createEmptyAuthStore();
+  store.providers = providers;
+  await saveAuthStore(store);
+}
+
+describe('runAuthLogoutCommand — usage error', () => {
+  withTmpHome();
+
+  it('prints usage to stderr and sets exitCode=1 when provider missing', async () => {
+    await runAuthLogoutCommand(undefined, []);
+    assert.ok(errs.some((l) => l.includes('사용법: ai-usage-agent auth logout')));
+    assert.equal(process.exitCode, 1);
+  });
+});
+
+describe('runAuthLogoutCommand — no accounts stored', () => {
+  withTmpHome();
+
+  it('reports 저장된 계정이 없습니다 when provider entry missing', async () => {
+    await saveAuthStore(createEmptyAuthStore());
+    await runAuthLogoutCommand('openai-codex', []);
+    assert.ok(logs.some((l) => l.includes('저장된 계정이 없습니다')));
+  });
+});
+
+describe('runAuthLogoutCommand — single account removal', () => {
+  withTmpHome();
+
+  it('removes the only account and logs removal details', async () => {
+    await seedStore({
+      'openai-codex': {
+        accounts: [
+          {
+            accountKey: 'openai-codex:alice',
+            email: 'alice@example.com',
+            source: 'agent-store',
+            authType: 'oauth',
+            status: 'active',
+            tokens: { accessToken: 'real-tok' },
+          },
+        ],
+      },
+    });
+
+    await runAuthLogoutCommand('openai-codex', []);
+
+    assert.ok(logs.some((l) => l.includes('제거 대상')));
+    assert.ok(logs.some((l) => l.includes('openai-codex:alice')));
+    assert.ok(logs.some((l) => l.includes('계정이 로컬 저장소에서 제거되었습니다')));
+  });
+});
+
+describe('runAuthLogoutCommand — --account selection', () => {
+  withTmpHome();
+
+  it('removes the account matching --account email', async () => {
+    await seedStore({
+      'openai-codex': {
+        accounts: [
+          {
+            accountKey: 'openai-codex:a',
+            email: 'a@x.com',
+            source: 'agent-store',
+            authType: 'oauth',
+            status: 'active',
+            tokens: { accessToken: 't1' },
+          },
+          {
+            accountKey: 'openai-codex:b',
+            email: 'b@x.com',
+            source: 'agent-store',
+            authType: 'oauth',
+            status: 'active',
+            tokens: { accessToken: 't2' },
+          },
+        ],
+      },
+    });
+
+    await runAuthLogoutCommand('openai-codex', ['--account', 'b@x.com']);
+
+    assert.ok(logs.some((l) => l.includes('openai-codex:b')));
+    assert.ok(!logs.some((l) => l.includes('제거 대상') && l.includes('a@x.com')));
+  });
+
+  it('reports not-found when --account does not match any account', async () => {
+    await seedStore({
+      'openai-codex': {
+        accounts: [
+          {
+            accountKey: 'openai-codex:a',
+            email: 'a@x.com',
+            source: 'agent-store',
+            authType: 'oauth',
+            status: 'active',
+            tokens: { accessToken: 't1' },
+          },
+        ],
+      },
+    });
+
+    await runAuthLogoutCommand('openai-codex', ['--account', 'nope@x.com']);
+    assert.ok(logs.some((l) => l.includes('계정을 찾을 수 없습니다')));
+    assert.equal(process.exitCode, 1);
+  });
+});

--- a/packages/agent/test/cli/config-init-command.test.js
+++ b/packages/agent/test/cli/config-init-command.test.js
@@ -1,0 +1,68 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runConfigInitCommand } from '../../src/cli/config-init-command.js';
+
+let tmpHome;
+let originalHome;
+let originalLog;
+let logged;
+
+function withTmpHome() {
+  before(() => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-usage-config-'));
+    process.env.HOME = tmpHome;
+    originalLog = console.log;
+    logged = [];
+    console.log = (...args) => logged.push(args.join(' '));
+  });
+  after(() => {
+    console.log = originalLog;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+}
+
+describe('runConfigInitCommand — fresh init', () => {
+  withTmpHome();
+
+  it('creates ~/.config/ai-usage-agent/config.json with default contents', async () => {
+    await runConfigInitCommand();
+
+    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    assert.ok(fs.existsSync(configPath), 'config file should exist');
+
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    assert.ok(parsed.providers);
+    assert.equal(parsed.providers.codex.enabled, true);
+    assert.equal(parsed.providers.claude.enabled, true);
+    assert.equal(typeof parsed.sync, 'object');
+  });
+
+  it('logs the created file path', async () => {
+    assert.ok(logged.some((l) => l.includes('기본 설정 파일을 생성했습니다')));
+    assert.ok(logged.some((l) => l.includes('config.json')));
+  });
+});
+
+describe('runConfigInitCommand — overwrite behavior', () => {
+  withTmpHome();
+
+  it('overwrites existing file (current contract — caller responsible for backup)', async () => {
+    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{"custom":"value"}');
+
+    await runConfigInitCommand();
+
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.equal(parsed.custom, undefined);
+    assert.ok(parsed.providers);
+  });
+});

--- a/packages/agent/test/cli/config-init-command.test.js
+++ b/packages/agent/test/cli/config-init-command.test.js
@@ -46,6 +46,9 @@ describe('runConfigInitCommand — fresh init', () => {
   });
 
   it('logs the created file path', async () => {
+    // 이전 it에 의존하지 않도록 자체적으로 커맨드를 재실행하고 로그도 reset 후 검증.
+    logged.length = 0;
+    await runConfigInitCommand();
     assert.ok(logged.some((l) => l.includes('기본 설정 파일을 생성했습니다')));
     assert.ok(logged.some((l) => l.includes('config.json')));
   });

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -1,0 +1,191 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatStatusOutput,
+  formatCodexSection,
+  formatClaudeSection,
+  formatClaudeNetworkUsage,
+  formatClaudeLocalUsage,
+  formatWindow,
+  STATUS_COMMANDS,
+} from '../../src/cli/status-command.js';
+
+describe('STATUS_COMMANDS', () => {
+  it('exposes status and usage as entry points', () => {
+    assert.deepEqual([...STATUS_COMMANDS].sort(), ['status', 'usage']);
+  });
+});
+
+describe('formatWindow', () => {
+  it('renders used_percent and reset_at when present', () => {
+    assert.equal(
+      formatWindow({ usedPercent: 25, resetAt: '2026-04-15T00:00:00Z' }),
+      'used_percent=25, reset_at=2026-04-15T00:00:00Z',
+    );
+  });
+
+  it('falls back to unknown when fields missing', () => {
+    assert.equal(
+      formatWindow({ usedPercent: null, resetAt: null }),
+      'used_percent=unknown, reset_at=unknown',
+    );
+  });
+});
+
+describe('formatCodexSection', () => {
+  it('shows 비활성화됨 when codex is disabled', () => {
+    const lines = formatCodexSection({ enabled: false });
+    assert.ok(lines.includes('비활성화됨'));
+  });
+
+  it('reports no profile message when enabled but snapshots empty', () => {
+    const lines = formatCodexSection({ enabled: true, authSource: 'agent-store', snapshots: [] });
+    assert.ok(lines.some((l) => l.includes('인증 소스: agent-store')));
+    assert.ok(lines.some((l) => l.includes('Codex OAuth 프로필이 없습니다')));
+  });
+
+  it('shows Auth profiles 경로 when openclaw-import', () => {
+    const lines = formatCodexSection({
+      enabled: true,
+      authSource: 'openclaw-import',
+      authProfilesPath: '/path/openclaw.json',
+      snapshots: [],
+    });
+    assert.ok(lines.some((l) => l.includes('Auth profiles 경로: /path/openclaw.json')));
+  });
+
+  it('renders snapshot details + windows + plan + error', () => {
+    const lines = formatCodexSection({
+      enabled: true,
+      authSource: 'agent-store',
+      snapshots: [
+        {
+          source: 'provider_usage_endpoint',
+          authType: 'oauth',
+          confidence: 'high',
+          account: { profileId: 'p1', email: 'x@example.com', plan: 'plus' },
+          status: { ok: true, httpStatus: 200, message: null },
+          usageWindows: [{ kind: 'primary', usedPercent: 5, resetAt: '2026-04-15' }],
+        },
+      ],
+    });
+    assert.ok(lines.some((l) => l.includes('p1 (x@example.com)')));
+    assert.ok(lines.some((l) => l.includes('상태: OK (200)')));
+    assert.ok(lines.some((l) => l.includes('confidence=high')));
+    assert.ok(lines.some((l) => l.includes('플랜: plus')));
+    assert.ok(lines.some((l) => l.includes('primary: used_percent=5')));
+  });
+
+  it('renders failure status with httpStatus/network and includes error message', () => {
+    const lines = formatCodexSection({
+      enabled: true,
+      authSource: 'agent-store',
+      snapshots: [
+        {
+          source: 'provider_usage_endpoint',
+          authType: 'oauth',
+          confidence: 'low',
+          account: { profileId: 'p1' },
+          status: { ok: false, httpStatus: 500, message: 'boom' },
+          usageWindows: [],
+        },
+      ],
+    });
+    assert.ok(lines.some((l) => l.includes('실패 (500)')));
+    assert.ok(lines.some((l) => l.includes('에러: boom')));
+  });
+
+  it('uses network/error label when httpStatus is null', () => {
+    const lines = formatCodexSection({
+      enabled: true,
+      authSource: 'agent-store',
+      snapshots: [
+        {
+          source: 'x',
+          authType: 'oauth',
+          confidence: 'low',
+          account: { profileId: 'p1' },
+          status: { ok: false, httpStatus: null },
+          usageWindows: [],
+        },
+      ],
+    });
+    assert.ok(lines.some((l) => l.includes('실패 (network/error)')));
+  });
+});
+
+describe('formatClaudeNetworkUsage', () => {
+  it('shows 호출 안 함 when networkUsage is null', () => {
+    assert.ok(formatClaudeNetworkUsage(null).some((l) => l.includes('호출 안 함')));
+  });
+
+  it('renders OK + windows on success', () => {
+    const lines = formatClaudeNetworkUsage({
+      status: { ok: true, httpStatus: 200 },
+      usageWindows: [{ kind: 'five_hour', usedPercent: 10, resetAt: '2026-04-15' }],
+    });
+    assert.ok(lines.some((l) => l.includes('상태: OK (200)')));
+    assert.ok(lines.some((l) => l.includes('five_hour: used_percent=10')));
+  });
+
+  it('reports usageWindows 없음 when ok=true with empty windows', () => {
+    const lines = formatClaudeNetworkUsage({
+      status: { ok: true, httpStatus: 200 },
+      usageWindows: [],
+    });
+    assert.ok(lines.some((l) => l.includes('usageWindows 없음')));
+  });
+
+  it('shows failure with bucket and message', () => {
+    const lines = formatClaudeNetworkUsage({
+      status: { ok: false, httpStatus: 403, bucket: 'auth_scope', message: 'missing scope' },
+      usageWindows: [],
+    });
+    assert.ok(lines.some((l) => l.includes('실패 (403, bucket=auth_scope)')));
+    assert.ok(lines.some((l) => l.includes('메시지: missing scope')));
+  });
+});
+
+describe('formatClaudeLocalUsage', () => {
+  it('shows 데이터 없음 when usage is null or not-found', () => {
+    assert.ok(formatClaudeLocalUsage(null).some((l) => l.includes('데이터 없음')));
+    assert.ok(formatClaudeLocalUsage({ source: 'not-found' }).some((l) => l.includes('데이터 없음')));
+  });
+
+  it('renders totalSessions / totalMessages / model usage indicators', () => {
+    const lines = formatClaudeLocalUsage({
+      source: 'stats-cache-json',
+      totalSessions: 10,
+      totalMessages: 200,
+      hasModelUsage: true,
+      hasDailyModelTokens: false,
+    });
+    assert.ok(lines.some((l) => l.includes('총 세션 수: 10')));
+    assert.ok(lines.some((l) => l.includes('총 메시지 수: 200')));
+    assert.ok(lines.some((l) => l.includes('모델별 usage: 있음')));
+    assert.ok(lines.some((l) => l.includes('일별 token 통계: 없음')));
+  });
+});
+
+describe('formatStatusOutput', () => {
+  it('contains the command name and config summary lines', () => {
+    const lines = formatStatusOutput('status', {
+      configPath: '/x/config.json',
+      providers: { codex: { enabled: true }, claude: { enabled: false } },
+      sync: { enabled: false },
+      codex: { enabled: false },
+      claude: {
+        authSource: 'not-found',
+        detected: false,
+        selectedAccount: null,
+        networkUsage: null,
+        usage: { source: 'not-found' },
+      },
+    });
+    assert.ok(lines.includes('명령: status'));
+    assert.ok(lines.includes('설정 파일: /x/config.json'));
+    assert.ok(lines.includes('Codex 사용: enabled'));
+    assert.ok(lines.includes('Claude 사용: disabled'));
+  });
+});

--- a/packages/agent/test/integration/smoke.test.js
+++ b/packages/agent/test/integration/smoke.test.js
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const BIN = path.resolve(__dirname, '../../bin/ai-usage-agent.js');
+
+/**
+ * Run the CLI in a clean tmp HOME so it never touches the real auth.json /
+ * Claude credentials. We accept that some commands (status / doctor) may
+ * attempt network calls; those should fail or produce empty results without
+ * crashing the process.
+ */
+function runCli(args, { timeoutMs = 20_000 } = {}) {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-usage-smoke-'));
+  try {
+    const result = spawnSync('node', [BIN, ...args], {
+      env: { ...process.env, HOME: tmpHome, NO_COLOR: '1' },
+      encoding: 'utf8',
+      timeout: timeoutMs,
+    });
+    return result;
+  } finally {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+}
+
+describe('bin/ai-usage-agent — smoke', () => {
+  it('exits 0 with usage-like output when called without args', () => {
+    const result = runCli([]);
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    // stdout 또는 stderr 어디든 사용법 안내가 있어야 함
+    const all = result.stdout + result.stderr;
+    assert.match(all, /ai-usage-agent|usage|status|doctor/i);
+  });
+
+  it('config init creates default config in HOME', () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-usage-smoke-init-'));
+    try {
+      const result = spawnSync('node', [BIN, 'config', 'init'], {
+        env: { ...process.env, HOME: tmpHome },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+      const expected = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+      assert.ok(fs.existsSync(expected), 'config.json should be created');
+      const parsed = JSON.parse(fs.readFileSync(expected, 'utf8'));
+      assert.ok(parsed.providers);
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('auth logout without provider prints usage and exits non-zero', () => {
+    const result = runCli(['auth', 'logout'], { timeoutMs: 10_000 });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /사용법/);
+  });
+
+  it('auth login claude --port foo prints validation warning and exits cleanly', () => {
+    const result = runCli(['auth', 'login', 'claude', '--port', 'foo'], {
+      timeoutMs: 10_000,
+    });
+    // exit code is 0 (returns early after warning), warning goes to stderr
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.match(result.stderr, /--port 값 "foo"/);
+    assert.match(result.stderr, /login을 중단합니다/);
+  });
+});

--- a/packages/agent/test/services/claude-provider.test.js
+++ b/packages/agent/test/services/claude-provider.test.js
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildClaudeSnapshot,
+  resolveClaudeProfileFromSnapshot,
+  selectClaudeAuthSource,
+  getClaudeSnapshot,
+} from '../../src/services/claude-provider.js';
+
+const FAKE_PATH = '/tmp/fake-claude-credentials.json';
+
+describe('selectClaudeAuthSource (via claude-provider)', () => {
+  it('agent-store > claude-cli-import > not-found', () => {
+    assert.equal(selectClaudeAuthSource([{ id: 'a' }], { x: true }), 'agent-store');
+    assert.equal(selectClaudeAuthSource([], { x: true }), 'claude-cli-import');
+    assert.equal(selectClaudeAuthSource([], null), 'not-found');
+  });
+});
+
+describe('buildClaudeSnapshot (via claude-provider)', () => {
+  it('returns detected=false when no credentials and no agent accounts', () => {
+    const snap = buildClaudeSnapshot(FAKE_PATH, () => null, [], '/tmp/no-stats.json', () => null);
+    assert.equal(snap.detected, false);
+    assert.equal(snap.authSource, 'not-found');
+    assert.equal(snap.usage.source, 'not-found');
+  });
+
+  it('detects credentials from injected readFn', () => {
+    const fakeCreds = {
+      accessToken: 't',
+      refreshToken: 'r',
+      expiresAt: null,
+      scopes: [],
+      subscriptionType: null,
+      rateLimitTier: null,
+    };
+    const snap = buildClaudeSnapshot(
+      FAKE_PATH,
+      () => fakeCreds,
+      [],
+      '/tmp/no-stats.json',
+      () => null,
+    );
+    assert.equal(snap.detected, true);
+    assert.equal(snap.authSource, 'claude-cli-import');
+    assert.equal(snap.selectedAccount?.accountKey, 'claude-cli-import');
+  });
+
+  it('includes stats-cache usage when readStatsCacheFn returns data', () => {
+    const snap = buildClaudeSnapshot(
+      FAKE_PATH,
+      () => null,
+      [],
+      '/tmp/stats.json',
+      () => ({
+        version: 3,
+        totalSessions: 10,
+        totalMessages: 42,
+        hasModelUsage: true,
+        hasDailyModelTokens: false,
+        raw: {},
+      }),
+    );
+    assert.equal(snap.usage.source, 'stats-cache-json');
+    assert.equal(snap.usage.totalSessions, 10);
+    assert.equal(snap.usage.hasModelUsage, true);
+  });
+
+  it('prefers agent-store account over claude-cli-import credentials', () => {
+    const fakeCreds = {
+      accessToken: 'cli',
+      refreshToken: null,
+      expiresAt: null,
+      scopes: [],
+      subscriptionType: null,
+      rateLimitTier: null,
+    };
+    const agentAccount = {
+      accountKey: 'claude:alice',
+      provider: 'claude',
+      source: 'agent-store',
+      status: 'active',
+      tokens: { accessToken: 'agent-store-tok' },
+    };
+    const snap = buildClaudeSnapshot(
+      FAKE_PATH,
+      () => fakeCreds,
+      [agentAccount],
+      '/tmp/stats.json',
+      () => null,
+    );
+    assert.equal(snap.authSource, 'agent-store');
+    assert.equal(snap.selectedAccount.accountKey, 'claude:alice');
+  });
+});
+
+describe('resolveClaudeProfileFromSnapshot (via claude-provider)', () => {
+  it('returns null when selectedAccount is missing', () => {
+    assert.equal(resolveClaudeProfileFromSnapshot({ selectedAccount: null }), null);
+  });
+
+  it('extracts accessToken from claude-cli-import (top-level)', () => {
+    const profile = resolveClaudeProfileFromSnapshot({
+      selectedAccount: {
+        accountKey: 'claude-cli-import',
+        accessToken: 'sk-ant-cli',
+        email: 'x@example.com',
+      },
+    });
+    assert.equal(profile.id, 'claude-cli-import');
+    assert.equal(profile.accessToken, 'sk-ant-cli');
+    assert.equal(profile.email, 'x@example.com');
+  });
+
+  it('extracts accessToken from tokens.accessToken (agent-store)', () => {
+    const profile = resolveClaudeProfileFromSnapshot({
+      selectedAccount: {
+        accountKey: 'claude:alice',
+        tokens: { accessToken: 'sk-ant-store' },
+      },
+    });
+    assert.equal(profile.accessToken, 'sk-ant-store');
+  });
+
+  it('returns null when no accessToken anywhere', () => {
+    assert.equal(
+      resolveClaudeProfileFromSnapshot({ selectedAccount: { accountKey: 'x' } }),
+      null,
+    );
+  });
+});
+
+describe('getClaudeSnapshot — disabled config contract', () => {
+  it('returns networkUsage=null when claude provider is disabled', async () => {
+    const snap = await getClaudeSnapshot({ providers: { claude: { enabled: false } } });
+    assert.equal(snap.networkUsage, null);
+    // base snapshot도 포함
+    assert.ok(typeof snap.authSource === 'string');
+  });
+});

--- a/packages/agent/test/services/codex-provider.test.js
+++ b/packages/agent/test/services/codex-provider.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getCodexSnapshot,
+  selectCodexAuthSource,
+  filterRealCodexAccounts,
+} from '../../src/services/codex-provider.js';
+
+// ── pure helpers ─────────────────────────────────────────────────────────────
+// selectCodexAuthSource / filterRealCodexAccounts는 순수 함수로 이미 일부
+// 커버되어 있지만(status-service.test.js에서 re-export 테스트 중), 여기서는
+// provider 모듈 자체 경로(../services/codex-provider.js)로도 import 동작을 검증.
+
+describe('selectCodexAuthSource (via codex-provider)', () => {
+  it('agent-store preferred when non-empty', () => {
+    const result = selectCodexAuthSource([{ id: 'a' }], [{ id: 'oc' }]);
+    assert.equal(result.authSource, 'agent-store');
+    assert.deepEqual(result.profiles, [{ id: 'a' }]);
+  });
+
+  it('falls back to openclaw-import when agent list is empty', () => {
+    const result = selectCodexAuthSource([], [{ id: 'oc' }]);
+    assert.equal(result.authSource, 'openclaw-import');
+  });
+});
+
+describe('filterRealCodexAccounts (via codex-provider)', () => {
+  it('keeps active accounts with real (non-mock) tokens', () => {
+    const accounts = [
+      { accountKey: 'real', status: 'active', tokens: { accessToken: 'real-x' } },
+      { accountKey: 'mock', status: 'active', tokens: { accessToken: 'mock-y' } },
+      {
+        accountKey: 'flagged',
+        status: 'active',
+        tokens: { accessToken: 'z' },
+        raw: { mock: true },
+      },
+      { accountKey: 'disabled', status: 'disabled', tokens: { accessToken: 'real-d' } },
+    ];
+    const result = filterRealCodexAccounts(accounts);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].accountKey, 'real');
+  });
+});
+
+// ── integration contract ────────────────────────────────────────────────────
+// getCodexSnapshot은 auth-store I/O에 의존하므로 여기서는 구조 계약만 검증.
+// disabled config → 항상 고정된 shape. live 케이스는 수동 smoke로 확인.
+
+describe('getCodexSnapshot — disabled config contract', () => {
+  it('returns enabled=false with empty snapshots when codex disabled', async () => {
+    const snap = await getCodexSnapshot({ providers: { codex: { enabled: false } } });
+    assert.equal(snap.enabled, false);
+    assert.deepEqual(snap.snapshots, []);
+    assert.equal(typeof snap.authProfilesPath, 'string');
+  });
+});

--- a/packages/agent/test/services/provider-registry.test.js
+++ b/packages/agent/test/services/provider-registry.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PROVIDER_REGISTRY, runProviderSnapshots } from '../../src/services/provider-registry.js';
+
+describe('PROVIDER_REGISTRY', () => {
+  it('is frozen (cannot be mutated)', () => {
+    assert.throws(() => PROVIDER_REGISTRY.push({ id: 'x', getSnapshot: async () => ({}) }));
+  });
+
+  it('contains codex and claude entries with id+getSnapshot', () => {
+    const ids = PROVIDER_REGISTRY.map((p) => p.id).sort();
+    assert.deepEqual(ids, ['claude', 'codex']);
+    for (const spec of PROVIDER_REGISTRY) {
+      assert.equal(typeof spec.id, 'string');
+      assert.equal(typeof spec.getSnapshot, 'function');
+    }
+  });
+});
+
+describe('runProviderSnapshots', () => {
+  // shape behaviour we can assert cheaply without hitting real network:
+  // runProviderSnapshots just maps spec.id → await spec.getSnapshot(config).
+  // We validate by providing a fake registry (indirectly via dependency injection
+  // would be cleaner, but here we exercise the real one with a disabled config —
+  // Codex/Claude providers both return cheap, deterministic snapshots when the
+  // provider is disabled).
+
+  it('returns an object keyed by provider id with both codex and claude present', async () => {
+    const out = await runProviderSnapshots({ providers: {} });
+    assert.ok('codex' in out);
+    assert.ok('claude' in out);
+  });
+
+  it('honors disabled provider config (codex returns enabled=false)', async () => {
+    const out = await runProviderSnapshots({
+      providers: { codex: { enabled: false }, claude: { enabled: false } },
+    });
+    assert.equal(out.codex.enabled, false);
+    // Claude snapshot always returns a base+networkUsage(null when disabled/no profile) — just assert shape
+    assert.equal(out.claude.networkUsage, null);
+  });
+});

--- a/packages/provider-adapters/test/codex/exchange-codex-authorization-code.test.js
+++ b/packages/provider-adapters/test/codex/exchange-codex-authorization-code.test.js
@@ -1,0 +1,210 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  exchangeCodexAuthorizationCode,
+  refreshCodexToken,
+} from '../../src/codex/exchange-codex-authorization-code.js';
+import { CODEX_AUTH } from '../../src/codex/codex-auth-constants.js';
+
+function jsonResponse({ status = 200, body = {} } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
+function baseExchangeParams(overrides = {}) {
+  return {
+    code: 'ac_code_abc',
+    callbackUrl: 'http://localhost:1455/auth/callback',
+    codeVerifier: 'verifier-xyz',
+    ...overrides,
+  };
+}
+
+describe('exchangeCodexAuthorizationCode — guard', () => {
+  it('throws when allowLiveExchange is not true', async () => {
+    await assert.rejects(
+      () => exchangeCodexAuthorizationCode(baseExchangeParams()),
+      /Live exchange is disabled/,
+    );
+  });
+});
+
+describe('exchangeCodexAuthorizationCode — live exchange', () => {
+  it('POSTs form-urlencoded body to CODEX_AUTH.tokenEndpoint', async () => {
+    let capturedUrl, capturedInit;
+    const fetchImpl = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return jsonResponse({
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      });
+    };
+
+    await exchangeCodexAuthorizationCode({
+      ...baseExchangeParams(),
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+
+    assert.equal(capturedUrl, CODEX_AUTH.tokenEndpoint);
+    assert.equal(capturedInit.method, 'POST');
+    assert.equal(capturedInit.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    const params = new URLSearchParams(capturedInit.body);
+    assert.equal(params.get('grant_type'), 'authorization_code');
+    assert.equal(params.get('code'), 'ac_code_abc');
+    assert.equal(params.get('redirect_uri'), 'http://localhost:1455/auth/callback');
+    assert.equal(params.get('code_verifier'), 'verifier-xyz');
+    assert.equal(params.get('client_id'), CODEX_AUTH.observedClientId);
+    assert.equal(params.has('client_secret'), false);
+  });
+
+  it('includes client_secret when provided', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return jsonResponse({ body: { access_token: 'a', expires_in: 1, token_type: 'Bearer' } });
+    };
+    await exchangeCodexAuthorizationCode({
+      ...baseExchangeParams(),
+      allowLiveExchange: true,
+      clientSecret: 's3cret',
+      fetchImpl,
+    });
+    assert.equal(new URLSearchParams(captured.body).get('client_secret'), 's3cret');
+  });
+
+  it('returns normalized token fields', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          id_token: 'id',
+          expires_in: 7200,
+          token_type: 'Bearer',
+          scope: 'openid email',
+        },
+      });
+    const result = await exchangeCodexAuthorizationCode({
+      ...baseExchangeParams(),
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+    assert.equal(result.accessToken, 'at');
+    assert.equal(result.refreshToken, 'rt');
+    assert.equal(result.idToken, 'id');
+    assert.equal(result.expiresIn, 7200);
+    assert.equal(result.tokenType, 'Bearer');
+    assert.equal(result.scope, 'openid email');
+  });
+
+  it('throws descriptive error on non-2xx', async () => {
+    const fetchImpl = async () => ({
+      status: 400,
+      statusText: 'Bad Request',
+      ok: false,
+      async text() {
+        return '{"error":"invalid_grant"}';
+      },
+    });
+    await assert.rejects(
+      () =>
+        exchangeCodexAuthorizationCode({
+          ...baseExchangeParams(),
+          allowLiveExchange: true,
+          fetchImpl,
+        }),
+      /Token exchange failed: 400/,
+    );
+  });
+});
+
+describe('refreshCodexToken — guard', () => {
+  it('throws when allowLiveExchange is not true', async () => {
+    await assert.rejects(
+      () => refreshCodexToken({ refreshToken: 'rt' }),
+      /Live exchange is disabled/,
+    );
+  });
+});
+
+describe('refreshCodexToken — live refresh', () => {
+  it('POSTs refresh_token grant with client_id', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return jsonResponse({
+        body: { access_token: 'at', refresh_token: 'rt-new', expires_in: 3600, token_type: 'Bearer' },
+      });
+    };
+    await refreshCodexToken({
+      refreshToken: 'rt-old',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+    const params = new URLSearchParams(captured.body);
+    assert.equal(params.get('grant_type'), 'refresh_token');
+    assert.equal(params.get('refresh_token'), 'rt-old');
+    assert.equal(params.get('client_id'), CODEX_AUTH.observedClientId);
+  });
+
+  it('keeps existing refreshToken when response omits one (no rotation)', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({ body: { access_token: 'a', expires_in: 1, token_type: 'Bearer' } });
+    const result = await refreshCodexToken({
+      refreshToken: 'rt-kept',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+    assert.equal(result.refreshToken, 'rt-kept');
+  });
+
+  it('uses rotated refreshToken when server returns one', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: { access_token: 'a', refresh_token: 'rt-rotated', expires_in: 1, token_type: 'Bearer' },
+      });
+    const result = await refreshCodexToken({
+      refreshToken: 'rt-old',
+      allowLiveExchange: true,
+      fetchImpl,
+    });
+    assert.equal(result.refreshToken, 'rt-rotated');
+  });
+
+  it('throws descriptive error on non-2xx', async () => {
+    const fetchImpl = async () => ({
+      status: 401,
+      statusText: 'Unauthorized',
+      ok: false,
+      async text() {
+        return 'expired';
+      },
+    });
+    await assert.rejects(
+      () =>
+        refreshCodexToken({
+          refreshToken: 'rt',
+          allowLiveExchange: true,
+          fetchImpl,
+        }),
+      /Token refresh failed: 401/,
+    );
+  });
+});

--- a/packages/provider-adapters/test/codex/fetch-codex-usage.test.js
+++ b/packages/provider-adapters/test/codex/fetch-codex-usage.test.js
@@ -1,0 +1,163 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchCodexUsage } from '../../src/codex/fetch-codex-usage.js';
+
+function mockResponse({ status = 200, body = {}, asText = null } = {}) {
+  const text = asText !== null ? asText : JSON.stringify(body);
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+  };
+}
+
+const BASE_PROFILE = {
+  id: 'live-ac_xyz',
+  accessToken: 'codex-access-token',
+  accountId: null,
+  email: null,
+};
+
+describe('fetchCodexUsage — request shape', () => {
+  it('sends GET to wham/usage with Bearer header and User-Agent', async () => {
+    let capturedUrl, capturedInit;
+    const fetchImpl = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return mockResponse({ status: 200, body: {} });
+    };
+
+    await fetchCodexUsage(BASE_PROFILE, { fetchImpl });
+
+    assert.equal(capturedUrl, 'https://chatgpt.com/backend-api/wham/usage');
+    assert.equal(capturedInit.method, 'GET');
+    assert.equal(capturedInit.headers.Authorization, 'Bearer codex-access-token');
+    assert.equal(capturedInit.headers['User-Agent'], 'CodexBar');
+    assert.equal(capturedInit.headers.Accept, 'application/json');
+  });
+
+  it('adds ChatGPT-Account-Id header when profile.accountId is set', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return mockResponse({ status: 200, body: {} });
+    };
+    await fetchCodexUsage({ ...BASE_PROFILE, accountId: 'acc-42' }, { fetchImpl });
+    assert.equal(captured.headers['ChatGPT-Account-Id'], 'acc-42');
+  });
+
+  it('omits ChatGPT-Account-Id header when profile.accountId is null', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return mockResponse({ status: 200, body: {} });
+    };
+    await fetchCodexUsage(BASE_PROFILE, { fetchImpl });
+    assert.equal('ChatGPT-Account-Id' in captured.headers, false);
+  });
+
+  it('propagates timeoutMs option to fetchWithTimeout (non-null AbortSignal)', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return mockResponse({ status: 200, body: {} });
+    };
+    await fetchCodexUsage(BASE_PROFILE, { fetchImpl, timeoutMs: 1000 });
+    assert.ok(captured.signal);
+  });
+});
+
+describe('fetchCodexUsage — snapshot on 200', () => {
+  const RESPONSE_BODY = {
+    plan_type: 'plus',
+    rate_limit: {
+      primary_window: { used_percent: 25, limit_window_seconds: 18000, reset_at: 1700000000 },
+      secondary_window: { used_percent: 80, limit_window_seconds: 604800, reset_at: 1700604800 },
+    },
+    credits: { balance: 100 },
+  };
+
+  async function run() {
+    const fetchImpl = async () => mockResponse({ status: 200, body: RESPONSE_BODY });
+    return fetchCodexUsage(BASE_PROFILE, { fetchImpl });
+  }
+
+  it('has provider.id openai-codex, confidence=high, bucket=ok', async () => {
+    const snap = await run();
+    assert.equal(snap.provider.id, 'openai-codex');
+    assert.equal(snap.status.ok, true);
+    assert.equal(snap.status.bucket, 'ok');
+    assert.equal(snap.confidence, 'high');
+  });
+
+  it('normalizes primary and secondary windows', async () => {
+    const snap = await run();
+    const primary = snap.usageWindows.find((w) => w.kind === 'primary');
+    const secondary = snap.usageWindows.find((w) => w.kind === 'secondary');
+    assert.ok(primary);
+    assert.equal(primary.usedPercent, 25);
+    assert.equal(primary.windowSeconds, 18000);
+    assert.match(primary.resetAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.ok(secondary);
+    assert.equal(secondary.usedPercent, 80);
+  });
+
+  it('includes account.plan from plan_type and credits.balance', async () => {
+    const snap = await run();
+    assert.equal(snap.account.plan, 'plus');
+    assert.equal(snap.credits.balance, 100);
+  });
+
+  it('skips windows when absent', async () => {
+    const fetchImpl = async () => mockResponse({ status: 200, body: {} });
+    const snap = await fetchCodexUsage(BASE_PROFILE, { fetchImpl });
+    assert.deepEqual(snap.usageWindows, []);
+  });
+});
+
+describe('fetchCodexUsage — error status buckets', () => {
+  async function runStatus(status, bodyOrText = {}) {
+    const fetchImpl = async () =>
+      typeof bodyOrText === 'string'
+        ? mockResponse({ status, asText: bodyOrText })
+        : mockResponse({ status, body: bodyOrText });
+    return fetchCodexUsage(BASE_PROFILE, { fetchImpl });
+  }
+
+  it('maps 401 → auth', async () => {
+    assert.equal((await runStatus(401)).status.bucket, 'auth');
+  });
+
+  it('maps 402 → billing', async () => {
+    assert.equal((await runStatus(402)).status.bucket, 'billing');
+  });
+
+  it('maps 429 → rate_limit', async () => {
+    assert.equal((await runStatus(429)).status.bucket, 'rate_limit');
+  });
+
+  it('maps 5xx → overloaded', async () => {
+    assert.equal((await runStatus(502)).status.bucket, 'overloaded');
+    assert.equal((await runStatus(500)).status.bucket, 'overloaded');
+  });
+
+  it('defaults to unknown for other statuses', async () => {
+    assert.equal((await runStatus(418)).status.bucket, 'unknown');
+  });
+
+  it('returns empty usageWindows and includes message on error', async () => {
+    const snap = await runStatus(500, 'boom');
+    assert.deepEqual(snap.usageWindows, []);
+    assert.equal(snap.status.message, 'boom');
+    assert.equal(snap.confidence, 'medium');
+  });
+
+  it('handles non-JSON body gracefully', async () => {
+    const snap = await runStatus(500, 'upstream plain text');
+    assert.equal(snap.status.ok, false);
+    assert.equal(snap.status.message, 'upstream plain text');
+  });
+});


### PR DESCRIPTION
## 요약

PR #29 머지 후 남아 있던 테스트 커버리지 비대칭과 누락을 두 단계(1차 #30, 2차 #31)로 보강한다. 동작 변화 없음. 신규 86 테스트(298 → 384).

## 변경 내용

### 1차 — provider/services 커버리지 (#30)

- `test/codex/fetch-codex-usage.test.js` (16) — Claude 쪽과 대칭. 요청 헤더, primary/secondary window, 401/402/429/5xx bucket, timeout signal, non-JSON 본문.
- `test/codex/exchange-codex-authorization-code.test.js` (14) — guard, form body, client_secret, 응답 정규화, refresh rotation 있음/없음/실패.
- `test/auth/manual-paste.test.js` (9) — extractCodeFromPaste error envelope, raw code, 유효 URL, no-code-in-url / invalid-url, https.
- `test/auth/mock-auth-exchange.test.js` (6) — accountKey 생성 규칙, 빈 입력 fallback, raw.mock 표시, mock token 컨벤션, manualInputPreview 120자.
- `test/services/provider-registry.test.js` (4) — frozen 검증, runProviderSnapshots 키/disabled config 존중.
- `test/services/codex-provider.test.js` (4) — pure helpers + disabled contract.
- `test/services/claude-provider.test.js` (10) — selectClaudeAuthSource 우선순위, buildClaudeSnapshot 주입 시나리오, resolveClaudeProfileFromSnapshot 두 shape, getClaudeSnapshot disabled contract.

### 2차 — CLI safety + smoke (#31)

- `cli/status-command.js` 리팩터: print* → format* (string[]). doctor-command와 동일한 패턴, runStatusCommand는 출력만 담당.
- `test/cli/status-command.test.js` (16) — 모든 formatter 분기.
- `test/cli/config-init-command.test.js` (3) — HOME=tmpdir 격리, 신규 / overwrite.
- `test/cli/auth-logout-command.test.js` (5) — provider 누락 → stderr+exitCode=1, 단일 계정 / 다중 계정 + --account / --account 미일치.
- `test/integration/smoke.test.js` (4) — bin/ai-usage-agent.js 실 spawn(인자 없음 / config init / auth logout / --port foo). 모두 HOME=tmpdir로 실환경 비파괴.

## 변경 이유

- Codex provider 쪽 커버리지가 Claude 대비 심하게 비대칭이라 fetch / exchange / refresh 회귀 위험이 컸음.
- services / cli / auth 헬퍼 일부에 단위 테스트 누락. 1·2차로 안정성 확보.
- spawn 기반 smoke로 진입점 회귀(예: 잘못된 옵션 메시지 변경)도 잡힘.

## 영향 범위

- [x] `packages/agent`
- [x] `packages/provider-adapters`

## 테스트 / 확인

- `npm test` 384 pass, 0 fail (1.6s)
- 모든 신규 smoke가 HOME 격리로 실 환경 무영향

## 리뷰 포인트

- format helper 분리가 status-command를 충분히 testable하게 만들었는지
- HOME=tmpdir 패턴이 다른 곳(예: claude-imported-account 관련 테스트)에도 일관 적용 가능한지 — 후속에서 검토
- smoke 테스트가 의도대로 spawn 기반 회귀를 잡는지 (네트워크 호출은 status에서 발생할 수 있는데, 본 PR에선 status smoke는 제외하고 인자 없음/init/logout/--port 검증 케이스만 cover)

## 참고

- 머지 시 close: #30, #31 (커밋 메시지 태그 포함)
- 다음 후보(별도 이슈 미등록): schemas 런타임 validator, run-cli dispatcher 단위 테스트, status spawn smoke (timeout 짧게 / mock 주입 옵션)