### PR TITLE
[refactor] 오케스트레이션/포맷터/비즈니스 로직 분리

### DIFF
--- a/packages/agent/src/auth/claude-refresh-store.js
+++ b/packages/agent/src/auth/claude-refresh-store.js
@@ -1,0 +1,40 @@
+import { loadAuthStore, saveAuthStore, upsertProviderAccount } from './auth-store.js';
+import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-constants.js';
+
+/**
+ * Claude refresh 성공 후 agent-store 갱신.
+ *
+ * @param {object} account - 갱신 대상 account 원본
+ * @param {object} tokenResponse - refreshClaudeToken 결과
+ * @returns {Promise<{ accountKey: string, expiresAt: string|null }>}
+ */
+export async function updateClaudeStoreAfterRefresh(account, tokenResponse) {
+  const now = new Date();
+  const expiresAt = tokenResponse.expiresIn
+    ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
+    : null;
+
+  const updatedAccount = {
+    ...account,
+    tokens: {
+      ...account.tokens,
+      accessToken: tokenResponse.accessToken,
+      refreshToken: tokenResponse.refreshToken,
+    },
+    expiresAt,
+    updatedAt: now.toISOString(),
+    lastUsedAt: now.toISOString(),
+    raw: {
+      ...account.raw,
+      lastRefreshedAt: now.toISOString(),
+      scope: tokenResponse.scope ?? account.raw?.scope ?? null,
+      tokenType: tokenResponse.tokenType ?? account.raw?.tokenType ?? null,
+    },
+  };
+
+  const freshStore = await loadAuthStore();
+  const nextStore = upsertProviderAccount(freshStore, CLAUDE_AUTH.storeProvider, updatedAccount);
+  await saveAuthStore(nextStore);
+
+  return { accountKey: updatedAccount.accountKey, expiresAt };
+}

--- a/packages/agent/src/auth/codex-refresh-store.js
+++ b/packages/agent/src/auth/codex-refresh-store.js
@@ -1,0 +1,36 @@
+import { loadAuthStore, saveAuthStore, upsertProviderAccount } from './auth-store.js';
+
+const CODEX_PROVIDER_ID = 'openai-codex';
+
+/**
+ * Codex refresh 성공 후 agent-store 갱신.
+ *
+ * @param {object} account - 갱신 대상 account 원본
+ * @param {object} tokenResponse - refreshCodexToken 결과
+ * @returns {Promise<{ accountKey: string, expiresAt: string|null }>}
+ */
+export async function updateCodexStoreAfterRefresh(account, tokenResponse) {
+  const now = new Date();
+  const expiresAt = tokenResponse.expiresIn
+    ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
+    : null;
+
+  const updatedAccount = {
+    ...account,
+    tokens: {
+      ...account.tokens,
+      accessToken: tokenResponse.accessToken,
+      refreshToken: tokenResponse.refreshToken,
+    },
+    expiresAt,
+    updatedAt: now.toISOString(),
+    lastUsedAt: now.toISOString(),
+    raw: { ...account.raw, lastRefreshedAt: now.toISOString() },
+  };
+
+  const freshStore = await loadAuthStore();
+  const nextStore = upsertProviderAccount(freshStore, CODEX_PROVIDER_ID, updatedAccount);
+  await saveAuthStore(nextStore);
+
+  return { accountKey: updatedAccount.accountKey, expiresAt };
+}

--- a/packages/agent/src/cli/doctor-codex-helpers.js
+++ b/packages/agent/src/cli/doctor-codex-helpers.js
@@ -1,0 +1,56 @@
+/**
+ * doctor codex 출력용 pure formatter + predicate 모음.
+ *
+ * 모든 format* 함수는 string[] 반환, console.log 호출 없음.
+ */
+
+import { formatTokenExpiry } from './doctor-helpers.js';
+
+/**
+ * Codex 계정이 mock 또는 refreshToken 없는 placeholder인지 판별.
+ */
+export function isCodexMockAccount(account) {
+  return account.raw?.mock === true || !account.tokens?.refreshToken;
+}
+
+/**
+ * 대상 계정 기본 정보 요약.
+ */
+export function formatCodexAccountSummary(account) {
+  return [
+    `대상 계정: ${account.accountKey}`,
+    `선택 이유: ${account._reason}`,
+    `email: ${account.email}`,
+    `authType: ${account.authType}`,
+    `source: ${account.source}`,
+    `expiresAt: ${account.expiresAt ?? '(없음)'}`,
+  ];
+}
+
+/**
+ * Mock/placeholder 계정 경고.
+ */
+export function formatCodexMockGuard(account) {
+  const lines = [
+    '',
+    '⚠ 이 계정은 mock이거나 refreshToken이 없습니다.',
+    '  refresh 시도를 건너뜁니다.',
+  ];
+  if (!account.tokens?.refreshToken) lines.push('  (tokens.refreshToken이 존재하지 않음)');
+  if (account.raw?.mock) lines.push('  (raw.mock = true)');
+  return lines;
+}
+
+/**
+ * Dry-run (--refresh-live 없을 때) 상태 출력.
+ */
+export function formatCodexDryRun(account) {
+  const lines = [
+    '',
+    'refresh 상태 확인만 수행합니다. (dry-run)',
+    '실제 refresh를 시도하려면 --refresh-live 옵션을 추가하세요.',
+  ];
+  const expiry = formatTokenExpiry(account.expiresAt);
+  if (expiry) lines.push(expiry);
+  return lines;
+}

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -1,23 +1,29 @@
 import { resolveAgentConfigPath } from '../config/config-path.js';
-import { loadAuthStore, saveAuthStore, upsertProviderAccount } from '../auth/auth-store.js';
+import { loadAuthStore } from '../auth/auth-store.js';
 import { resolveAccount } from '../auth/account-resolver.js';
 import { getClaudeSnapshot } from '../services/status-service.js';
 import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-constants.js';
 import {
   formatClaudeSection,
-  formatTokenExpiry,
   runRefreshLiveAttempt,
   CODEX_REFRESH_SPEC,
   CLAUDE_REFRESH_SPEC,
 } from './doctor-helpers.js';
+import {
+  isCodexMockAccount,
+  formatCodexAccountSummary,
+  formatCodexMockGuard,
+  formatCodexDryRun,
+} from './doctor-codex-helpers.js';
+import { updateCodexStoreAfterRefresh } from '../auth/codex-refresh-store.js';
+import { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
 
-// formatClaudeSection은 doctor-helpers로 이전했지만 외부(CLI 테스트)에서 같은 모듈
-// 경로로 import하던 이력을 지키기 위해 re-export.
+// 기존 import 경로 호환 re-export.
 export { formatClaudeSection };
+export { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
 
-/**
- * `ai-usage-agent doctor [subcommand] [options]`
- */
+// ─── Dispatcher ────────────────────────────────────────────────────────────
+
 export async function runDoctorCommand(subcommand, args = []) {
   if (subcommand === 'codex') {
     await runDoctorCodex(args);
@@ -86,43 +92,41 @@ async function runDoctorClaudeRefreshLive(snapshot, { accountIdentifier } = {}) 
   if (!refreshToken) {
     console.log('');
     console.log(`대상 계정(${account.accountKey})에서 refreshToken을 찾을 수 없습니다.`);
-    console.log('Claude CLI에서 최신 로그인 상태인지 확인하세요.');
     return;
   }
 
   console.log('');
   console.log(`대상 계정: ${account.accountKey}`);
 
-  // claude-cli-import source는 auth-store에 대응 레코드가 없으므로(원본 파일을 비파괴로
-  // 읽어오는 경로) store 갱신 대신 안내 메시지만 출력한다.
   const isImportSource = account?.source === 'claude-cli-import';
 
   console.log('');
   await runRefreshLiveAttempt(CLAUDE_REFRESH_SPEC, refreshToken, async (tokenResponse) => {
     if (isImportSource) {
       console.log('');
-      console.log('ℹ claude-cli-import 출처 계정입니다 — agent-store에는 대응 레코드가 없어');
-      console.log('  새 토큰을 저장하지 않습니다 (원본 ~/.claude/.credentials.json 비파괴).');
+      console.log('ℹ claude-cli-import 출처 — agent-store에 저장하지 않습니다.');
       console.log('  agent-store에 유지하려면 `auth login claude --live-exchange`로 재로그인하세요.');
       return;
     }
-    await updateClaudeStoreAfterRefresh(account, tokenResponse);
+    const result = await updateClaudeStoreAfterRefresh(account, tokenResponse);
+    console.log('');
+    console.log('store 갱신 완료:');
+    console.log(`  accountKey: ${result.accountKey}`);
+    console.log(`  expiresAt: ${result.expiresAt ?? '(없음)'}`);
   });
 }
 
 /**
- * refresh 대상 계정 선택 규칙. Exported for testing.
+ * refresh 대상 Claude 계정 선택. Exported for testing.
  */
 export async function resolveClaudeRefreshTargetAccount(snapshot, accountIdentifier) {
   if (!accountIdentifier) {
-    const account = snapshot.selectedAccount;
-    if (!account) {
+    if (!snapshot.selectedAccount) {
       console.log('');
       console.log('선택 가능한 Claude 계정이 없습니다.');
-      console.log('`auth login claude --live-exchange` 또는 `auth import claude`로 먼저 저장하세요.');
       return null;
     }
-    return account;
+    return snapshot.selectedAccount;
   }
 
   const store = await loadAuthStore();
@@ -130,7 +134,6 @@ export async function resolveClaudeRefreshTargetAccount(snapshot, accountIdentif
   if (accounts.length === 0) {
     console.log('');
     console.log('agent-store에 저장된 Claude 계정이 없습니다.');
-    console.log('--account 옵션은 agent-store 계정에만 동작합니다.');
     return null;
   }
 
@@ -138,47 +141,9 @@ export async function resolveClaudeRefreshTargetAccount(snapshot, accountIdentif
   if (!account) {
     console.log('');
     console.log(`계정을 찾을 수 없습니다. (reason: ${reason})`);
-    console.log('  email / accountKey / label 중 하나로 지정하세요.');
     return null;
   }
   return account;
-}
-
-/**
- * Claude refresh 성공 후 agent-store 갱신. Exported for testing.
- */
-export async function updateClaudeStoreAfterRefresh(account, tokenResponse) {
-  const now = new Date();
-  const expiresAt = tokenResponse.expiresIn
-    ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
-    : null;
-
-  const updatedAccount = {
-    ...account,
-    tokens: {
-      ...account.tokens,
-      accessToken: tokenResponse.accessToken,
-      refreshToken: tokenResponse.refreshToken,
-    },
-    expiresAt,
-    updatedAt: now.toISOString(),
-    lastUsedAt: now.toISOString(),
-    raw: {
-      ...account.raw,
-      lastRefreshedAt: now.toISOString(),
-      scope: tokenResponse.scope ?? account.raw?.scope ?? null,
-      tokenType: tokenResponse.tokenType ?? account.raw?.tokenType ?? null,
-    },
-  };
-
-  const freshStore = await loadAuthStore();
-  const nextStore = upsertProviderAccount(freshStore, CLAUDE_AUTH.storeProvider, updatedAccount);
-  await saveAuthStore(nextStore);
-
-  console.log('');
-  console.log('store 갱신 완료:');
-  console.log(`  accountKey: ${updatedAccount.accountKey}`);
-  console.log(`  expiresAt: ${expiresAt ?? '(없음)'}`);
 }
 
 export function parseDoctorClaudeOptions(args) {
@@ -189,10 +154,7 @@ export function parseDoctorClaudeOptions(args) {
     if (arg === '--refresh-live') options.refreshLive = true;
     else if (arg === '--account') {
       const value = list[i + 1];
-      if (value) {
-        options.account = value;
-        i += 1;
-      }
+      if (value) { options.account = value; i += 1; }
     }
   }
   return options;
@@ -209,29 +171,34 @@ async function runDoctorCodex(args) {
   const account = await resolveCodexDoctorAccount(options);
   if (!account) return;
 
-  printCodexAccountSummary(account);
+  for (const line of formatCodexAccountSummary(account)) console.log(line);
 
   if (isCodexMockAccount(account)) {
-    printCodexMockGuard(account);
+    for (const line of formatCodexMockGuard(account)) console.log(line);
     return;
   }
   console.log('refreshToken 존재: 예');
 
   if (!options.refreshLive) {
-    printCodexDryRun(account);
+    for (const line of formatCodexDryRun(account)) console.log(line);
     return;
   }
 
   console.log('');
   console.log('⚠ --refresh-live: 실제 token endpoint에 refresh POST를 시도합니다.');
   console.log(`  대상 accountKey: ${account.accountKey}`);
-  console.log('  주의: client_id는 관찰값(observed)이며 성공이 보장되지 않습니다.');
   console.log('');
 
   await runRefreshLiveAttempt(
     CODEX_REFRESH_SPEC,
     account.tokens.refreshToken,
-    (tokenResponse) => updateCodexStoreAfterRefresh(account, tokenResponse),
+    async (tokenResponse) => {
+      const result = await updateCodexStoreAfterRefresh(account, tokenResponse);
+      console.log('');
+      console.log('store 갱신 완료:');
+      console.log(`  accountKey: ${result.accountKey}`);
+      console.log(`  expiresAt: ${result.expiresAt ?? '(없음)'}`);
+    },
   );
 }
 
@@ -239,13 +206,12 @@ async function resolveCodexDoctorAccount(options) {
   const store = await loadAuthStore();
   const provider = store.providers['openai-codex'];
   if (!provider?.accounts?.length) {
-    console.log('openai-codex 계정이 없습니다. `ai-usage-agent auth login codex`로 먼저 로그인하세요.');
+    console.log('openai-codex 계정이 없습니다.');
     return null;
   }
 
   const refreshableAccounts = provider.accounts.filter(
-    (a) =>
-      a.status !== 'disabled' && a.raw?.mock !== true && a.tokens?.refreshToken,
+    (a) => a.status !== 'disabled' && a.raw?.mock !== true && a.tokens?.refreshToken,
   );
   const candidateAccounts = options.account ? provider.accounts : refreshableAccounts;
 
@@ -256,8 +222,6 @@ async function resolveCodexDoctorAccount(options) {
   if (!account) {
     if (!options.account && refreshableAccounts.length === 0) {
       console.log('refresh 가능한 real 계정을 찾지 못했습니다.');
-      console.log('mock 계정만 있거나 refreshToken이 없는 계정만 존재합니다.');
-      console.log('`ai-usage-agent auth login codex --live-exchange`로 real token을 먼저 저장하세요.');
       return null;
     }
     console.log(`계정을 찾을 수 없습니다. (reason: ${reason})`);
@@ -268,64 +232,6 @@ async function resolveCodexDoctorAccount(options) {
   return account;
 }
 
-function isCodexMockAccount(account) {
-  return account.raw?.mock === true || !account.tokens?.refreshToken;
-}
-
-function printCodexAccountSummary(account) {
-  console.log(`대상 계정: ${account.accountKey}`);
-  console.log(`선택 이유: ${account._reason}`);
-  console.log(`email: ${account.email}`);
-  console.log(`authType: ${account.authType}`);
-  console.log(`source: ${account.source}`);
-  console.log(`expiresAt: ${account.expiresAt ?? '(없음)'}`);
-}
-
-function printCodexMockGuard(account) {
-  console.log('');
-  console.log('⚠ 이 계정은 mock이거나 refreshToken이 없습니다.');
-  console.log('  refresh 시도를 건너뜁니다.');
-  if (!account.tokens?.refreshToken) console.log('  (tokens.refreshToken이 존재하지 않음)');
-  if (account.raw?.mock) console.log('  (raw.mock = true)');
-}
-
-function printCodexDryRun(account) {
-  console.log('');
-  console.log('refresh 상태 확인만 수행합니다. (dry-run)');
-  console.log('실제 refresh를 시도하려면 --refresh-live 옵션을 추가하세요.');
-  const expiry = formatTokenExpiry(account.expiresAt);
-  if (expiry) console.log(expiry);
-}
-
-async function updateCodexStoreAfterRefresh(account, tokenResponse) {
-  const now = new Date();
-  const expiresAt = tokenResponse.expiresIn
-    ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
-    : null;
-
-  const updatedAccount = {
-    ...account,
-    tokens: {
-      ...account.tokens,
-      accessToken: tokenResponse.accessToken,
-      refreshToken: tokenResponse.refreshToken,
-    },
-    expiresAt,
-    updatedAt: now.toISOString(),
-    lastUsedAt: now.toISOString(),
-    raw: { ...account.raw, lastRefreshedAt: now.toISOString() },
-  };
-
-  const freshStore = await loadAuthStore();
-  const nextStore = upsertProviderAccount(freshStore, 'openai-codex', updatedAccount);
-  await saveAuthStore(nextStore);
-
-  console.log('');
-  console.log('store 갱신 완료:');
-  console.log(`  accountKey: ${updatedAccount.accountKey}`);
-  console.log(`  expiresAt: ${expiresAt ?? '(없음)'}`);
-}
-
 function parseDoctorCodexOptions(args) {
   const options = { refreshLive: false, account: null };
   for (let i = 0; i < args.length; i += 1) {
@@ -333,10 +239,7 @@ function parseDoctorCodexOptions(args) {
     if (arg === '--refresh-live') options.refreshLive = true;
     if (arg === '--account') {
       const value = args[i + 1];
-      if (value) {
-        options.account = value;
-        i += 1;
-      }
+      if (value) { options.account = value; i += 1; }
     }
   }
   return options;

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -1,13 +1,24 @@
 import { getStatusSnapshot } from '../services/status-service.js';
 
+// 포맷터는 status-formatters.js에서 관리. 기존 import 경로 호환을 위해 re-export.
+export {
+  formatStatusOutput,
+  formatCodexSection,
+  formatClaudeSection,
+  formatClaudeNetworkUsages,
+  formatClaudeNetworkUsageBody,
+  formatClaudeNetworkUsage,
+  formatClaudeLocalUsage,
+  formatWindow,
+} from './status-formatters.js';
+
+import { formatStatusOutput } from './status-formatters.js';
+
 export const STATUS_COMMANDS = ['status', 'usage'];
 
 /**
  * `status` / `usage` 진입점.
- * 출력 라인 생성은 pure formatter에 위임하고, 본 함수는 console.log만 담당.
- *
- * @param {string} command
- * @param {string[]} [args] - CLI args (e.g. ['--account', 'alice@x.com'])
+ * 옵션 파싱 → snapshot 조회 → formatter → 출력.
  */
 export async function runStatusCommand(command, args = []) {
   const options = parseStatusOptions(args);
@@ -19,11 +30,6 @@ export async function runStatusCommand(command, args = []) {
 
 /**
  * `status` / `usage` 옵션 파서.
- * 현재 지원: `--account <id>` (email / accountKey 매치).
- * Unknown flag는 무시.
- *
- * @param {string[]} args
- * @returns {{ account: string|null }}
  */
 export function parseStatusOptions(args) {
   const options = { account: null };
@@ -38,189 +44,4 @@ export function parseStatusOptions(args) {
     }
   }
   return options;
-}
-
-/**
- * 전체 status 출력 라인 배열을 만드는 pure 함수.
- * @param {string} command
- * @param {object} snapshot - getStatusSnapshot 결과
- * @returns {string[]}
- */
-export function formatStatusOutput(command, snapshot) {
-  const lines = [
-    `명령: ${command}`,
-    '로컬 에이전트 상태 요약',
-    '-----------------------',
-    `설정 파일: ${snapshot.configPath}`,
-    `Codex 사용: ${snapshot.providers.codex.enabled ? 'enabled' : 'disabled'}`,
-    `Claude 사용: ${snapshot.providers.claude.enabled ? 'enabled' : 'disabled'}`,
-    `서버 sync: ${snapshot.sync.enabled ? 'enabled' : 'disabled'}`,
-  ];
-  if (snapshot.accountFilter) {
-    lines.push(`계정 필터: ${snapshot.accountFilter}`);
-  }
-  lines.push(
-    '',
-    ...formatCodexSection(snapshot.codex),
-    '',
-    ...formatClaudeSection(snapshot.claude),
-  );
-  return lines;
-}
-
-/** Pure formatter: Codex usage section. */
-export function formatCodexSection(codex) {
-  const lines = ['Codex usage', '-----------'];
-
-  if (!codex.enabled) {
-    lines.push('비활성화됨');
-    return lines;
-  }
-
-  lines.push(`인증 소스: ${codex.authSource ?? 'unknown'}`);
-  if (codex.authProfilesPath) {
-    lines.push(`Auth profiles 경로: ${codex.authProfilesPath}`);
-  }
-
-  if (codex.snapshots.length === 0) {
-    if (codex.filteredOut) {
-      lines.push(`계정 필터 "${codex.accountFilter}"에 해당하는 Codex 계정을 찾지 못했습니다.`);
-    } else {
-      lines.push('발견된 Codex OAuth 프로필이 없습니다.');
-    }
-    return lines;
-  }
-
-  for (const snapshot of codex.snapshots) {
-    const label = snapshot.account.email
-      ? `${snapshot.account.profileId} (${snapshot.account.email})`
-      : snapshot.account.profileId;
-    lines.push(`- ${label}`);
-    lines.push(
-      `  상태: ${
-        snapshot.status.ok
-          ? `OK (${snapshot.status.httpStatus})`
-          : `실패 (${snapshot.status.httpStatus ?? 'network/error'})`
-      }`,
-    );
-    lines.push(
-      `  source=${snapshot.source}, authType=${snapshot.authType}, confidence=${snapshot.confidence}`,
-    );
-    if (snapshot.account.plan) lines.push(`  플랜: ${snapshot.account.plan}`);
-    for (const window of snapshot.usageWindows) {
-      lines.push(`  ${window.kind}: ${formatWindow(window)}`);
-    }
-    if (snapshot.status.message) lines.push(`  에러: ${snapshot.status.message}`);
-  }
-  return lines;
-}
-
-/** Pure formatter: Claude usage section. */
-export function formatClaudeSection(claude) {
-  const lines = ['Claude usage', '------------'];
-  lines.push(`인증 소스: ${claude.authSource}`);
-  lines.push(`credential 감지: ${claude.detected}`);
-  // `기본 계정` 라인은 accountFilter가 없을 때만 표시한다.
-  // 필터가 걸려 있으면 아래 네트워크 조회 블록에 실제 조회 대상이 드러나고,
-  // 상단 'accountFilter' 라인에서 필터 값도 이미 보이므로 혼동을 피하기 위해 생략.
-  if (claude.selectedAccount && !claude.accountFilter) {
-    lines.push(`기본 계정: ${claude.selectedAccount.accountKey}`);
-  }
-
-  // Multi-account: networkUsages 배열 우선. 없으면 networkUsage 단일 값으로 fallback.
-  const usages = Array.isArray(claude.networkUsages)
-    ? claude.networkUsages
-    : claude.networkUsage
-      ? [{ accountKey: claude.selectedAccount?.accountKey ?? null, snapshot: claude.networkUsage }]
-      : [];
-  lines.push(
-    ...formatClaudeNetworkUsages(usages, {
-      filteredOut: claude.filteredOut,
-      accountFilter: claude.accountFilter,
-    }),
-  );
-  lines.push(...formatClaudeLocalUsage(claude.usage));
-  return lines;
-}
-
-/**
- * Pure formatter: Claude live network usage 블록(들).
- * usages가 비어 있으면 "호출 안 함" 단일 블록, 여러 개면 계정별 블록 반복.
- */
-export function formatClaudeNetworkUsages(usages, context = {}) {
-  const lines = ['', '[live] api.anthropic.com/api/oauth/usage'];
-  if (!usages || usages.length === 0) {
-    if (context.filteredOut) {
-      lines.push(`  계정 필터 "${context.accountFilter}"에 해당하는 Claude 계정을 찾지 못했습니다.`);
-    } else {
-      lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
-    }
-    return lines;
-  }
-
-  for (const { accountKey, snapshot } of usages) {
-    if (usages.length > 1) lines.push(`  - 계정: ${accountKey ?? '(unknown)'}`);
-    lines.push(...formatClaudeNetworkUsageBody(snapshot, usages.length > 1));
-  }
-  return lines;
-}
-
-/**
- * 단일 Claude network usage snapshot 출력 (들여쓰기 포함).
- * @param {object|null} networkUsage
- * @param {boolean} indented - multi-account 블록일 때 true → 추가 들여쓰기
- */
-export function formatClaudeNetworkUsageBody(networkUsage, indented = false) {
-  const prefix = indented ? '    ' : '  ';
-  const lines = [];
-  if (!networkUsage) {
-    lines.push(`${prefix}호출 안 함`);
-    return lines;
-  }
-
-  if (networkUsage.status?.ok) {
-    lines.push(`${prefix}상태: OK (${networkUsage.status.httpStatus})`);
-    if (networkUsage.usageWindows.length === 0) {
-      lines.push(`${prefix}usageWindows 없음 (응답에 기대한 필드가 없었음)`);
-    }
-    for (const window of networkUsage.usageWindows) {
-      lines.push(`${prefix}${window.kind}: ${formatWindow(window)}`);
-    }
-    return lines;
-  }
-
-  const http = networkUsage.status?.httpStatus ?? 'network/error';
-  const bucket = networkUsage.status?.bucket ?? 'unknown';
-  lines.push(`${prefix}상태: 실패 (${http}, bucket=${bucket})`);
-  if (networkUsage.status?.message) lines.push(`${prefix}메시지: ${networkUsage.status.message}`);
-  return lines;
-}
-
-/**
- * 기존 이름 유지(backward compat): 단일 networkUsage 객체를 받는 구 시그니처.
- * 신규 코드는 formatClaudeNetworkUsages(배열)를 권장.
- */
-export function formatClaudeNetworkUsage(networkUsage) {
-  const header = ['', '[live] api.anthropic.com/api/oauth/usage'];
-  return [...header, ...formatClaudeNetworkUsageBody(networkUsage, false)];
-}
-
-/** Pure formatter: Claude local stats-cache block. */
-export function formatClaudeLocalUsage(usage) {
-  const lines = ['', '[local] stats-cache.json'];
-  if (!usage || usage.source === 'not-found') {
-    lines.push('  데이터 없음 (stats-cache.json 미발견)');
-    return lines;
-  }
-  lines.push(`  총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
-  lines.push(`  총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
-  lines.push(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
-  lines.push(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
-  return lines;
-}
-
-export function formatWindow(window) {
-  const reset = window.resetAt ? `reset_at=${window.resetAt}` : 'reset_at=unknown';
-  const used = window.usedPercent ?? 'unknown';
-  return `used_percent=${used}, ${reset}`;
 }

--- a/packages/agent/src/cli/status-formatters.js
+++ b/packages/agent/src/cli/status-formatters.js
@@ -1,0 +1,176 @@
+/**
+ * status / usage 출력용 pure formatter 모음.
+ *
+ * 모든 함수는 string[] 반환, console.log 호출 없음.
+ * status-command.js의 runStatusCommand가 이 함수들의 결과를 출력한다.
+ */
+
+/**
+ * 전체 status 출력 라인 배열.
+ */
+export function formatStatusOutput(command, snapshot) {
+  const lines = [
+    `명령: ${command}`,
+    '로컬 에이전트 상태 요약',
+    '-----------------------',
+    `설정 파일: ${snapshot.configPath}`,
+    `Codex 사용: ${snapshot.providers.codex.enabled ? 'enabled' : 'disabled'}`,
+    `Claude 사용: ${snapshot.providers.claude.enabled ? 'enabled' : 'disabled'}`,
+    `서버 sync: ${snapshot.sync.enabled ? 'enabled' : 'disabled'}`,
+  ];
+  if (snapshot.accountFilter) {
+    lines.push(`계정 필터: ${snapshot.accountFilter}`);
+  }
+  lines.push(
+    '',
+    ...formatCodexSection(snapshot.codex),
+    '',
+    ...formatClaudeSection(snapshot.claude),
+  );
+  return lines;
+}
+
+/** Codex usage section. */
+export function formatCodexSection(codex) {
+  const lines = ['Codex usage', '-----------'];
+
+  if (!codex.enabled) {
+    lines.push('비활성화됨');
+    return lines;
+  }
+
+  lines.push(`인증 소스: ${codex.authSource ?? 'unknown'}`);
+  if (codex.authProfilesPath) {
+    lines.push(`Auth profiles 경로: ${codex.authProfilesPath}`);
+  }
+
+  if (codex.snapshots.length === 0) {
+    if (codex.filteredOut) {
+      lines.push(`계정 필터 "${codex.accountFilter}"에 해당하는 Codex 계정을 찾지 못했습니다.`);
+    } else {
+      lines.push('발견된 Codex OAuth 프로필이 없습니다.');
+    }
+    return lines;
+  }
+
+  for (const snapshot of codex.snapshots) {
+    const label = snapshot.account.email
+      ? `${snapshot.account.profileId} (${snapshot.account.email})`
+      : snapshot.account.profileId;
+    lines.push(`- ${label}`);
+    lines.push(
+      `  상태: ${
+        snapshot.status.ok
+          ? `OK (${snapshot.status.httpStatus})`
+          : `실패 (${snapshot.status.httpStatus ?? 'network/error'})`
+      }`,
+    );
+    lines.push(
+      `  source=${snapshot.source}, authType=${snapshot.authType}, confidence=${snapshot.confidence}`,
+    );
+    if (snapshot.account.plan) lines.push(`  플랜: ${snapshot.account.plan}`);
+    for (const window of snapshot.usageWindows) {
+      lines.push(`  ${window.kind}: ${formatWindow(window)}`);
+    }
+    if (snapshot.status.message) lines.push(`  에러: ${snapshot.status.message}`);
+  }
+  return lines;
+}
+
+/** Claude usage section. */
+export function formatClaudeSection(claude) {
+  const lines = ['Claude usage', '------------'];
+  lines.push(`인증 소스: ${claude.authSource}`);
+  lines.push(`credential 감지: ${claude.detected}`);
+  if (claude.selectedAccount && !claude.accountFilter) {
+    lines.push(`기본 계정: ${claude.selectedAccount.accountKey}`);
+  }
+
+  const usages = Array.isArray(claude.networkUsages)
+    ? claude.networkUsages
+    : claude.networkUsage
+      ? [{ accountKey: claude.selectedAccount?.accountKey ?? null, snapshot: claude.networkUsage }]
+      : [];
+  lines.push(
+    ...formatClaudeNetworkUsages(usages, {
+      filteredOut: claude.filteredOut,
+      accountFilter: claude.accountFilter,
+    }),
+  );
+  lines.push(...formatClaudeLocalUsage(claude.usage));
+  return lines;
+}
+
+/** Claude live network usage 블록(들). */
+export function formatClaudeNetworkUsages(usages, context = {}) {
+  const lines = ['', '[live] api.anthropic.com/api/oauth/usage'];
+  if (!usages || usages.length === 0) {
+    if (context.filteredOut) {
+      lines.push(`  계정 필터 "${context.accountFilter}"에 해당하는 Claude 계정을 찾지 못했습니다.`);
+    } else {
+      lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
+    }
+    return lines;
+  }
+
+  for (const { accountKey, snapshot } of usages) {
+    if (usages.length > 1) lines.push(`  - 계정: ${accountKey ?? '(unknown)'}`);
+    lines.push(...formatClaudeNetworkUsageBody(snapshot, usages.length > 1));
+  }
+  return lines;
+}
+
+/** 단일 Claude network usage snapshot 출력. */
+export function formatClaudeNetworkUsageBody(networkUsage, indented = false) {
+  const prefix = indented ? '    ' : '  ';
+  const lines = [];
+  if (!networkUsage) {
+    lines.push(`${prefix}호출 안 함`);
+    return lines;
+  }
+
+  if (networkUsage.status?.ok) {
+    lines.push(`${prefix}상태: OK (${networkUsage.status.httpStatus})`);
+    if (networkUsage.usageWindows.length === 0) {
+      lines.push(`${prefix}usageWindows 없음 (응답에 기대한 필드가 없었음)`);
+    }
+    for (const window of networkUsage.usageWindows) {
+      lines.push(`${prefix}${window.kind}: ${formatWindow(window)}`);
+    }
+    return lines;
+  }
+
+  const http = networkUsage.status?.httpStatus ?? 'network/error';
+  const bucket = networkUsage.status?.bucket ?? 'unknown';
+  lines.push(`${prefix}상태: 실패 (${http}, bucket=${bucket})`);
+  if (networkUsage.status?.message) lines.push(`${prefix}메시지: ${networkUsage.status.message}`);
+  return lines;
+}
+
+/**
+ * @deprecated 신규 코드는 formatClaudeNetworkUsages(배열)를 사용.
+ */
+export function formatClaudeNetworkUsage(networkUsage) {
+  const header = ['', '[live] api.anthropic.com/api/oauth/usage'];
+  return [...header, ...formatClaudeNetworkUsageBody(networkUsage, false)];
+}
+
+/** Claude local stats-cache block. */
+export function formatClaudeLocalUsage(usage) {
+  const lines = ['', '[local] stats-cache.json'];
+  if (!usage || usage.source === 'not-found') {
+    lines.push('  데이터 없음 (stats-cache.json 미발견)');
+    return lines;
+  }
+  lines.push(`  총 세션 수: ${usage.totalSessions ?? '알 수 없음'}`);
+  lines.push(`  총 메시지 수: ${usage.totalMessages ?? '알 수 없음'}`);
+  lines.push(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
+  lines.push(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
+  return lines;
+}
+
+export function formatWindow(window) {
+  const reset = window.resetAt ? `reset_at=${window.resetAt}` : 'reset_at=unknown';
+  const used = window.usedPercent ?? 'unknown';
+  return `used_percent=${used}, ${reset}`;
+}

--- a/packages/agent/src/services/claude-account-spec.js
+++ b/packages/agent/src/services/claude-account-spec.js
@@ -1,0 +1,47 @@
+/**
+ * Claude provider account spec.
+ *
+ * filterFn / mapFn / matchesFilter — provider-specific 정의.
+ */
+
+/**
+ * Active, non-mock, non-import accounts with a usable access token.
+ * claude-cli-import source는 buildClaudeSnapshot 경로가 별도 처리한다.
+ */
+export function filterClaudeRealAccounts(accounts) {
+  return (accounts ?? []).filter((a) => {
+    if (a.status === 'disabled') return false;
+    if (a.raw?.mock === true) return false;
+    const accessToken = a.tokens?.accessToken ?? a.accessToken ?? null;
+    if (!accessToken) return false;
+    if (a.source === 'claude-cli-import') return false;
+    return true;
+  });
+}
+
+/**
+ * Account → fetchClaudeUsage profile shape.
+ */
+export function claudeMapAccountToProfile(account) {
+  return {
+    id: account.accountKey,
+    accessToken: account.tokens?.accessToken ?? account.accessToken ?? null,
+    accountId: account.accountId ?? null,
+    email: account.email ?? null,
+    label: account.label ?? null,
+  };
+}
+
+/**
+ * Single profile이 accountFilter에 매치되는지 판별.
+ * cli-import fallback에서 사용.
+ */
+export function matchesFilter(profile, accountFilter) {
+  if (!accountFilter) return true;
+  const needle = String(accountFilter).toLowerCase();
+  return (
+    (profile.id ?? '').toLowerCase() === needle
+    || (profile.email ?? '').toLowerCase() === needle
+    || (profile.label ?? '').toLowerCase() === needle
+  );
+}

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -12,6 +12,11 @@ import { loadAuthStore } from '../auth/auth-store.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveProviderProfiles } from './provider-profile-resolver.js';
 import { filterProfilesByAccount } from './account-filter.js';
+import {
+  filterClaudeRealAccounts,
+  claudeMapAccountToProfile,
+  matchesFilter,
+} from './claude-account-spec.js';
 
 /**
  * Build the Claude section of the top-level status snapshot.
@@ -106,36 +111,8 @@ export async function getClaudeSnapshot(
 // Re-export from shared for backward-compat (tests import from this module).
 export { filterProfilesByAccount } from './account-filter.js';
 
-function filterClaudeRealAccounts(accounts) {
-  return (accounts ?? []).filter((a) => {
-    if (a.status === 'disabled') return false;
-    if (a.raw?.mock === true) return false;
-    const accessToken = a.tokens?.accessToken ?? a.accessToken ?? null;
-    if (!accessToken) return false;
-    if (a.source === 'claude-cli-import') return false;
-    return true;
-  });
-}
-
-function claudeMapAccountToProfile(account) {
-  return {
-    id: account.accountKey,
-    accessToken: account.tokens?.accessToken ?? account.accessToken ?? null,
-    accountId: account.accountId ?? null,
-    email: account.email ?? null,
-    label: account.label ?? null,
-  };
-}
-
-function matchesFilter(profile, accountFilter) {
-  if (!accountFilter) return true;
-  const needle = String(accountFilter).toLowerCase();
-  return (
-    (profile.id ?? '').toLowerCase() === needle
-    || (profile.email ?? '').toLowerCase() === needle
-    || (profile.label ?? '').toLowerCase() === needle
-  );
-}
+// filterClaudeRealAccounts, claudeMapAccountToProfile, matchesFilter
+// → imported from claude-account-spec.js
 
 /**
  * Pure: build a Claude credential + stats-cache snapshot.

--- a/packages/agent/src/services/codex-account-spec.js
+++ b/packages/agent/src/services/codex-account-spec.js
@@ -1,0 +1,33 @@
+/**
+ * Codex provider account spec.
+ *
+ * filterFn / mapFn — resolveProviderProfiles에 주입되는 provider-specific 정의.
+ */
+
+/**
+ * Active, non-mock accounts with a usable access token.
+ * @param {object[]} accounts
+ * @returns {object[]}
+ */
+export function filterRealCodexAccounts(accounts) {
+  return (accounts ?? []).filter(
+    (a) => a.status !== 'disabled'
+      && a.tokens?.accessToken
+      && !a.raw?.mock
+      && !a.tokens.accessToken.startsWith('mock-'),
+  );
+}
+
+/**
+ * Account → fetchCodexUsage profile shape.
+ */
+export function codexMapAccountToProfile(account) {
+  return {
+    id: account.accountKey,
+    accessToken: account.tokens.accessToken,
+    accountId: account.accountId ?? null,
+    email: account.email ?? null,
+    label: account.label ?? null,
+    expires: account.expiresAt ?? null,
+  };
+}

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -7,6 +7,7 @@ import { filterProfilesByAccount } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveAuthSource } from './auth-source-resolver.js';
 import { resolveProviderProfiles } from './provider-profile-resolver.js';
+import { filterRealCodexAccounts, codexMapAccountToProfile } from './codex-account-spec.js';
 
 const CODEX_PROVIDER_ID = 'openai-codex';
 
@@ -60,18 +61,8 @@ export function selectCodexAuthSource(agentProfiles, openclawProfiles) {
   return { profiles: accounts, authSource };
 }
 
-/**
- * Pure predicate: keep active, non-mock accounts with a usable access token.
- * Exported for testing.
- */
-export function filterRealCodexAccounts(accounts) {
-  return (accounts ?? []).filter(
-    (a) => a.status !== 'disabled'
-      && a.tokens?.accessToken
-      && !a.raw?.mock
-      && !a.tokens.accessToken.startsWith('mock-'),
-  );
-}
+// Re-export for backward compat (tests/status-service import from here).
+export { filterRealCodexAccounts } from './codex-account-spec.js';
 
 async function resolveCodexProfiles(accountFilter) {
   // Source 선택은 unfiltered 기준으로 먼저 결정한다.
@@ -98,16 +89,7 @@ async function resolveCodexProfiles(accountFilter) {
   return { profiles: accounts, authSource };
 }
 
-function codexMapAccountToProfile(account) {
-  return {
-    id: account.accountKey,
-    accessToken: account.tokens.accessToken,
-    accountId: account.accountId ?? null,
-    email: account.email ?? null,
-    label: account.label ?? null,
-    expires: account.expiresAt ?? null,
-  };
-}
+// codexMapAccountToProfile imported from codex-account-spec.js
 
 function createCodexFailureSnapshot(profile, error) {
   const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## 요약

CLI 커맨드 파일과 provider 파일에 혼재된 오케스트레이션 / 포맷터 / 비즈니스 로직을 관심사별로 분리한다. #49(account/source 공통화)와 독립.

이슈 #50 해결.

## 변경 내용

### Step A — status-command 포맷터 분리

- `cli/status-formatters.js` 신설 ← format* 8개 함수 이동 (모두 pure string[] 반환).
- `status-command.js`: 226 → 45 LOC (parseStatusOptions + runStatusCommand + re-export만).
- doctor-command → doctor-helpers 패턴과 동일 구조.

### Step C — provider account helper 분리

- `services/codex-account-spec.js` ← filterRealCodexAccounts / codexMapAccountToProfile
- `services/claude-account-spec.js` ← filterClaudeRealAccounts / claudeMapAccountToProfile / matchesFilter
- provider 파일은 spec import + runner 호출만 남김.

### Step B — doctor-command print* → format* + 비즈니스 로직 분리

- `cli/doctor-codex-helpers.js` 신설 ← isCodexMockAccount / formatCodexAccountSummary / formatCodexMockGuard / formatCodexDryRun (pure string[] 반환).
- `auth/codex-refresh-store.js` ← updateCodexStoreAfterRefresh (store I/O).
- `auth/claude-refresh-store.js` ← updateClaudeStoreAfterRefresh (store I/O).
- `doctor-command.js`: 343 → 246 LOC (dispatcher + orchestration + console.log만).

## 테스트

전체 489 pass (회귀 없음, 신규 0 — re-export로 기존 테스트 경로 유지).

## 영향 범위

- [x] `packages/agent`

## 리뷰 포인트

- status-command re-export 패턴이 doctor-command와 일관적인지
- doctor-command가 여전히 246 LOC인 점 — console.log 안내 블록이 많지만 비즈니스 로직/포맷터/predicate는 빠져나감
- codex-account-spec / claude-account-spec이 services/ 하위가 맞는지 (vs provider-adapters/)

closes #50