### PR TITLE
[fix] Claude OAuth 로그인 후 profile metadata 보강

### DIFF
--- a/packages/agent/src/cli/auth-list-command.js
+++ b/packages/agent/src/cli/auth-list-command.js
@@ -43,6 +43,7 @@ export async function runAuthListCommand(provider, options = {}) {
       const lines = [
         `  accountKey : ${acct.accountKey}`,
         `  email      : ${acct.email ?? '(없음)'}`,
+        `  name       : ${acct.displayName ?? '(없음)'}`,
         `  label      : ${acct.label ?? '(없음)'}`,
         `  source     : ${acct.source ?? '(알 수 없음)'}`,
         `  authType   : ${acct.authType ?? '(알 수 없음)'}`,

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -247,7 +247,7 @@ async function saveLiveExchangeAccount(spec, tokenResponse, identity, { label, k
  *
  * Unknown flag는 조용히 무시한다 (provider별 추가 플래그는 필요시 별도 처리).
  */
-async function enrichIdentityFromProviderProfile(spec, tokenResponse, identity) {
+export async function enrichIdentityFromProviderProfile(spec, tokenResponse, identity) {
   if (spec.id !== 'claude') {
     return { identity, profile: null };
   }

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -11,6 +11,7 @@ import {
 import { createAccount } from '../auth/auth-store-schema.js';
 import { extractAccountIdentity } from '../auth/token-claims.js';
 import { findLegacyDuplicates } from '../auth/find-legacy-duplicates.js';
+import { fetchClaudeOauthProfile } from '../../../provider-adapters/src/claude/fetch-claude-oauth-profile.js';
 
 /**
  * Provider spec shape used by runOAuthLoginFlow.
@@ -136,15 +137,16 @@ async function runLiveExchangeStep(spec, { code, callbackUrl, codeVerifier, stat
     console.log(`  expires_in: ${tokenResponse.expiresIn}`);
     console.log(`  scope: ${tokenResponse.scope ?? '(없음)'}`);
 
-    const identity = extractAccountIdentity({
+    const baseIdentity = extractAccountIdentity({
       idToken: tokenResponse.idToken,
       accessToken: tokenResponse.accessToken,
       fallbackCode: code,
       fallbackEmailDomain: spec.fallbackEmailDomain,
     });
+    const { identity, profile } = await enrichIdentityFromProviderProfile(spec, tokenResponse, baseIdentity);
     console.log(`  identity source: ${identity.claimSource}`);
 
-    await saveLiveExchangeAccount(spec, tokenResponse, identity, { label, keepLegacy });
+    await saveLiveExchangeAccount(spec, tokenResponse, identity, { label, keepLegacy, profile });
   } catch (err) {
     console.log('');
     console.log(`❌ live token exchange 실패: ${err.message}`);
@@ -158,7 +160,7 @@ async function runLiveExchangeStep(spec, { code, callbackUrl, codeVerifier, stat
   }
 }
 
-async function saveLiveExchangeAccount(spec, tokenResponse, identity, { label, keepLegacy } = {}) {
+async function saveLiveExchangeAccount(spec, tokenResponse, identity, { label, keepLegacy, profile } = {}) {
   const now = new Date();
   const expiresAt = tokenResponse.expiresIn
     ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
@@ -186,6 +188,13 @@ async function saveLiveExchangeAccount(spec, tokenResponse, identity, { label, k
       idToken: tokenResponse.idToken ?? null,
       exchangedAt: now.toISOString(),
       identityClaimSource: identity.claimSource,
+      ...(profile ? {
+        profile: {
+          account: profile.account,
+          organization: profile.organization,
+          application: profile.application,
+        },
+      } : {}),
       note: 'live token exchange 결과 — observed client_id + S256 PKCE 기반',
     },
   });
@@ -238,6 +247,32 @@ async function saveLiveExchangeAccount(spec, tokenResponse, identity, { label, k
  *
  * Unknown flag는 조용히 무시한다 (provider별 추가 플래그는 필요시 별도 처리).
  */
+async function enrichIdentityFromProviderProfile(spec, tokenResponse, identity) {
+  if (spec.id !== 'claude') {
+    return { identity, profile: null };
+  }
+
+  try {
+    const profile = await fetchClaudeOauthProfile({
+      accessToken: tokenResponse.accessToken,
+    });
+
+    const enrichedIdentity = {
+      email: profile.email ?? identity.email,
+      accountId: profile.accountId ?? identity.accountId,
+      displayName: profile.displayName ?? identity.displayName,
+      claimSource: profile.accountId || profile.email || profile.displayName
+        ? 'profile'
+        : identity.claimSource,
+    };
+
+    return { identity: enrichedIdentity, profile };
+  } catch (error) {
+    console.log(`  profile enrichment skipped: ${error.message}`);
+    return { identity, profile: null };
+  }
+}
+
 export function parseLoginOptions(args) {
   const options = {
     noOpen: false,

--- a/packages/agent/src/cli/status-formatters.js
+++ b/packages/agent/src/cli/status-formatters.js
@@ -83,7 +83,7 @@ export function formatClaudeSection(claude) {
   lines.push(`인증 소스: ${claude.authSource}`);
   lines.push(`credential 감지: ${claude.detected}`);
   if (claude.selectedAccount && !claude.accountFilter) {
-    lines.push(`기본 계정: ${claude.selectedAccount.accountKey}`);
+    lines.push(`기본 계정: ${formatAccountDisplay(claude.selectedAccount)}`);
   }
 
   const usages = Array.isArray(claude.networkUsages)
@@ -113,8 +113,8 @@ export function formatClaudeNetworkUsages(usages, context = {}) {
     return lines;
   }
 
-  for (const { accountKey, snapshot } of usages) {
-    if (usages.length > 1) lines.push(`  - 계정: ${accountKey ?? '(unknown)'}`);
+  for (const { accountKey, snapshot, account } of usages) {
+    if (usages.length > 1) lines.push(`  - 계정: ${formatAccountDisplay(account ?? { accountKey })}`);
     lines.push(...formatClaudeNetworkUsageBody(snapshot, usages.length > 1));
   }
   return lines;
@@ -167,6 +167,17 @@ export function formatClaudeLocalUsage(usage) {
   lines.push(`  모델별 usage: ${usage.hasModelUsage ? '있음' : '없음'}`);
   lines.push(`  일별 token 통계: ${usage.hasDailyModelTokens ? '있음' : '없음'}`);
   return lines;
+}
+
+function formatAccountDisplay(account) {
+  if (!account) return '(unknown)';
+  const accountKey = account.accountKey ?? '(unknown)';
+  const displayName = account.displayName ?? null;
+  const email = account.email ?? null;
+  if (displayName && email) return `${accountKey} (${displayName} / ${email})`;
+  if (displayName) return `${accountKey} (${displayName})`;
+  if (email) return `${accountKey} (${email})`;
+  return accountKey;
 }
 
 export function formatWindow(window) {

--- a/packages/agent/src/services/claude-account-spec.js
+++ b/packages/agent/src/services/claude-account-spec.js
@@ -25,9 +25,11 @@ export function filterClaudeRealAccounts(accounts) {
 export function claudeMapAccountToProfile(account) {
   return {
     id: account.accountKey,
+    accountKey: account.accountKey,
     accessToken: account.tokens?.accessToken ?? account.accessToken ?? null,
     accountId: account.accountId ?? null,
     email: account.email ?? null,
+    displayName: account.displayName ?? null,
     label: account.label ?? null,
   };
 }

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -171,9 +171,12 @@ export function resolveClaudeProfileFromSnapshot(snapshot) {
 
   return {
     id: account.accountKey ?? 'claude',
+    accountKey: account.accountKey ?? 'claude',
     accessToken,
     accountId: account.accountId ?? null,
     email: account.email ?? null,
+    displayName: account.displayName ?? null,
+    label: account.label ?? null,
   };
 }
 

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -84,10 +84,11 @@ export async function getClaudeSnapshot(
     profiles.map(async (profile) => {
       try {
         const snapshot = await fetchClaudeUsage(profile);
-        return { accountKey: profile.id, snapshot };
+        return { accountKey: profile.id, account: profile, snapshot };
       } catch (error) {
         return {
           accountKey: profile.id,
+          account: profile,
           snapshot: createClaudeNetworkFailureSnapshot(profile, error),
         };
       }

--- a/packages/agent/test/cli/auth-list-command.test.js
+++ b/packages/agent/test/cli/auth-list-command.test.js
@@ -141,6 +141,32 @@ describe('runAuthListCommand — Claude import block', () => {
     assert.ok(flat.includes('true'));
   });
 
+  it('shows displayName as name column when present', async () => {
+    const storeWithClaude = async () => ({
+      providers: {
+        claude: {
+          accounts: [{
+            accountKey: 'anthropic-claude:acct-123',
+            email: 'everdigm.itteam@gmail.com',
+            displayName: '에버다임 IT팀',
+            authType: 'oauth',
+            source: 'agent-store',
+            raw: {},
+            tokens: { refreshToken: 'rt' },
+          }],
+        },
+      },
+    });
+    const lines = await captureOutput(() =>
+      runAuthListCommand('claude', {
+        claudeReadFn: () => null,
+        loadStore: storeWithClaude,
+      })
+    );
+    const flat = lines.join('\n');
+    assert.ok(flat.includes('name       : 에버다임 IT팀'));
+  });
+
   it('authSource reflects agent-store when store has Claude accounts', async () => {
     const storeWithClaude = async () => ({
       providers: {

--- a/packages/agent/test/cli/login-runner.test.js
+++ b/packages/agent/test/cli/login-runner.test.js
@@ -1,7 +1,103 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseLoginOptions } from '../../src/cli/login-runner.js';
+import {
+  enrichIdentityFromProviderProfile,
+  parseLoginOptions,
+} from '../../src/cli/login-runner.js';
+
+describe('enrichIdentityFromProviderProfile', () => {
+  it('returns original identity for non-claude providers', async () => {
+    const identity = {
+      email: 'fallback@example.com',
+      accountId: null,
+      displayName: null,
+      claimSource: 'fallback:code-prefix',
+    };
+
+    const result = await enrichIdentityFromProviderProfile(
+      { id: 'codex' },
+      { accessToken: 'token-123' },
+      identity,
+    );
+
+    assert.equal(result.profile, null);
+    assert.deepEqual(result.identity, identity);
+  });
+
+  it('enriches Claude identity from oauth/profile', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      async json() {
+        return {
+          account: {
+            uuid: 'acct-123',
+            display_name: '에버다임 IT팀',
+            email: 'everdigm.itteam@gmail.com',
+          },
+          organization: { uuid: 'org-123' },
+          application: { uuid: 'app-123' },
+        };
+      },
+    });
+
+    try {
+      const result = await enrichIdentityFromProviderProfile(
+        { id: 'claude' },
+        { accessToken: 'token-123' },
+        {
+          email: 'live-abc@claude.com',
+          accountId: null,
+          displayName: null,
+          claimSource: 'fallback:code-prefix',
+        },
+      );
+
+      assert.equal(result.identity.email, 'everdigm.itteam@gmail.com');
+      assert.equal(result.identity.accountId, 'acct-123');
+      assert.equal(result.identity.displayName, '에버다임 IT팀');
+      assert.equal(result.identity.claimSource, 'profile');
+      assert.equal(result.profile.organization.uuid, 'org-123');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('keeps fallback identity when profile fetch fails', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      status: 403,
+      statusText: 'Forbidden',
+      ok: false,
+      async json() {
+        return { error: { message: 'missing scope' } };
+      },
+    });
+
+    const identity = {
+      email: 'live-abc@claude.com',
+      accountId: null,
+      displayName: null,
+      claimSource: 'fallback:code-prefix',
+    };
+
+    try {
+      const result = await enrichIdentityFromProviderProfile(
+        { id: 'claude' },
+        { accessToken: 'token-123' },
+        identity,
+      );
+
+      assert.equal(result.profile, null);
+      assert.deepEqual(result.identity, identity);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
 
 describe('parseLoginOptions — defaults & flags', () => {
   it('returns defaults for empty args', () => {

--- a/packages/agent/test/services/claude-account-spec.test.js
+++ b/packages/agent/test/services/claude-account-spec.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { claudeMapAccountToProfile } from '../../src/services/claude-account-spec.js';
+
+describe('claudeMapAccountToProfile', () => {
+  it('preserves account display metadata for formatter consumers', () => {
+    const profile = claudeMapAccountToProfile({
+      accountKey: 'anthropic-claude:acct-123',
+      accountId: 'acct-123',
+      email: 'everdigm.itteam@gmail.com',
+      displayName: '에버다임 IT팀',
+      label: 'work',
+      tokens: { accessToken: 'token-123' },
+    });
+
+    assert.equal(profile.id, 'anthropic-claude:acct-123');
+    assert.equal(profile.accountKey, 'anthropic-claude:acct-123');
+    assert.equal(profile.displayName, '에버다임 IT팀');
+    assert.equal(profile.email, 'everdigm.itteam@gmail.com');
+    assert.equal(profile.label, 'work');
+  });
+});

--- a/packages/agent/test/services/claude-provider.test.js
+++ b/packages/agent/test/services/claude-provider.test.js
@@ -107,11 +107,16 @@ describe('resolveClaudeProfileFromSnapshot (via claude-provider)', () => {
         accountKey: 'claude-cli-import',
         accessToken: 'sk-ant-cli',
         email: 'x@example.com',
+        displayName: 'Claude Import',
+        label: 'personal',
       },
     });
     assert.equal(profile.id, 'claude-cli-import');
+    assert.equal(profile.accountKey, 'claude-cli-import');
     assert.equal(profile.accessToken, 'sk-ant-cli');
     assert.equal(profile.email, 'x@example.com');
+    assert.equal(profile.displayName, 'Claude Import');
+    assert.equal(profile.label, 'personal');
   });
 
   it('extracts accessToken from tokens.accessToken (agent-store)', () => {

--- a/packages/provider-adapters/src/claude/fetch-claude-oauth-profile.js
+++ b/packages/provider-adapters/src/claude/fetch-claude-oauth-profile.js
@@ -1,0 +1,88 @@
+import { fetchWithTimeout } from '../shared/fetch-with-timeout.js';
+
+/**
+ * Claude OAuth profile endpoint (internal, unofficial).
+ * Best-effort only: callers must tolerate 401/403/404/429/5xx and schema drift.
+ */
+const DEFAULT_ENDPOINT = 'https://api.anthropic.com/api/oauth/profile';
+
+/**
+ * @param {{
+ *   accessToken: string,
+ *   endpoint?: string,
+ *   fetchImpl?: typeof fetch,
+ *   timeoutMs?: number,
+ * }} params
+ * @returns {Promise<{
+ *   account: object|null,
+ *   organization: object|null,
+ *   application: object|null,
+ *   email: string|null,
+ *   displayName: string|null,
+ *   accountId: string|null,
+ *   raw: object,
+ * }>} 
+ */
+export async function fetchClaudeOauthProfile({
+  accessToken,
+  endpoint = DEFAULT_ENDPOINT,
+  fetchImpl = fetch,
+  timeoutMs = 15_000,
+}) {
+  if (!accessToken) {
+    throw new Error('fetchClaudeOauthProfile: accessToken이 비어 있습니다.');
+  }
+
+  const res = await fetchWithTimeout(fetchImpl, endpoint, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'oauth-2025-04-20',
+      'User-Agent': 'ai-usage-agent',
+    },
+    timeoutMs,
+  });
+
+  let payload = null;
+  try {
+    payload = await res.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!res.ok) {
+    const message = payload?.error?.message
+      ?? payload?.error_description
+      ?? payload?.message
+      ?? res.statusText;
+    throw new Error(`Claude OAuth profile fetch failed: ${res.status} ${message}`);
+  }
+
+  const account = isRecord(payload?.account) ? payload.account : null;
+  const organization = isRecord(payload?.organization) ? payload.organization : null;
+  const application = isRecord(payload?.application) ? payload.application : null;
+
+  return {
+    account,
+    organization,
+    application,
+    email: readString(account?.email),
+    displayName: readString(account?.display_name)
+      ?? readString(account?.full_name)
+      ?? null,
+    accountId: readString(account?.uuid),
+    raw: isRecord(payload) ? payload : {},
+  };
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(value) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null;
+}

--- a/packages/provider-adapters/src/claude/index.js
+++ b/packages/provider-adapters/src/claude/index.js
@@ -23,3 +23,4 @@ export { refreshClaudeToken } from './refresh-claude-token.js';
 export { CLAUDE_AUTH } from './claude-auth-constants.js';
 export { buildClaudeAuthorizationUrl } from './build-claude-authorization-url.js';
 export { exchangeClaudeAuthorizationCode } from './exchange-claude-authorization-code.js';
+export { fetchClaudeOauthProfile } from './fetch-claude-oauth-profile.js';

--- a/packages/provider-adapters/test/claude/fetch-claude-oauth-profile.test.js
+++ b/packages/provider-adapters/test/claude/fetch-claude-oauth-profile.test.js
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchClaudeOauthProfile } from '../../src/claude/fetch-claude-oauth-profile.js';
+
+function jsonResponse({ status = 200, body = {} } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
+describe('fetchClaudeOauthProfile', () => {
+  it('parses account, organization, application and identity fields', async () => {
+    const fetchImpl = async () => jsonResponse({
+      body: {
+        account: {
+          uuid: 'acct-123',
+          display_name: '라군',
+          full_name: '이석호',
+          email: 'lagoon@example.com',
+        },
+        organization: {
+          uuid: 'org-123',
+          name: 'Lagoon Org',
+        },
+        application: {
+          uuid: 'app-123',
+          name: 'Claude Code',
+        },
+      },
+    });
+
+    const result = await fetchClaudeOauthProfile({
+      accessToken: 'token-123',
+      fetchImpl,
+    });
+
+    assert.equal(result.accountId, 'acct-123');
+    assert.equal(result.email, 'lagoon@example.com');
+    assert.equal(result.displayName, '라군');
+    assert.equal(result.organization.uuid, 'org-123');
+    assert.equal(result.application.name, 'Claude Code');
+  });
+
+  it('falls back to full_name when display_name is absent', async () => {
+    const fetchImpl = async () => jsonResponse({
+      body: {
+        account: {
+          uuid: 'acct-123',
+          full_name: '에버다임 IT팀',
+          email: 'everdigm@example.com',
+        },
+      },
+    });
+
+    const result = await fetchClaudeOauthProfile({ accessToken: 'token-123', fetchImpl });
+    assert.equal(result.displayName, '에버다임 IT팀');
+  });
+
+  it('throws descriptive error on non-2xx response', async () => {
+    const fetchImpl = async () => jsonResponse({
+      status: 403,
+      body: {
+        error: {
+          message: 'OAuth token does not meet scope requirement user:profile',
+        },
+      },
+    });
+
+    await assert.rejects(
+      () => fetchClaudeOauthProfile({ accessToken: 'token-123', fetchImpl }),
+      /403 .*user:profile/,
+    );
+  });
+
+  it('throws when accessToken is empty', async () => {
+    await assert.rejects(
+      () => fetchClaudeOauthProfile({ accessToken: '' }),
+      /accessToken이 비어/,
+    );
+  });
+});


### PR DESCRIPTION
## 요약

- Claude OAuth 로그인 직후 비공식 내부 endpoint `/api/oauth/profile`를 best-effort로 조회해 계정 metadata를 보강하도록 추가했습니다.
- token claims만으로는 `live-...@claude.com` fallback으로 저장되던 문제를 실제 `email/displayName/account.uuid` 저장으로 개선했습니다.
- 내부 endpoint 실패 시에는 기존 fallback 경로를 그대로 유지하도록 설계했습니다.

## 변경 내용

- Claude OAuth profile fetcher 추가 (`packages/provider-adapters/src/claude/fetch-claude-oauth-profile.js`)
- Claude live login 직후 profile enrichment 연결 및 raw profile metadata 저장
- auth list / status 출력에서 Claude `displayName` 노출 개선
- 관련 자동 테스트 추가 및 fallback 동작 검증

## 변경 이유

- 실측 결과 Claude OAuth token exchange 응답에는 `id_token`이 없고, access token도 JWT claims 디코드가 불가능해 현재 구현만으로는 실제 계정명을 복원할 수 없었습니다.
- 추가 확인 결과 동일 OAuth access token으로 `/api/oauth/profile` 호출 시 계정명, 이메일, account UUID, organization/application metadata를 얻을 수 있었습니다.
- 다만 해당 endpoint는 공식 공개 인터페이스가 아니므로 로그인 성공의 필수 경로가 아니라 **보강용 best-effort** 로만 사용하도록 제한했습니다.

## 영향 범위

- [x] `packages/agent`
- [ ] `packages/schemas`
- [x] `packages/provider-adapters`
- [ ] `repo`
- [ ] `docs`

## 스크린샷 / 데모

- 수동 검증 결과 Claude 재로그인 후 `identity source: profile`로 저장되었고, auth list에 `email=everdigm.itteam@gmail.com`, `name=에버다임 IT팀`이 표시되는 것을 확인했습니다.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인
- [ ] 필요한 문서 업데이트 반영
- [x] schema / provider / CLI 영향 범위를 직접 점검

## 리뷰 포인트

- Claude OAuth login 흐름에서 token claims → profile enrichment → fallback 순서가 안전하게 유지되는지
- 내부 endpoint 실패(401/403/404/429/5xx, schema drift) 시 로그인 성공 경로를 깨지 않는지
- account identity 우선순위와 legacy synthetic account 저장과의 상호작용이 적절한지

## 참고 사항

- `/api/oauth/profile`는 비공식 내부 endpoint라 향후 무력화 또는 응답 스키마 변경 가능성이 있습니다.
- 그래서 retry 없이 1회만 조회하고, 실패 시 기존 `fallback:code-prefix` 저장 경로를 유지합니다.
- 예전 synthetic Claude 계정 레코드 정리 정책은 별도 후속 작업으로 다룰 수 있습니다.
