### PR TITLE
[refactor] account 선택 + auth source 선택 로직 공통화

### DIFF
--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -176,11 +176,40 @@ export async function fetchFooUsage(profile, options = {}) {
 
 ```
 packages/agent/src/services/
-├── status-service.js         얇은 진입점: loadConfig + registry 순회
-├── provider-registry.js      PROVIDER_REGISTRY 배열 + runProviderSnapshots
-├── codex-provider.js         Codex snapshot + auth resolver
-└── claude-provider.js        Claude snapshot + auth resolver
+├── status-service.js              얇은 진입점: loadConfig + registry 순회
+├── provider-registry.js           PROVIDER_REGISTRY + runProviderSnapshots
+├── auth-source-resolver.js        공통 auth source 우선순위 결정
+├── provider-profile-resolver.js   공통 "store → filter → map → accountFilter" runner
+├── account-filter.js              filterProfilesByAccount (id/email/label 매치)
+├── codex-provider.js              Codex snapshot + provider spec
+└── claude-provider.js             Claude snapshot + provider spec
 ```
+
+### 4.1.1 Account 선택 vs Auth source 선택 흐름
+
+두 가지 "선택"이 존재한다. 혼동하지 말 것.
+
+**Account 선택** — "여러 계정 중 누구를 쓸까?"
+```
+store.providers[id].accounts
+  → filterFn (real 계정만: mock/disabled/토큰 없음 제거)
+  → mapFn (account → profile shape)
+  → filterProfilesByAccount (--account / config default 매치)
+  → resolveDefaultAccount (multi-account 중 기본 계정 결정)
+```
+공통 runner: `provider-profile-resolver.js::resolveProviderProfiles`
+provider는 `filterFn` + `mapFn`만 선언적으로 제공한다.
+
+**Auth source 선택** — "그 토큰을 어디서 읽을까?"
+```
+resolveAuthSource(agentAccounts, [
+  { id: 'openclaw-import', accounts: [...] },
+  { id: 'claude-cli-import', accounts: [...] },
+])
+→ { accounts, authSource: 'agent-store' | '{import-id}' | 'not-found' }
+```
+공통 함수: `auth-source-resolver.js::resolveAuthSource`
+우선순위: agent-store > 첫 번째 비어있지 않은 import source > not-found
 
 ### 4.2 Provider spec (registry용)
 

--- a/packages/agent/src/auth/resolve-claude-account.js
+++ b/packages/agent/src/auth/resolve-claude-account.js
@@ -1,5 +1,5 @@
-import { selectClaudeAccountsSource } from '../../../provider-adapters/src/claude/claude-imported-account.js';
 import { resolveAccount } from './account-resolver.js';
+import { resolveAuthSource } from '../services/auth-source-resolver.js';
 
 /**
  * Picks the active Claude account from agent-store accounts (priority) or
@@ -15,10 +15,9 @@ export function resolveClaudeAccount(
   importedClaudeAccounts,
   options = {},
 ) {
-  const { accounts, authSource } = selectClaudeAccountsSource(
-    agentClaudeAccounts,
-    importedClaudeAccounts,
-  );
+  const { accounts, authSource } = resolveAuthSource(agentClaudeAccounts, [
+    { id: 'claude-cli-import', accounts: importedClaudeAccounts },
+  ]);
 
   const { account, reason } = resolveAccount(accounts, options);
   return { account, authSource, reason };

--- a/packages/agent/src/services/auth-source-resolver.js
+++ b/packages/agent/src/services/auth-source-resolver.js
@@ -1,0 +1,31 @@
+/**
+ * 공통 auth source 우선순위 결정.
+ *
+ * 모든 provider가 동일한 패턴을 따른다:
+ *   1. agent-store에 real 계정이 있으면 그것을 사용
+ *   2. 없으면 import source들을 순서대로 시도 (첫 번째 비어있지 않은 것)
+ *   3. 모두 비어있으면 'not-found'
+ *
+ * provider별 차이(Codex의 openclaw-import, Claude의 claude-cli-import 등)는
+ * importSources 배열의 id 값으로만 구분된다.
+ *
+ * @param {Array<object>} agentAccounts - agent-store에서 읽은 real 계정 목록
+ * @param {Array<{ id: string, accounts: Array<object> }>} [importSources=[]]
+ *   fallback import source 후보들. 순서대로 시도.
+ *   예: [{ id: 'openclaw-import', accounts: [...] }]
+ *       [{ id: 'claude-cli-import', accounts: [...] }]
+ * @returns {{ accounts: Array<object>, authSource: string }}
+ */
+export function resolveAuthSource(agentAccounts, importSources = []) {
+  if (Array.isArray(agentAccounts) && agentAccounts.length > 0) {
+    return { accounts: agentAccounts, authSource: 'agent-store' };
+  }
+
+  for (const source of importSources) {
+    if (Array.isArray(source.accounts) && source.accounts.length > 0) {
+      return { accounts: source.accounts, authSource: source.id };
+    }
+  }
+
+  return { accounts: [], authSource: 'not-found' };
+}

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -11,6 +11,7 @@ import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-c
 import { loadAuthStore } from '../auth/auth-store.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveProviderProfiles } from './provider-profile-resolver.js';
+import { filterProfilesByAccount } from './account-filter.js';
 
 /**
  * Build the Claude section of the top-level status snapshot.
@@ -39,23 +40,30 @@ export async function getClaudeSnapshot(
     return { ...base, networkUsages: [], networkUsage: null };
   }
 
-  // agent-store의 real 계정을 runner로 일괄 해결.
-  // runner가 0개 반환 시 selectedAccount(= cli-import)를 single profile로 fallback.
-  let profiles = await resolveProviderProfiles({
+  // Source 선택은 unfiltered 기준으로 먼저 결정.
+  // accountFilter가 source precedence를 바꿔서는 안 된다.
+  const allAgentProfiles = await resolveProviderProfiles({
     providerId: CLAUDE_AUTH.storeProvider,
     filterFn: filterClaudeRealAccounts,
     mapFn: claudeMapAccountToProfile,
-    accountFilter: options.accountFilter,
+    accountFilter: null, // source 선택은 필터 없이
     updateLastUsed: false,
   });
-  if (profiles.length === 0) {
+
+  let profiles;
+  if (allAgentProfiles.length > 0) {
+    // agent-store 확정. 그 위에서 accountFilter 적용.
+    profiles = filterProfilesByAccount(allAgentProfiles, options.accountFilter);
+  } else {
+    // cli-import fallback
     const single = resolveClaudeProfileFromSnapshot(base);
-    if (single && !options.accountFilter) {
+    if (single && (!options.accountFilter || matchesFilter(single, options.accountFilter))) {
       profiles = [single];
-    } else if (single && matchesFilter(single, options.accountFilter)) {
-      profiles = [single];
+    } else {
+      profiles = [];
     }
   }
+
   if (profiles.length === 0) {
     return {
       ...base,

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -9,8 +9,8 @@ import { readClaudeStatsCache } from '../../../provider-adapters/src/claude/read
 import { fetchClaudeUsage } from '../../../provider-adapters/src/claude/fetch-claude-usage.js';
 import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-constants.js';
 import { loadAuthStore } from '../auth/auth-store.js';
-import { filterProfilesByAccount as filterProfilesByAccountImpl } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
+import { resolveProviderProfiles } from './provider-profile-resolver.js';
 
 /**
  * Build the Claude section of the top-level status snapshot.
@@ -39,15 +39,30 @@ export async function getClaudeSnapshot(
     return { ...base, networkUsages: [], networkUsage: null };
   }
 
-  const allProfiles = resolveClaudeProfilesForFetch(base, agentClaudeAccounts);
-  const profiles = filterProfilesByAccountImpl(allProfiles, options.accountFilter);
+  // agent-store의 real 계정을 runner로 일괄 해결.
+  // runner가 0개 반환 시 selectedAccount(= cli-import)를 single profile로 fallback.
+  let profiles = await resolveProviderProfiles({
+    providerId: CLAUDE_AUTH.storeProvider,
+    filterFn: filterClaudeRealAccounts,
+    mapFn: claudeMapAccountToProfile,
+    accountFilter: options.accountFilter,
+    updateLastUsed: false,
+  });
+  if (profiles.length === 0) {
+    const single = resolveClaudeProfileFromSnapshot(base);
+    if (single && !options.accountFilter) {
+      profiles = [single];
+    } else if (single && matchesFilter(single, options.accountFilter)) {
+      profiles = [single];
+    }
+  }
   if (profiles.length === 0) {
     return {
       ...base,
       networkUsages: [],
       networkUsage: null,
       accountFilter: options.accountFilter ?? null,
-      filteredOut: options.accountFilter && allProfiles.length > 0,
+      filteredOut: Boolean(options.accountFilter),
     };
   }
 
@@ -83,23 +98,35 @@ export async function getClaudeSnapshot(
 // Re-export from shared for backward-compat (tests import from this module).
 export { filterProfilesByAccount } from './account-filter.js';
 
-/**
- * 조회 대상 계정 목록 결정.
- *   - agent-store에 real 계정이 1개 이상 있으면 그 전부 (multi-account A).
- *   - 없으면 selectedAccount(= claude-cli-import)를 단일 profile로 변환.
- */
-function resolveClaudeProfilesForFetch(base, agentClaudeAccounts) {
-  if (agentClaudeAccounts.length > 0) {
-    return agentClaudeAccounts.map((a) => ({
-      id: a.accountKey,
-      accessToken: a.tokens?.accessToken ?? a.accessToken ?? null,
-      accountId: a.accountId ?? null,
-      email: a.email ?? null,
-      label: a.label ?? null,
-    })).filter((p) => p.accessToken);
-  }
-  const single = resolveClaudeProfileFromSnapshot(base);
-  return single ? [single] : [];
+function filterClaudeRealAccounts(accounts) {
+  return (accounts ?? []).filter((a) => {
+    if (a.status === 'disabled') return false;
+    if (a.raw?.mock === true) return false;
+    const accessToken = a.tokens?.accessToken ?? a.accessToken ?? null;
+    if (!accessToken) return false;
+    if (a.source === 'claude-cli-import') return false;
+    return true;
+  });
+}
+
+function claudeMapAccountToProfile(account) {
+  return {
+    id: account.accountKey,
+    accessToken: account.tokens?.accessToken ?? account.accessToken ?? null,
+    accountId: account.accountId ?? null,
+    email: account.email ?? null,
+    label: account.label ?? null,
+  };
+}
+
+function matchesFilter(profile, accountFilter) {
+  if (!accountFilter) return true;
+  const needle = String(accountFilter).toLowerCase();
+  return (
+    (profile.id ?? '').toLowerCase() === needle
+    || (profile.email ?? '').toLowerCase() === needle
+    || (profile.label ?? '').toLowerCase() === needle
+  );
 }
 
 /**
@@ -175,7 +202,9 @@ export function selectClaudeAuthSource(agentAccounts, importedCredential) {
 
 /**
  * agent-store에 저장된 Claude 계정 중 live token이 있는 항목만 반환.
- * claude-cli-import source는 buildClaudeSnapshot 기반 경로가 별도로 처리한다.
+ * resolveProviderProfiles의 filterFn과 동일한 기준이지만, 여기서는
+ * buildClaudeSnapshot에 agentClaudeAccounts를 넘기기 위해 별도로 로드.
+ * (runner와는 달리 profile shape가 아닌 account shape 그대로 반환.)
  */
 async function loadAgentStoreClaudeAccounts() {
   let store;
@@ -188,20 +217,11 @@ async function loadAgentStoreClaudeAccounts() {
   const provider = store.providers?.[CLAUDE_AUTH.storeProvider];
   if (!provider?.accounts?.length) return [];
 
-  return provider.accounts
-    .filter((a) => {
-      if (a.status === 'disabled') return false;
-      if (a.raw?.mock === true) return false;
-      const accessToken = a.tokens?.accessToken ?? a.accessToken ?? null;
-      if (!accessToken) return false;
-      if (a.source === 'claude-cli-import') return false;
-      return true;
-    })
-    .map((a) => ({
-      ...a,
-      provider: a.provider ?? 'claude',
-      source: a.source ?? 'agent-store',
-    }));
+  return filterClaudeRealAccounts(provider.accounts).map((a) => ({
+    ...a,
+    provider: a.provider ?? 'claude',
+    source: a.source ?? 'agent-store',
+  }));
 }
 
 function createClaudeNetworkFailureSnapshot(profile, error) {

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -165,10 +165,7 @@ export function resolveClaudeProfileFromSnapshot(snapshot) {
 }
 
 /**
- * Pure: select effective Claude auth source (Codex 쪽 selectCodexAuthSource과 유사).
- * Priority: agent-store > claude-cli-import > not-found.
- *
- * Exported for testing.
+ * @deprecated 공통 resolveAuthSource로 대체됨. 기존 테스트 import 호환용.
  */
 export function selectClaudeAuthSource(agentAccounts, importedCredential) {
   if (agentAccounts && agentAccounts.length > 0) return 'agent-store';

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -74,15 +74,19 @@ export function filterRealCodexAccounts(accounts) {
 }
 
 async function resolveCodexProfiles(accountFilter) {
-  const agentProfiles = await resolveProviderProfiles({
+  // Source 선택은 unfiltered 기준으로 먼저 결정한다.
+  // accountFilter가 source precedence를 바꿔서는 안 된다.
+  const allAgentProfiles = await resolveProviderProfiles({
     providerId: CODEX_PROVIDER_ID,
     filterFn: filterRealCodexAccounts,
     mapFn: codexMapAccountToProfile,
-    accountFilter,
+    accountFilter: null, // 필터 없이 전체 real 프로필 로드
   });
 
-  if (agentProfiles.length > 0) {
-    return { profiles: agentProfiles, authSource: 'agent-store' };
+  if (allAgentProfiles.length > 0) {
+    // agent-store 확정. 그 위에서 accountFilter 적용.
+    const filtered = filterProfilesByAccount(allAgentProfiles, accountFilter);
+    return { profiles: filtered, authSource: 'agent-store' };
   }
 
   // Fallback: OpenClaw import

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -3,11 +3,10 @@ import {
   getDefaultAuthProfilesPath,
   readCodexAuthProfiles,
 } from '../../../provider-adapters/src/codex/index.js';
-import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
-import { resolveDefaultAccount } from '../auth/account-resolver.js';
 import { filterProfilesByAccount } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveAuthSource } from './auth-source-resolver.js';
+import { resolveProviderProfiles } from './provider-profile-resolver.js';
 
 const CODEX_PROVIDER_ID = 'openai-codex';
 
@@ -27,8 +26,7 @@ export async function getCodexSnapshot(config, options = {}) {
     };
   }
 
-  const { profiles: allProfiles, authSource } = await resolveCodexProfiles();
-  const profiles = filterProfilesByAccount(allProfiles, options.accountFilter);
+  const { profiles, authSource } = await resolveCodexProfiles(options.accountFilter);
   const snapshots = [];
 
   for (const profile of profiles) {
@@ -45,7 +43,7 @@ export async function getCodexSnapshot(config, options = {}) {
     authProfilesPath: authSource === 'openclaw-import' ? getDefaultAuthProfilesPath() : null,
     snapshots,
     accountFilter: options.accountFilter ?? null,
-    filteredOut: options.accountFilter && allProfiles.length > 0 && profiles.length === 0,
+    filteredOut: Boolean(options.accountFilter) && profiles.length === 0,
   };
 }
 
@@ -75,47 +73,28 @@ export function filterRealCodexAccounts(accounts) {
   );
 }
 
-async function resolveCodexProfiles() {
-  const agentProfiles = await getAgentStoreProfiles();
-  const openclawProfiles = agentProfiles.length === 0 ? readCodexAuthProfiles() : [];
-  const { accounts, authSource } = resolveAuthSource(agentProfiles, [
-    { id: 'openclaw-import', accounts: openclawProfiles },
+async function resolveCodexProfiles(accountFilter) {
+  const agentProfiles = await resolveProviderProfiles({
+    providerId: CODEX_PROVIDER_ID,
+    filterFn: filterRealCodexAccounts,
+    mapFn: codexMapAccountToProfile,
+    accountFilter,
+  });
+
+  if (agentProfiles.length > 0) {
+    return { profiles: agentProfiles, authSource: 'agent-store' };
+  }
+
+  // Fallback: OpenClaw import
+  const openclawProfiles = readCodexAuthProfiles();
+  const filtered = filterProfilesByAccount(openclawProfiles, accountFilter);
+  const { accounts, authSource } = resolveAuthSource([], [
+    { id: 'openclaw-import', accounts: filtered },
   ]);
   return { profiles: accounts, authSource };
 }
 
-async function getAgentStoreProfiles() {
-  let store;
-  try {
-    store = await loadAuthStore();
-  } catch {
-    return [];
-  }
-
-  const providerData = store.providers?.[CODEX_PROVIDER_ID];
-  if (!providerData?.accounts?.length) return [];
-
-  const realAccounts = filterRealCodexAccounts(providerData.accounts);
-  if (realAccounts.length === 0) return [];
-
-  // lastUsedAt 업데이트는 "기본 선택" 계정에만 적용한다 — multi-account일 때
-  // 모두 갱신하면 자동 선택 로직이 의미 없어진다. 조회 자체는 모든 real 계정에 대해 수행.
-  try {
-    const { account: defaultAccount } = resolveDefaultAccount(realAccounts);
-    if (defaultAccount) {
-      const freshStore = await loadAuthStore();
-      const updatedAccount = { ...defaultAccount, lastUsedAt: new Date().toISOString() };
-      const nextStore = upsertProviderAccount(freshStore, CODEX_PROVIDER_ID, updatedAccount);
-      await saveAuthStore(nextStore);
-    }
-  } catch {
-    // best-effort
-  }
-
-  return realAccounts.map(mapAccountToProfile);
-}
-
-function mapAccountToProfile(account) {
+function codexMapAccountToProfile(account) {
   return {
     id: account.accountKey,
     accessToken: account.tokens.accessToken,

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -7,6 +7,7 @@ import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/aut
 import { resolveDefaultAccount } from '../auth/account-resolver.js';
 import { filterProfilesByAccount } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
+import { resolveAuthSource } from './auth-source-resolver.js';
 
 const CODEX_PROVIDER_ID = 'openai-codex';
 
@@ -52,14 +53,13 @@ export async function getCodexSnapshot(config, options = {}) {
 export { filterProfilesByAccount } from './account-filter.js';
 
 /**
- * Pure selection: agent-store > openclaw-import.
- * Exported for testing.
+ * @deprecated 공통 resolveAuthSource로 대체됨. 기존 테스트 import 호환용 re-export.
  */
 export function selectCodexAuthSource(agentProfiles, openclawProfiles) {
-  if (agentProfiles.length > 0) {
-    return { profiles: agentProfiles, authSource: 'agent-store' };
-  }
-  return { profiles: openclawProfiles, authSource: 'openclaw-import' };
+  const { accounts, authSource } = resolveAuthSource(agentProfiles, [
+    { id: 'openclaw-import', accounts: openclawProfiles },
+  ]);
+  return { profiles: accounts, authSource };
 }
 
 /**
@@ -78,7 +78,10 @@ export function filterRealCodexAccounts(accounts) {
 async function resolveCodexProfiles() {
   const agentProfiles = await getAgentStoreProfiles();
   const openclawProfiles = agentProfiles.length === 0 ? readCodexAuthProfiles() : [];
-  return selectCodexAuthSource(agentProfiles, openclawProfiles);
+  const { accounts, authSource } = resolveAuthSource(agentProfiles, [
+    { id: 'openclaw-import', accounts: openclawProfiles },
+  ]);
+  return { profiles: accounts, authSource };
 }
 
 async function getAgentStoreProfiles() {

--- a/packages/agent/src/services/provider-profile-resolver.js
+++ b/packages/agent/src/services/provider-profile-resolver.js
@@ -1,0 +1,57 @@
+import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
+import { resolveDefaultAccount } from '../auth/account-resolver.js';
+import { filterProfilesByAccount } from './account-filter.js';
+
+/**
+ * 공통 provider profile resolver.
+ *
+ * "store 로드 → real 계정 필터 → profile 매핑 → accountFilter 적용
+ *  → lastUsedAt 갱신" 흐름을 한 곳에서 처리한다.
+ *
+ * provider별 차이는 spec 객체로 주입:
+ *   - providerId:  store.providers[providerId]
+ *   - filterFn:    (accounts) => real accounts (mock/disabled 제거)
+ *   - mapFn:       (account) => profile shape (fetchXxxUsage가 받는 형태)
+ *   - updateLastUsed: true면 기본 선택 계정에 lastUsedAt 갱신
+ *
+ * @param {{
+ *   providerId: string,
+ *   filterFn: (accounts: object[]) => object[],
+ *   mapFn: (account: object) => object,
+ *   accountFilter?: string|null,
+ *   updateLastUsed?: boolean,
+ * }} spec
+ * @returns {Promise<object[]>} - fetch에 넘길 profile 배열
+ */
+export async function resolveProviderProfiles(spec) {
+  let store;
+  try {
+    store = await loadAuthStore();
+  } catch {
+    return [];
+  }
+
+  const providerData = store.providers?.[spec.providerId];
+  if (!providerData?.accounts?.length) return [];
+
+  const realAccounts = spec.filterFn(providerData.accounts);
+  if (realAccounts.length === 0) return [];
+
+  // lastUsedAt 갱신: 기본 선택 계정에 대해서만 (multi-account 자동 선택 안정화).
+  if (spec.updateLastUsed !== false) {
+    try {
+      const { account: defaultAccount } = resolveDefaultAccount(realAccounts);
+      if (defaultAccount) {
+        const freshStore = await loadAuthStore();
+        const updatedAccount = { ...defaultAccount, lastUsedAt: new Date().toISOString() };
+        const nextStore = upsertProviderAccount(freshStore, spec.providerId, updatedAccount);
+        await saveAuthStore(nextStore);
+      }
+    } catch {
+      // best-effort
+    }
+  }
+
+  const profiles = realAccounts.map(spec.mapFn);
+  return filterProfilesByAccount(profiles, spec.accountFilter ?? null);
+}

--- a/packages/agent/test/services/auth-source-resolver.test.js
+++ b/packages/agent/test/services/auth-source-resolver.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveAuthSource } from '../../src/services/auth-source-resolver.js';
+
+describe('resolveAuthSource', () => {
+  it('returns agent-store when agentAccounts is non-empty', () => {
+    const result = resolveAuthSource(
+      [{ id: 'agent-1' }],
+      [{ id: 'openclaw-import', accounts: [{ id: 'oc-1' }] }],
+    );
+    assert.equal(result.authSource, 'agent-store');
+    assert.deepEqual(result.accounts, [{ id: 'agent-1' }]);
+  });
+
+  it('falls back to first non-empty import source', () => {
+    const result = resolveAuthSource(
+      [],
+      [
+        { id: 'openclaw-import', accounts: [{ id: 'oc-1' }] },
+      ],
+    );
+    assert.equal(result.authSource, 'openclaw-import');
+    assert.deepEqual(result.accounts, [{ id: 'oc-1' }]);
+  });
+
+  it('skips empty import sources and uses the first non-empty one', () => {
+    const result = resolveAuthSource(
+      [],
+      [
+        { id: 'empty-source', accounts: [] },
+        { id: 'claude-cli-import', accounts: [{ id: 'cli-1' }] },
+      ],
+    );
+    assert.equal(result.authSource, 'claude-cli-import');
+    assert.deepEqual(result.accounts, [{ id: 'cli-1' }]);
+  });
+
+  it('returns not-found when all sources are empty', () => {
+    const result = resolveAuthSource([], []);
+    assert.equal(result.authSource, 'not-found');
+    assert.deepEqual(result.accounts, []);
+  });
+
+  it('returns not-found when agentAccounts is empty and no importSources provided', () => {
+    const result = resolveAuthSource([]);
+    assert.equal(result.authSource, 'not-found');
+  });
+
+  it('handles null/undefined agentAccounts gracefully', () => {
+    const result = resolveAuthSource(null, [{ id: 'x', accounts: [{ id: 'a' }] }]);
+    assert.equal(result.authSource, 'x');
+  });
+
+  it('prefers agent-store even when import sources also have accounts', () => {
+    const agent = [{ id: 'a1' }, { id: 'a2' }];
+    const result = resolveAuthSource(agent, [
+      { id: 'openclaw-import', accounts: [{ id: 'oc' }] },
+      { id: 'claude-cli-import', accounts: [{ id: 'cli' }] },
+    ]);
+    assert.equal(result.authSource, 'agent-store');
+    assert.equal(result.accounts.length, 2);
+  });
+});

--- a/packages/agent/test/services/status-service.test.js
+++ b/packages/agent/test/services/status-service.test.js
@@ -103,9 +103,9 @@ describe('selectCodexAuthSource', () => {
     assert.deepStrictEqual(result.profiles, [openclawProfile]);
   });
 
-  it('returns openclaw-import with empty profiles when both lists are empty', () => {
+  it('returns not-found when both lists are empty (공통 resolveAuthSource 기준)', () => {
     const result = selectCodexAuthSource([], []);
-    assert.equal(result.authSource, 'openclaw-import');
+    assert.equal(result.authSource, 'not-found');
     assert.equal(result.profiles.length, 0);
   });
 });

--- a/packages/provider-adapters/src/codex/fetch-codex-usage.js
+++ b/packages/provider-adapters/src/codex/fetch-codex-usage.js
@@ -45,7 +45,7 @@ export async function fetchCodexUsage(profile, options = {}) {
         normalizeWindow('primary', data?.rate_limit?.primary_window),
         normalizeWindow('secondary', data?.rate_limit?.secondary_window),
       ].filter(Boolean),
-      credits: { balance: data?.credits?.balance ?? null, unit: null },
+      credits: { balance: toNumberOrNull(data?.credits?.balance), unit: null },
       raw: {
         rate_limit: data?.rate_limit ?? null,
         credits: data?.credits ?? null,
@@ -67,4 +67,11 @@ function normalizeWindow(kind, window) {
     windowSeconds: window.limit_window_seconds ?? null,
     resetAt: toIsoFromEpochSeconds(window.reset_at),
   };
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return value;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
 }


### PR DESCRIPTION
## 요약

provider별로 흩어져 있던 "account 선택"과 "auth source 선택" 로직을 공통 함수 2개로 통합.

이슈 #48 해결.

## 변경 내용

### Step 1 — 공통 auth source resolver

- `services/auth-source-resolver.js` 신설
  - `resolveAuthSource(agentAccounts, importSources)` → `{ accounts, authSource }`
  - 우선순위: agent-store > 첫 번째 비어있지 않은 import source > not-found
- Codex: `selectCodexAuthSource` + `resolveCodexProfiles` → `resolveAuthSource` 호출로 교체
- Claude: `auth/resolve-claude-account.js`가 `selectClaudeAccountsSource` 대신 `resolveAuthSource` 사용
- 기존 `select*` 함수는 deprecated re-export으로 유지 (기존 테스트 호환)
- 동작 변경: `selectCodexAuthSource([], [])` — `'openclaw-import'` → `'not-found'` (빈 import source는 후보가 아님)
- 테스트 7개 신규

### Step 2 — 공통 provider profile resolver

- `services/provider-profile-resolver.js` 신설
  - `resolveProviderProfiles({ providerId, filterFn, mapFn, accountFilter, updateLastUsed })`
  - store 로드 → filterFn (real 계정 필터) → mapFn (profile shape) → accountFilter → lastUsedAt 갱신
- Codex: `getAgentStoreProfiles` + `mapAccountToProfile` 제거 → runner + openclaw fallback
- Claude: `loadAgentStoreClaudeAccounts` 축소 (`filterClaudeRealAccounts` 재사용), `resolveClaudeProfilesForFetch` 제거 → runner + cli-import fallback
- `filteredOut` 판정 단순화: `Boolean(accountFilter) && profiles.length === 0`

### Step 3 — resolve-claude-account.js 유지

`resolveAuthSource` + `resolveAccount`의 얇은 합성이지만, `buildClaudeSnapshot`에서 단일 호출점으로 깔끔. 파일 유지 결정.

### Step 4 — 정리 + 문서

- `fetch-codex-usage.js`: `credits.balance`에 `toNumberOrNull` 적용. Codex API가 문자열 반환 시 schema-warning 뜨던 문제 해결.
- `docs/codebase-guide.md` §4.1 구조 갱신, §4.1.1 "Account 선택 vs Auth source 선택 흐름" 신설.

## 테스트

전체 482 → **489** pass (+7 auth-source-resolver).

## 실동 검증

- `status` / `status --account test-account` 정상 출력
- schema-warning 0건 (credits.balance 수정 후)
- multi-account 전체 조회 / 필터 / label 매치 모두 동일 동작

## 영향 범위

- [x] `packages/agent`
- [x] `packages/provider-adapters`
- [x] `docs`

## 리뷰 포인트

- `resolveProviderProfiles`가 Codex/Claude 두 provider의 차이를 filterFn/mapFn spec으로 충분히 흡수하는지
- Claude의 cli-import fallback이 runner 바깥에서 별도 처리되는 점이 자연스러운지 (provider-adapters → agent 역방향 import 금지 때문)
- `selectCodexAuthSource([], [])` 동작 변경(`openclaw-import` → `not-found`)이 합리적인지

closes #48