### PR TITLE
[docs] usage 자동 refresh 정책 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ npm run agent:config:init
   - `status --account <email | accountKey | label>`로 필터
   - `config.json defaults.profiles.{provider}`로 기본 필터 지정
 - refresh token rotation 반영
+- usage/status 자동 refresh orchestration
+  - `expiresAt` 기준으로 이미 만료된 agent-store 계정은 provider 호출 전에 preflight refresh 시도
+  - 첫 usage 호출 결과가 `status.bucket === 'auth'`면 refresh 후 1회만 재시도
+  - import/fallback source(`openclaw-import`, `claude-cli-import`)는 자동 refresh 대상에서 제외
+  - refresh 실패는 해당 계정 단위 실패로 남기고 다른 계정 조회는 계속 진행
 - `--live-exchange` guard (실수로 실제 token 호출이 반복되는 것 방지)
 - network 호출 timeout/abort (기본 15초, `fetchWithTimeout`)
 - CLI / status-service / provider adapter 3계층 분리
@@ -73,6 +78,12 @@ ai-usage-agent status --account <email | accountKey | label>  # 특정 계정만
 
 provider별 credential 상태, 선택된 계정, live usage window, 로컬 캐시 요약을 출력한다.
 한 provider에 여러 계정이 저장되어 있으면 기본은 모두 병렬 조회.
+
+자동 refresh 정책:
+- agent-store 계정에서 `expiresAt`이 이미 지난 access token은 provider 호출 전에 먼저 refresh를 시도한다.
+- 첫 provider 응답이 인증성 실패(`status.bucket === 'auth'`)로 분류되면 refresh 후 1회만 다시 시도한다.
+- import source 계정은 store 갱신 경로가 없으므로 자동 refresh하지 않는다.
+- `--account` / config 기반 계정 필터는 source 선택 이후에도 다시 적용된다.
 
 ### auth
 

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -74,6 +74,18 @@ provider별 callback path:
 - 로그에 access/refresh token 출력 금지
 - raw provider 응답에서 민감 auth 값 저장 금지
 
+## Usage/status 자동 refresh 흐름
+
+`status` / `usage`는 단순 조회만 하지 않고, agent-store 계정에 대해서는 공통 auto-refresh orchestration을 거친다.
+
+1. provider별 account/source 후보를 수집한다.
+2. auth source 우선순위는 unfiltered 기준으로 결정한다.
+3. 실제 조회 대상은 선택된 source 위에 `--account` / config 필터를 다시 적용한다.
+4. agent-store 계정의 `expiresAt`이 이미 만료되었으면 provider 호출 전에 preflight refresh를 시도한다.
+5. 첫 usage 호출 결과가 인증성 실패(`status.bucket === 'auth'`)면 refresh 후 1회만 재시도한다.
+6. refresh 실패는 해당 계정 단위 실패로 남기고, 다른 계정 조회는 계속 진행한다.
+7. import source(`openclaw-import`, `claude-cli-import`)는 store 갱신 경로가 없으므로 자동 refresh 대상에서 제외한다.
+
 ## Provider adapter 역할
 
 auth broker는 공통이지만, provider별 전략은 adapter가 정의한다:

--- a/docs/auth-cli.md
+++ b/docs/auth-cli.md
@@ -88,6 +88,8 @@ ai-usage-agent doctor claude --refresh-live --account <id>  # 특정 계정 지�
 - live usage endpoint 응답 요약
 - `--refresh-live` 시 실제 refresh 호출 + 결과 표시
 
+`doctor --refresh-live`는 수동 진단/검증용 경로다. `status` / `usage`의 자동 refresh와는 별도로 동작한다.
+
 ## Guard 정책 (`allowLiveExchange`)
 
 - `exchangeCodexAuthorizationCode`, `refreshCodexToken`, `exchangeClaudeAuthorizationCode`, `refreshClaudeToken` 모두 기본 guarded
@@ -108,6 +110,15 @@ guard를 해제할 시점:
 - `--port` 명시 시 해당 포트만 시도, 실패 시 에러
 
 Claude는 동일한 `resolveCallbackPort` 로직을 사용하되 callback path가 다르다.
+
+## status / usage 자동 refresh 정책
+
+- 대상은 **agent-store real account**만이다.
+- `expiresAt`이 이미 지난 access token은 provider 호출 전에 preflight refresh를 먼저 시도한다.
+- 첫 provider 응답이 인증성 실패(`status.bucket === 'auth'`)로 정규화되면 refresh 후 1회만 다시 시도한다.
+- refresh 실패는 해당 계정의 usage 실패로 남고, 다른 계정 조회는 계속 진행한다.
+- import source(`openclaw-import`, `claude-cli-import`)는 store 갱신 경로가 없으므로 자동 refresh 대상에서 제외한다.
+- source precedence는 unfiltered 기준으로 먼저 결정하고, 실제 조회 대상은 선택된 source 위에 `--account` / config 필터를 다시 적용한다.
 
 ## Multi-account 정책
 

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -180,7 +180,8 @@ packages/agent/src/services/
 ├── provider-registry.js           PROVIDER_REGISTRY + runProviderSnapshots
 ├── auth-source-resolver.js        공통 auth source 우선순위 결정
 ├── provider-profile-resolver.js   공통 "store → filter → map → accountFilter" runner
-├── account-filter.js              filterProfilesByAccount (id/email/label 매치)
+├── account-filter.js              filterProfilesByAccount / filterEntriesByAccount
+├── usage-auto-refresh.js          preflight refresh + auth bucket 재시도 orchestration
 ├── codex-provider.js              Codex snapshot + provider spec
 └── claude-provider.js             Claude snapshot + provider spec
 ```
@@ -210,6 +211,12 @@ resolveAuthSource(agentAccounts, [
 ```
 공통 함수: `auth-source-resolver.js::resolveAuthSource`
 우선순위: agent-store > 첫 번째 비어있지 않은 import source > not-found
+
+중요한 규칙:
+- source precedence는 **unfiltered 계정 집합** 기준으로 먼저 결정한다.
+- 실제 usage/status 조회 대상은 **선택된 source 위에 `accountFilter`를 다시 적용한 결과**를 사용한다.
+- agent-store 계정에 대해서만 `usage-auto-refresh.js`가 preflight refresh와 `auth` bucket 재시도를 담당한다.
+- import source는 store를 갱신할 수 없으므로 자동 refresh 대상이 아니다.
 
 ### 4.2 Provider spec (registry용)
 


### PR DESCRIPTION
## 요약

- `status` / `usage`의 OAuth access token 자동 refresh 정책을 README와 auth 관련 문서에 반영했습니다.
- `doctor --refresh-live`의 수동 진단 경로와, usage/status의 자동 refresh orchestration을 구분해서 설명했습니다.
- source precedence와 accountFilter 재적용 규칙도 함께 문서화했습니다.

## 변경 내용

- `README.md`
  - usage/status 자동 refresh 정책 추가
  - import source 자동 refresh 제외 규칙 추가
  - source 선택 후 accountFilter 재적용 규칙 추가
- `docs/auth-cli.md`
  - `doctor --refresh-live`와 자동 refresh 경로의 역할 차이 명시
  - status/usage 자동 refresh 정책 섹션 추가
- `docs/auth-architecture.md`
  - usage/status auto-refresh 흐름 추가
- `docs/codebase-guide.md`
  - `usage-auto-refresh.js`와 관련 서비스 계층 규칙 반영

## 변경 이유

- PR #57에서 usage/status 경로에 공통 auto-refresh orchestration이 추가됐는데, 사용자 문서와 내부 구조 문서에는 그 정책이 아직 반영되지 않았습니다.
- 특히 `401 전용 재시도`처럼 좁게 읽히는 설명 대신, 실제 구현 기준인 `auth` bucket 재시도 정책과 import source 제외 규칙을 명확히 남길 필요가 있었습니다.
- 또한 리뷰 과정에서 중요하게 확인된 "source precedence는 unfiltered 기준, 실제 조회는 선택된 source에 filter 재적용" 규칙도 문서에 남겨두는 편이 안전합니다.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `repo`
- [x] `docs`

## 스크린샷 / 데모

- 없음

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인
- [x] 필요한 문서 업데이트 반영
- [x] schema / provider / CLI 영향 범위를 직접 점검

추가 확인:
- `git diff -- README.md docs/auth-cli.md docs/auth-architecture.md docs/codebase-guide.md`

## 리뷰 포인트

- 자동 refresh 정책 설명이 현재 구현(`preflight refresh` + `auth bucket` 1회 재시도)과 일치하는지
- `doctor --refresh-live`와 `status` / `usage` 자동 refresh의 역할 구분이 충분히 명확한지
- README / auth 문서 / codebase guide 사이 설명이 과하게 중복되거나 어긋나는 부분이 없는지

## 참고 사항

- 이 PR은 문서 보강만 포함하며 런타임 동작 변경은 없습니다.
- 관련 구현 변경은 이미 머지된 PR #57에서 반영되었습니다.
