### PR TITLE
[feat] usage/status 조회 시 OAuth access token 자동 refresh 추가

### DIFF
--- a/packages/agent/src/services/account-filter.js
+++ b/packages/agent/src/services/account-filter.js
@@ -19,3 +19,16 @@ export function filterProfilesByAccount(profiles, accountFilter) {
       || (p.label ?? '').toLowerCase() === needle,
   );
 }
+
+/**
+ * `{ account, profile }` entry 배열에 동일한 accountFilter 규칙 적용.
+ *
+ * @template T
+ * @param {{ account: object|null, profile: T }[]} entries
+ * @param {string|null|undefined} accountFilter
+ * @returns {{ account: object|null, profile: T }[]}
+ */
+export function filterEntriesByAccount(entries, accountFilter) {
+  if (!accountFilter) return entries;
+  return entries.filter((entry) => filterProfilesByAccount([entry.profile], accountFilter).length > 0);
+}

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -11,7 +11,7 @@ import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-c
 import { loadAuthStore } from '../auth/auth-store.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveProviderAccountEntries } from './provider-profile-resolver.js';
-import { filterProfilesByAccount } from './account-filter.js';
+import { filterEntriesByAccount, filterProfilesByAccount } from './account-filter.js';
 import { fetchUsageWithAutoRefresh } from './usage-auto-refresh.js';
 import { refreshClaudeToken } from '../../../provider-adapters/src/claude/refresh-claude-token.js';
 import { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
@@ -60,7 +60,7 @@ export async function getClaudeSnapshot(
 
   let entries;
   if (allAgentEntries.length > 0) {
-    entries = allAgentEntries;
+    entries = filterEntriesByAccount(allAgentEntries, options.accountFilter);
   } else {
     // cli-import fallback
     const single = resolveClaudeProfileFromSnapshot(base);

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -10,8 +10,11 @@ import { fetchClaudeUsage } from '../../../provider-adapters/src/claude/fetch-cl
 import { CLAUDE_AUTH } from '../../../provider-adapters/src/claude/claude-auth-constants.js';
 import { loadAuthStore } from '../auth/auth-store.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
-import { resolveProviderProfiles } from './provider-profile-resolver.js';
+import { resolveProviderAccountEntries } from './provider-profile-resolver.js';
 import { filterProfilesByAccount } from './account-filter.js';
+import { fetchUsageWithAutoRefresh } from './usage-auto-refresh.js';
+import { refreshClaudeToken } from '../../../provider-adapters/src/claude/refresh-claude-token.js';
+import { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
 import {
   filterClaudeRealAccounts,
   claudeMapAccountToProfile,
@@ -47,7 +50,7 @@ export async function getClaudeSnapshot(
 
   // Source 선택은 unfiltered 기준으로 먼저 결정.
   // accountFilter가 source precedence를 바꿔서는 안 된다.
-  const allAgentProfiles = await resolveProviderProfiles({
+  const allAgentEntries = await resolveProviderAccountEntries({
     providerId: CLAUDE_AUTH.storeProvider,
     filterFn: filterClaudeRealAccounts,
     mapFn: claudeMapAccountToProfile,
@@ -55,21 +58,20 @@ export async function getClaudeSnapshot(
     updateLastUsed: false,
   });
 
-  let profiles;
-  if (allAgentProfiles.length > 0) {
-    // agent-store 확정. 그 위에서 accountFilter 적용.
-    profiles = filterProfilesByAccount(allAgentProfiles, options.accountFilter);
+  let entries;
+  if (allAgentEntries.length > 0) {
+    entries = allAgentEntries;
   } else {
     // cli-import fallback
     const single = resolveClaudeProfileFromSnapshot(base);
     if (single && (!options.accountFilter || matchesFilter(single, options.accountFilter))) {
-      profiles = [single];
+      entries = [{ account: null, profile: single }];
     } else {
-      profiles = [];
+      entries = [];
     }
   }
 
-  if (profiles.length === 0) {
+  if (entries.length === 0) {
     return {
       ...base,
       networkUsages: [],
@@ -81,15 +83,19 @@ export async function getClaudeSnapshot(
 
   // 각 계정에 대해 병렬로 usage 조회. 한 계정이 실패해도 다른 계정은 유지.
   const settled = await Promise.all(
-    profiles.map(async (profile) => {
+    entries.map(async (entry) => {
       try {
-        const snapshot = await fetchClaudeUsage(profile);
-        return { accountKey: profile.id, account: profile, snapshot };
+        return await fetchUsageWithAutoRefresh(entry, {
+          fetchUsage: fetchClaudeUsage,
+          refreshToken: refreshClaudeToken,
+          updateStoreAfterRefresh: updateClaudeStoreAfterRefresh,
+          mapAccountToProfile: claudeMapAccountToProfile,
+        });
       } catch (error) {
         return {
-          accountKey: profile.id,
-          account: profile,
-          snapshot: createClaudeNetworkFailureSnapshot(profile, error),
+          accountKey: entry.profile.id,
+          account: entry.profile,
+          snapshot: createClaudeNetworkFailureSnapshot(entry.profile, error),
         };
       }
     }),

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -6,8 +6,11 @@ import {
 import { filterProfilesByAccount } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveAuthSource } from './auth-source-resolver.js';
-import { resolveProviderProfiles } from './provider-profile-resolver.js';
+import { resolveProviderAccountEntries } from './provider-profile-resolver.js';
 import { filterRealCodexAccounts, codexMapAccountToProfile } from './codex-account-spec.js';
+import { fetchUsageWithAutoRefresh } from './usage-auto-refresh.js';
+import { refreshCodexToken } from '../../../provider-adapters/src/codex/index.js';
+import { updateCodexStoreAfterRefresh } from '../auth/codex-refresh-store.js';
 
 const CODEX_PROVIDER_ID = 'openai-codex';
 
@@ -27,14 +30,21 @@ export async function getCodexSnapshot(config, options = {}) {
     };
   }
 
-  const { profiles, authSource } = await resolveCodexProfiles(options.accountFilter);
+  const { entries, authSource } = await resolveCodexProfiles(options.accountFilter);
   const snapshots = [];
 
-  for (const profile of profiles) {
+  for (const entry of entries) {
     try {
-      snapshots.push(await fetchCodexUsage(profile));
+      snapshots.push(
+        (await fetchUsageWithAutoRefresh(entry, {
+          fetchUsage: fetchCodexUsage,
+          refreshToken: refreshCodexToken,
+          updateStoreAfterRefresh: updateCodexStoreAfterRefresh,
+          mapAccountToProfile: codexMapAccountToProfile,
+        })).snapshot,
+      );
     } catch (error) {
-      snapshots.push(createCodexFailureSnapshot(profile, error));
+      snapshots.push(createCodexFailureSnapshot(entry.profile, error));
     }
   }
 
@@ -44,7 +54,7 @@ export async function getCodexSnapshot(config, options = {}) {
     authProfilesPath: authSource === 'openclaw-import' ? getDefaultAuthProfilesPath() : null,
     snapshots,
     accountFilter: options.accountFilter ?? null,
-    filteredOut: Boolean(options.accountFilter) && profiles.length === 0,
+    filteredOut: Boolean(options.accountFilter) && entries.length === 0,
   };
 }
 
@@ -67,17 +77,15 @@ export { filterRealCodexAccounts } from './codex-account-spec.js';
 async function resolveCodexProfiles(accountFilter) {
   // Source 선택은 unfiltered 기준으로 먼저 결정한다.
   // accountFilter가 source precedence를 바꿔서는 안 된다.
-  const allAgentProfiles = await resolveProviderProfiles({
+  const allAgentEntries = await resolveProviderAccountEntries({
     providerId: CODEX_PROVIDER_ID,
     filterFn: filterRealCodexAccounts,
     mapFn: codexMapAccountToProfile,
     accountFilter: null, // 필터 없이 전체 real 프로필 로드
   });
 
-  if (allAgentProfiles.length > 0) {
-    // agent-store 확정. 그 위에서 accountFilter 적용.
-    const filtered = filterProfilesByAccount(allAgentProfiles, accountFilter);
-    return { profiles: filtered, authSource: 'agent-store' };
+  if (allAgentEntries.length > 0) {
+    return { entries: allAgentEntries, authSource: 'agent-store' };
   }
 
   // Fallback: OpenClaw import
@@ -86,7 +94,10 @@ async function resolveCodexProfiles(accountFilter) {
   const { accounts, authSource } = resolveAuthSource([], [
     { id: 'openclaw-import', accounts: filtered },
   ]);
-  return { profiles: accounts, authSource };
+  return {
+    entries: accounts.map((profile) => ({ account: null, profile })),
+    authSource,
+  };
 }
 
 // codexMapAccountToProfile imported from codex-account-spec.js

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -3,7 +3,7 @@ import {
   getDefaultAuthProfilesPath,
   readCodexAuthProfiles,
 } from '../../../provider-adapters/src/codex/index.js';
-import { filterProfilesByAccount } from './account-filter.js';
+import { filterEntriesByAccount, filterProfilesByAccount } from './account-filter.js';
 import { buildUsageSnapshot } from '../../../provider-adapters/src/shared/usage-snapshot.js';
 import { resolveAuthSource } from './auth-source-resolver.js';
 import { resolveProviderAccountEntries } from './provider-profile-resolver.js';
@@ -85,7 +85,8 @@ async function resolveCodexProfiles(accountFilter) {
   });
 
   if (allAgentEntries.length > 0) {
-    return { entries: allAgentEntries, authSource: 'agent-store' };
+    const filteredEntries = filterEntriesByAccount(allAgentEntries, accountFilter);
+    return { entries: filteredEntries, authSource: 'agent-store' };
   }
 
   // Fallback: OpenClaw import

--- a/packages/agent/src/services/provider-profile-resolver.js
+++ b/packages/agent/src/services/provider-profile-resolver.js
@@ -24,6 +24,24 @@ import { filterProfilesByAccount } from './account-filter.js';
  * @returns {Promise<object[]>} - fetch에 넘길 profile 배열
  */
 export async function resolveProviderProfiles(spec) {
+  const entries = await resolveProviderAccountEntries(spec);
+  return entries.map((entry) => entry.profile);
+}
+
+/**
+ * resolveProviderProfiles와 동일한 흐름이지만 raw account + mapped profile을 함께 반환.
+ * refresh/store-update 같은 후속 처리가 필요한 provider 서비스에서 사용한다.
+ *
+ * @param {{
+ *   providerId: string,
+ *   filterFn: (accounts: object[]) => object[],
+ *   mapFn: (account: object) => object,
+ *   accountFilter?: string|null,
+ *   updateLastUsed?: boolean,
+ * }} spec
+ * @returns {Promise<Array<{ account: object, profile: object }>>}
+ */
+export async function resolveProviderAccountEntries(spec) {
   let store;
   try {
     store = await loadAuthStore();
@@ -52,6 +70,8 @@ export async function resolveProviderProfiles(spec) {
     }
   }
 
-  const profiles = realAccounts.map(spec.mapFn);
-  return filterProfilesByAccount(profiles, spec.accountFilter ?? null);
+  const entries = realAccounts.map((account) => ({ account, profile: spec.mapFn(account) }));
+  return entries.filter((entry) =>
+    filterProfilesByAccount([entry.profile], spec.accountFilter ?? null).length > 0,
+  );
 }

--- a/packages/agent/src/services/usage-auto-refresh.js
+++ b/packages/agent/src/services/usage-auto-refresh.js
@@ -1,0 +1,90 @@
+function getRefreshToken(account) {
+  return account?.tokens?.refreshToken ?? account?.refreshToken ?? null;
+}
+
+function getAccessToken(account) {
+  return account?.tokens?.accessToken ?? account?.accessToken ?? null;
+}
+
+function isExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const expiry = Date.parse(expiresAt);
+  if (Number.isNaN(expiry)) return false;
+  return expiry <= Date.now();
+}
+
+function mergeRefreshedAccount(account, tokenResponse) {
+  const now = new Date();
+  const expiresAt = tokenResponse.expiresIn
+    ? new Date(now.getTime() + tokenResponse.expiresIn * 1000).toISOString()
+    : account.expiresAt ?? null;
+
+  return {
+    ...account,
+    tokens: {
+      ...account.tokens,
+      accessToken: tokenResponse.accessToken,
+      refreshToken: tokenResponse.refreshToken ?? getRefreshToken(account),
+    },
+    accessToken: tokenResponse.accessToken,
+    refreshToken: tokenResponse.refreshToken ?? getRefreshToken(account),
+    expiresAt,
+  };
+}
+
+async function refreshEntry(entry, spec) {
+  if (!entry?.account) return entry;
+  const refreshToken = getRefreshToken(entry.account);
+  if (!refreshToken) return entry;
+
+  const tokenResponse = await spec.refreshToken({
+    refreshToken,
+    allowLiveExchange: true,
+  });
+  await spec.updateStoreAfterRefresh(entry.account, tokenResponse);
+
+  const refreshedAccount = mergeRefreshedAccount(entry.account, tokenResponse);
+  return {
+    account: refreshedAccount,
+    profile: spec.mapAccountToProfile(refreshedAccount),
+    refresh: {
+      attempted: true,
+      success: true,
+      reason: 'token_refreshed',
+    },
+  };
+}
+
+export async function fetchUsageWithAutoRefresh(entry, spec) {
+  let activeEntry = entry;
+  let refreshAttempted = false;
+
+  const canRefresh = Boolean(entry?.account && getRefreshToken(entry.account));
+  if (canRefresh && isExpired(entry.account.expiresAt)) {
+    activeEntry = await refreshEntry(entry, spec);
+    refreshAttempted = true;
+  }
+
+  let snapshot = await spec.fetchUsage(activeEntry.profile);
+  if (
+    canRefresh
+    && !refreshAttempted
+    && snapshot?.status?.bucket === 'auth'
+  ) {
+    activeEntry = await refreshEntry(activeEntry, spec);
+    snapshot = await spec.fetchUsage(activeEntry.profile);
+  }
+
+  return {
+    accountKey: activeEntry.profile.accountKey ?? activeEntry.profile.id,
+    account: activeEntry.profile,
+    snapshot,
+  };
+}
+
+export const __testables = {
+  isExpired,
+  getRefreshToken,
+  getAccessToken,
+  mergeRefreshedAccount,
+};

--- a/packages/agent/test/services/claude-provider.test.js
+++ b/packages/agent/test/services/claude-provider.test.js
@@ -8,6 +8,7 @@ import {
   getClaudeSnapshot,
   filterProfilesByAccount,
 } from '../../src/services/claude-provider.js';
+import { filterEntriesByAccount } from '../../src/services/account-filter.js';
 
 const FAKE_PATH = '/tmp/fake-claude-credentials.json';
 
@@ -143,6 +144,20 @@ describe('getClaudeSnapshot — disabled config contract', () => {
     assert.equal(snap.networkUsage, null);
     assert.deepEqual(snap.networkUsages, []);
     assert.ok(typeof snap.authSource === 'string');
+  });
+});
+
+describe('filterEntriesByAccount (claude-provider)', () => {
+  it('filters agent-store entry arrays by mapped profile fields', () => {
+    const entries = [
+      { account: { accountKey: 'a' }, profile: { id: 'anthropic-claude:a', email: 'a@x.com', label: 'work' } },
+      { account: { accountKey: 'b' }, profile: { id: 'anthropic-claude:b', email: 'b@x.com', label: 'personal' } },
+    ];
+
+    assert.equal(filterEntriesByAccount(entries, 'anthropic-claude:a').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'B@X.COM').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'personal').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'nope').length, 0);
   });
 });
 

--- a/packages/agent/test/services/codex-provider.test.js
+++ b/packages/agent/test/services/codex-provider.test.js
@@ -7,6 +7,7 @@ import {
   filterRealCodexAccounts,
   filterProfilesByAccount,
 } from '../../src/services/codex-provider.js';
+import { filterEntriesByAccount } from '../../src/services/account-filter.js';
 
 // ── pure helpers ─────────────────────────────────────────────────────────────
 // selectCodexAuthSource / filterRealCodexAccounts는 순수 함수로 이미 일부
@@ -100,6 +101,20 @@ describe('filterProfilesByAccount', () => {
 
   it('returns empty array when no match', () => {
     assert.deepEqual(filterProfilesByAccount(profiles, 'nope'), []);
+  });
+});
+
+describe('filterEntriesByAccount', () => {
+  it('filters entry arrays by profile id/email/label', () => {
+    const entries = [
+      { account: { accountKey: 'a' }, profile: { id: 'openai-codex:a', email: 'a@x.com', label: 'work' } },
+      { account: { accountKey: 'b' }, profile: { id: 'openai-codex:b', email: 'b@x.com', label: 'personal' } },
+    ];
+
+    assert.equal(filterEntriesByAccount(entries, 'openai-codex:a').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'B@X.COM').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'personal').length, 1);
+    assert.equal(filterEntriesByAccount(entries, 'nope').length, 0);
   });
 });
 

--- a/packages/agent/test/services/usage-auto-refresh.test.js
+++ b/packages/agent/test/services/usage-auto-refresh.test.js
@@ -140,4 +140,20 @@ describe('fetchUsageWithAutoRefresh', () => {
     assert.deepEqual(calls, ['fetch']);
     assert.equal(result.snapshot.status.bucket, 'auth');
   });
+
+  it('surfaces refresh failure when an expired account cannot be refreshed', async () => {
+    await assert.rejects(
+      () => fetchUsageWithAutoRefresh(
+        makeEntry({
+          account: { expiresAt: '2000-01-01T00:00:00.000Z' },
+        }),
+        makeSpec({
+          refreshToken: async () => {
+            throw new Error('invalid_grant');
+          },
+        }),
+      ),
+      /invalid_grant/,
+    );
+  });
 });

--- a/packages/agent/test/services/usage-auto-refresh.test.js
+++ b/packages/agent/test/services/usage-auto-refresh.test.js
@@ -1,0 +1,143 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  __testables,
+  fetchUsageWithAutoRefresh,
+} from '../../src/services/usage-auto-refresh.js';
+
+function makeEntry(overrides = {}) {
+  const account = {
+    accountKey: 'acct-1',
+    expiresAt: null,
+    tokens: {
+      accessToken: 'old-at',
+      refreshToken: 'rt-1',
+    },
+    ...overrides.account,
+  };
+  return {
+    account,
+    profile: {
+      id: account.accountKey,
+      accountKey: account.accountKey,
+      accessToken: account.tokens?.accessToken ?? account.accessToken,
+      email: 'user@example.com',
+      ...overrides.profile,
+    },
+  };
+}
+
+function makeSpec(overrides = {}) {
+  return {
+    fetchUsage: async (profile) => ({
+      account: { profileId: profile.id },
+      status: { bucket: 'ok', ok: true },
+    }),
+    refreshToken: async () => ({
+      accessToken: 'new-at',
+      refreshToken: 'new-rt',
+      expiresIn: 3600,
+    }),
+    updateStoreAfterRefresh: async () => ({ accountKey: 'acct-1', expiresAt: null }),
+    mapAccountToProfile: (account) => ({
+      id: account.accountKey,
+      accountKey: account.accountKey,
+      accessToken: account.tokens.accessToken,
+      email: 'user@example.com',
+    }),
+    ...overrides,
+  };
+}
+
+describe('usage-auto-refresh helpers', () => {
+  it('treats past expiresAt as expired', () => {
+    assert.equal(__testables.isExpired('2000-01-01T00:00:00.000Z'), true);
+  });
+
+  it('treats future expiresAt as not expired', () => {
+    assert.equal(__testables.isExpired('2999-01-01T00:00:00.000Z'), false);
+  });
+});
+
+describe('fetchUsageWithAutoRefresh', () => {
+  it('refreshes before fetch when access token is already expired', async () => {
+    const calls = [];
+    const result = await fetchUsageWithAutoRefresh(
+      makeEntry({
+        account: { expiresAt: '2000-01-01T00:00:00.000Z' },
+      }),
+      makeSpec({
+        refreshToken: async () => {
+          calls.push('refresh');
+          return { accessToken: 'new-at', refreshToken: 'new-rt', expiresIn: 3600 };
+        },
+        updateStoreAfterRefresh: async () => {
+          calls.push('store');
+          return { accountKey: 'acct-1', expiresAt: null };
+        },
+        fetchUsage: async (profile) => {
+          calls.push(`fetch:${profile.accessToken}`);
+          return { status: { bucket: 'ok', ok: true } };
+        },
+      }),
+    );
+
+    assert.deepEqual(calls, ['refresh', 'store', 'fetch:new-at']);
+    assert.equal(result.account.accessToken, 'new-at');
+  });
+
+  it('refreshes once after auth failure and retries fetch', async () => {
+    const calls = [];
+    let attempt = 0;
+    const result = await fetchUsageWithAutoRefresh(
+      makeEntry(),
+      makeSpec({
+        fetchUsage: async (profile) => {
+          attempt += 1;
+          calls.push(`fetch:${attempt}:${profile.accessToken}`);
+          if (attempt === 1) return { status: { bucket: 'auth', ok: false } };
+          return { status: { bucket: 'ok', ok: true } };
+        },
+        refreshToken: async () => {
+          calls.push('refresh');
+          return { accessToken: 'new-at', refreshToken: 'new-rt', expiresIn: 3600 };
+        },
+        updateStoreAfterRefresh: async () => {
+          calls.push('store');
+          return { accountKey: 'acct-1', expiresAt: null };
+        },
+      }),
+    );
+
+    assert.deepEqual(calls, ['fetch:1:old-at', 'refresh', 'store', 'fetch:2:new-at']);
+    assert.equal(result.snapshot.status.bucket, 'ok');
+  });
+
+  it('does not attempt refresh for import entries without raw account', async () => {
+    const calls = [];
+    const result = await fetchUsageWithAutoRefresh(
+      {
+        account: null,
+        profile: {
+          id: 'import-1',
+          accountKey: 'import-1',
+          accessToken: 'import-at',
+        },
+      },
+      makeSpec({
+        fetchUsage: async () => {
+          calls.push('fetch');
+          return { status: { bucket: 'auth', ok: false } };
+        },
+        refreshToken: async () => {
+          calls.push('refresh');
+          return { accessToken: 'new-at', refreshToken: 'new-rt', expiresIn: 3600 };
+        },
+      }),
+    );
+
+    assert.deepEqual(calls, ['fetch']);
+    assert.equal(result.snapshot.status.bucket, 'auth');
+  });
+});


### PR DESCRIPTION
## 요약

- Codex/Claude usage,status 조회 시 만료된 access token을 자동으로 refresh하는 공통 orchestration을 추가했습니다.
- `expiresAt` 기반 사전 refresh와 401 auth 실패 후 1회 refresh 재시도를 지원합니다.
- refresh 성공 시 agent-store를 갱신하고, 실패한 계정은 다른 계정 조회를 깨지 않도록 개별 실패로 남깁니다.

## 변경 내용

- provider 공통 계층 `usage-auto-refresh.js` 추가
- `resolveProviderProfiles` 확장: raw account + mapped profile을 함께 다루는 entry resolver 추가
- Codex usage 경로에 자동 refresh 연결
- Claude usage 경로에 자동 refresh 연결
- auto-refresh 성공/재시도/실패 케이스 테스트 추가

## 변경 이유

- 기존에는 Codex/Claude 모두 refresh 기능은 있었지만 `usage` / `status` 조회 중에는 자동 refresh가 수행되지 않았습니다.
- 그래서 access token이 만료되면 실시간 usage 조회가 바로 401로 실패했고, 사용자는 수동으로 `doctor ... --refresh-live`를 실행해야 했습니다.
- 이번 변경은 이 refresh 흐름을 공통 orchestration으로 끌어올려 provider별 중복 구현 없이 재사용 가능하게 만드는 데 목적이 있습니다.

## 영향 범위

- [x] `packages/agent`
- [ ] `packages/schemas`
- [x] `packages/provider-adapters`
- [ ] `repo`
- [ ] `docs`

## 스크린샷 / 데모

- 수동 검증에서 만료된 Claude 계정이 `usage` 조회 중 자동 refresh 후 `api/oauth/usage` 200으로 복구되는 것을 확인했습니다.
- refresh token이 이미 무효인 계정은 provider 호출 전 refresh 실패 메시지로 개별 실패 처리되는 것도 확인했습니다.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인
- [ ] 필요한 문서 업데이트 반영
- [x] schema / provider / CLI 영향 범위를 직접 점검

## 리뷰 포인트

- 공통 auto-refresh orchestration이 Codex/Claude 양쪽에서 동일한 계약으로 동작하는지
- `expiresAt` preflight refresh와 401 후 1회 재시도 정책이 과도한 재시도 없이 안전한지
- multi-account 조회에서 한 계정 refresh 실패가 전체 snapshot 구성을 깨지 않는지
- import source(`account: null`)는 refresh 대상에서 제외되는 정책이 적절한지

## 참고 사항

- 현재 자동 refresh는 `usage/status` 조회 경로에 우선 적용했습니다.
- refresh token 자체가 무효인 계정은 자동 복구되지 않으며, 이 경우 기존처럼 개별 auth failure로 남습니다.
- 이번 PR은 공통 orchestration 도입이 중심이라, 후속으로 메시지/상태 표기를 더 다듬을 여지는 있습니다.
