### PR TITLE
[refactor] CLI option parser 공통화

### DIFF
--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -291,6 +291,40 @@ Provider spec shape(`LoginProviderSpec`):
 
 호출자는 `options.warnings.length > 0`이면 stderr로 출력 후 조기 리턴한다 (`auth-login-command.js::reportAndGuardOptionWarnings` 참고).
 
+### 5.3 공통 option parser
+
+모든 CLI 파서(`parseLoginOptions`, `parseStatusOptions`, `parseLogoutOptions`,
+`parseDoctorClaudeOptions`, `parseDoctorCodexOptions`)는 스펙 기반 공통 헬퍼
+`cli/parse-options.js::parseCliOptions`를 사용한다. 각 커맨드는 `defaults` 객체와
+`flags` 스펙 맵만 선언하면 된다.
+
+```js
+import { parseCliOptions } from './parse-options.js';
+
+export function parseStatusOptions(args) {
+  return parseCliOptions(args, {
+    defaults: { account: null },
+    flags: { '--account': { key: 'account', type: 'string' } },
+  });
+}
+```
+
+플래그 타입: `boolean` / `string` / `int`. 부가 속성:
+- `trim` (string): 값을 trim하고 빈 문자열이면 skip. `emptyMessage` 있으면 warning.
+- `validate` (int): 범위/부호 검증. 실패 시 default 유지.
+- `transform` (int): 유효 값을 다른 단위로 변환 (e.g. `(n) => n * 1000`).
+- `invalidMessage` (int): 실패 시 warnings에 push. `${value}`는 입력 원문으로 치환.
+
+규약:
+- unknown flag는 silent skip (호출자 관점에서 기존 동작 유지).
+- `collectWarnings: true`일 때만 반환 객체에 `warnings: []`가 추가된다.
+  warnings가 필요 없는 파서(`status`, `logout`, `doctor`)는 이 플래그를 생략한다.
+- 값이 뒤따르지 않는 value flag(`--account` 뒤에 값 없음)도 silent skip — warning을 쌓지 않는다.
+
+새 플래그를 추가할 때는 가능한 이 헬퍼의 스펙으로 표현하고, 표현이 어려우면
+헬퍼를 확장(타입/옵션 추가)하는 쪽으로 결정한다. 커맨드별 임시 switch 문으로
+되돌리지 말 것.
+
 ---
 
 ## 6. Auth store / credential 처리

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -320,6 +320,10 @@ export function parseStatusOptions(args) {
 - `collectWarnings: true`일 때만 반환 객체에 `warnings: []`가 추가된다.
   warnings가 필요 없는 파서(`status`, `logout`, `doctor`)는 이 플래그를 생략한다.
 - 값이 뒤따르지 않는 value flag(`--account` 뒤에 값 없음)도 silent skip — warning을 쌓지 않는다.
+- `type:'string'` + `trim` 미지정인 플래그에서 값이 빈 문자열("")이면
+  레거시 파서(`if (value)`)와 동일하게 "값 없음"으로 간주해 assign/consume을
+  모두 하지 않는다. 반대로 `trim:true`는 emptyMessage warning을 쌓을 수 있으므로
+  consume한다 (예: `--label`).
 
 새 플래그를 추가할 때는 가능한 이 헬퍼의 스펙으로 표현하고, 표현이 어려우면
 헬퍼를 확장(타입/옵션 추가)하는 쪽으로 결정한다. 커맨드별 임시 switch 문으로

--- a/packages/agent/src/cli/auth-logout-command.js
+++ b/packages/agent/src/cli/auth-logout-command.js
@@ -1,5 +1,6 @@
 import { loadAuthStore, saveAuthStore, removeProviderAccount } from '../auth/auth-store.js';
 import { resolveAccount } from '../auth/account-resolver.js';
+import { parseCliOptions } from './parse-options.js';
 
 /**
  * `ai-usage-agent auth logout <provider> [--account <id>]`
@@ -61,12 +62,10 @@ export async function runAuthLogoutCommand(provider, args) {
 }
 
 function parseLogoutOptions(args) {
-  const options = { account: null };
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--account' && args[i + 1]) {
-      options.account = args[i + 1];
-      i += 1;
-    }
-  }
-  return options;
+  return parseCliOptions(args, {
+    defaults: { account: null },
+    flags: {
+      '--account': { key: 'account', type: 'string' },
+    },
+  });
 }

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -17,6 +17,13 @@ import {
 } from './doctor-codex-helpers.js';
 import { updateCodexStoreAfterRefresh } from '../auth/codex-refresh-store.js';
 import { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
+import { parseCliOptions } from './parse-options.js';
+
+const DOCTOR_FLAGS = {
+  '--refresh-live': { key: 'refreshLive', type: 'boolean' },
+  '--account': { key: 'account', type: 'string' },
+};
+const DOCTOR_DEFAULTS = { refreshLive: false, account: null };
 
 // 기존 import 경로 호환 re-export.
 export { formatClaudeSection };
@@ -147,17 +154,7 @@ export async function resolveClaudeRefreshTargetAccount(snapshot, accountIdentif
 }
 
 export function parseDoctorClaudeOptions(args) {
-  const options = { refreshLive: false, account: null };
-  const list = args ?? [];
-  for (let i = 0; i < list.length; i += 1) {
-    const arg = list[i];
-    if (arg === '--refresh-live') options.refreshLive = true;
-    else if (arg === '--account') {
-      const value = list[i + 1];
-      if (value) { options.account = value; i += 1; }
-    }
-  }
-  return options;
+  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS });
 }
 
 // ─── Codex ─────────────────────────────────────────────────────────────────
@@ -233,14 +230,5 @@ async function resolveCodexDoctorAccount(options) {
 }
 
 function parseDoctorCodexOptions(args) {
-  const options = { refreshLive: false, account: null };
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (arg === '--refresh-live') options.refreshLive = true;
-    if (arg === '--account') {
-      const value = args[i + 1];
-      if (value) { options.account = value; i += 1; }
-    }
-  }
-  return options;
+  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS });
 }

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -12,6 +12,7 @@ import { createAccount } from '../auth/auth-store-schema.js';
 import { extractAccountIdentity } from '../auth/token-claims.js';
 import { findLegacyDuplicates } from '../auth/find-legacy-duplicates.js';
 import { fetchClaudeOauthProfile } from '../../../provider-adapters/src/claude/fetch-claude-oauth-profile.js';
+import { parseCliOptions } from './parse-options.js';
 
 /**
  * Provider spec shape used by runOAuthLoginFlow.
@@ -273,79 +274,48 @@ export async function enrichIdentityFromProviderProfile(spec, tokenResponse, ide
   }
 }
 
+const LOGIN_DEFAULTS = {
+  noOpen: false,
+  manual: false,
+  device: false,
+  liveExchange: false,
+  port: null,
+  timeoutMs: 120_000,
+  label: null,
+  keepLegacy: false,
+};
+
+const LOGIN_FLAGS = {
+  '--no-open': { key: 'noOpen', type: 'boolean' },
+  '--manual': { key: 'manual', type: 'boolean' },
+  '--device': { key: 'device', type: 'boolean' },
+  '--live-exchange': { key: 'liveExchange', type: 'boolean' },
+  '--keep-legacy': { key: 'keepLegacy', type: 'boolean' },
+  '--port': {
+    key: 'port',
+    type: 'int',
+    validate: (n) => n >= 0 && n <= 65535,
+    invalidMessage: '--port 값 "${value}"이(가) 유효하지 않습니다. 정수 0~65535 범위로 지정해 주세요.',
+  },
+  '--timeout': {
+    key: 'timeoutMs',
+    type: 'int',
+    validate: (n) => n > 0,
+    transform: (n) => n * 1000,
+    invalidMessage: '--timeout 값 "${value}"이(가) 유효하지 않습니다. 양의 정수(초)로 지정해 주세요.',
+  },
+  '--label': {
+    key: 'label',
+    type: 'string',
+    trim: true,
+    emptyMessage: '--label 값이 비어 있습니다.',
+  },
+};
+
 export function parseLoginOptions(args) {
-  const options = {
-    noOpen: false,
-    manual: false,
-    device: false,
-    liveExchange: false,
-    port: null,
-    timeoutMs: 120_000,
-    label: null,
-    keepLegacy: false,
-    warnings: [],
-  };
-
-  for (let index = 0; index < (args ?? []).length; index += 1) {
-    const arg = args[index];
-    if (arg === '--no-open') options.noOpen = true;
-    else if (arg === '--manual') options.manual = true;
-    else if (arg === '--device') options.device = true;
-    else if (arg === '--live-exchange') options.liveExchange = true;
-    else if (arg === '--keep-legacy') options.keepLegacy = true;
-    else if (arg === '--port') {
-      const value = args[index + 1];
-      if (value !== undefined) {
-        const parsed = parsePortValue(value);
-        if (parsed === null) {
-          options.warnings.push(
-            `--port 값 "${value}"이(가) 유효하지 않습니다. 정수 0~65535 범위로 지정해 주세요.`,
-          );
-        } else {
-          options.port = parsed;
-        }
-        index += 1;
-      }
-    } else if (arg === '--timeout') {
-      const value = args[index + 1];
-      if (value !== undefined) {
-        const parsed = parseTimeoutSeconds(value);
-        if (parsed === null) {
-          options.warnings.push(
-            `--timeout 값 "${value}"이(가) 유효하지 않습니다. 양의 정수(초)로 지정해 주세요.`,
-          );
-        } else {
-          options.timeoutMs = parsed * 1000;
-        }
-        index += 1;
-      }
-    } else if (arg === '--label') {
-      const value = args[index + 1];
-      if (value !== undefined) {
-        const trimmed = String(value).trim();
-        if (trimmed.length === 0) {
-          options.warnings.push('--label 값이 비어 있습니다.');
-        } else {
-          options.label = trimmed;
-        }
-        index += 1;
-      }
-    }
-  }
-
-  return options;
-}
-
-function parsePortValue(raw) {
-  const n = Number(raw);
-  if (!Number.isInteger(n)) return null;
-  if (n < 0 || n > 65535) return null;
-  return n;
-}
-
-function parseTimeoutSeconds(raw) {
-  const n = Number(raw);
-  if (!Number.isInteger(n)) return null;
-  if (n <= 0) return null;
-  return n;
+  return parseCliOptions(args, {
+    defaults: LOGIN_DEFAULTS,
+    flags: LOGIN_FLAGS,
+    collectWarnings: true,
+  });
 }

--- a/packages/agent/src/cli/parse-options.js
+++ b/packages/agent/src/cli/parse-options.js
@@ -48,6 +48,12 @@ export function parseCliOptions(args, spec) {
 
     const value = list[i + 1];
     if (value === undefined) continue;
+
+    // 레거시 파서(status/logout/doctor) 호환: `type:'string'` + `trim` 미지정이면
+    // 빈 문자열("")은 "값 없음"으로 간주하여 assign/consume 모두 하지 않는다.
+    // trim=true 쪽은 빈 값에도 emptyMessage warning을 push할 수 있으므로 consume한다.
+    if (flagSpec.type === 'string' && !flagSpec.trim && value === '') continue;
+
     i += 1;
 
     if (flagSpec.type === 'string') {

--- a/packages/agent/src/cli/parse-options.js
+++ b/packages/agent/src/cli/parse-options.js
@@ -1,0 +1,88 @@
+/**
+ * Spec-based CLI option parser.
+ *
+ * 각 커맨드의 파서는 defaults + flags 스펙만 선언하면 되도록 공통 루프를 분리한다.
+ * 기존 parser(parseLoginOptions, parseStatusOptions 등)의 외부 계약을 보존하기 위해
+ * - unknown flag: silent skip
+ * - value-consuming flag에 값이 없으면: silent skip (warning 없음)
+ * - 유효하지 않은 int/trim-empty string: 값은 default 유지, warnings 수집은 opt-in
+ * 규약을 따른다.
+ *
+ * @typedef {object} FlagSpec
+ * @property {string} key
+ *   결과 객체에 값을 저장할 필드명.
+ * @property {'boolean'|'string'|'int'} type
+ * @property {boolean} [trim]
+ *   type='string'일 때 값을 trim. 결과가 빈 문자열이면 skip (emptyMessage가 있으면 warning 수집).
+ * @property {(n: number) => boolean} [validate]
+ *   type='int'일 때 추가 유효성 검증. 실패 시 값은 default 유지.
+ * @property {(n: number) => unknown} [transform]
+ *   type='int'에서 유효 값을 변환 (e.g. seconds → ms).
+ * @property {string} [invalidMessage]
+ *   int 유효성 실패 시 warnings에 push할 메시지. `${value}` placeholder를 입력 문자열로 치환.
+ * @property {string} [emptyMessage]
+ *   trim=true에서 빈 문자열이 들어왔을 때 warning 메시지.
+ *
+ * @param {string[]|null|undefined} args
+ * @param {{
+ *   defaults: Record<string, unknown>,
+ *   flags: Record<string, FlagSpec>,
+ *   collectWarnings?: boolean,
+ * }} spec
+ * @returns {Record<string, unknown>}
+ */
+export function parseCliOptions(args, spec) {
+  const options = { ...spec.defaults };
+  if (spec.collectWarnings) options.warnings = [];
+
+  const list = args ?? [];
+  for (let i = 0; i < list.length; i += 1) {
+    const arg = list[i];
+    const flagSpec = spec.flags[arg];
+    if (!flagSpec) continue;
+
+    if (flagSpec.type === 'boolean') {
+      options[flagSpec.key] = true;
+      continue;
+    }
+
+    const value = list[i + 1];
+    if (value === undefined) continue;
+    i += 1;
+
+    if (flagSpec.type === 'string') {
+      applyStringFlag(options, flagSpec, value, spec.collectWarnings);
+    } else if (flagSpec.type === 'int') {
+      applyIntFlag(options, flagSpec, value, spec.collectWarnings);
+    }
+  }
+
+  return options;
+}
+
+function applyStringFlag(options, flagSpec, value, collectWarnings) {
+  if (!flagSpec.trim) {
+    options[flagSpec.key] = value;
+    return;
+  }
+  const trimmed = String(value).trim();
+  if (trimmed.length === 0) {
+    if (collectWarnings && flagSpec.emptyMessage) {
+      options.warnings.push(flagSpec.emptyMessage);
+    }
+    return;
+  }
+  options[flagSpec.key] = trimmed;
+}
+
+function applyIntFlag(options, flagSpec, value, collectWarnings) {
+  const n = Number(value);
+  const valid = Number.isInteger(n) && (flagSpec.validate ? flagSpec.validate(n) : true);
+  if (!valid) {
+    if (collectWarnings && flagSpec.invalidMessage) {
+      options.warnings.push(flagSpec.invalidMessage.replace('${value}', String(value)));
+    }
+    return;
+  }
+  options[flagSpec.key] = flagSpec.transform ? flagSpec.transform(n) : n;
+}

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -1,4 +1,5 @@
 import { getStatusSnapshot } from '../services/status-service.js';
+import { parseCliOptions } from './parse-options.js';
 
 // 포맷터는 status-formatters.js에서 관리. 기존 import 경로 호환을 위해 re-export.
 export {
@@ -32,16 +33,10 @@ export async function runStatusCommand(command, args = []) {
  * `status` / `usage` 옵션 파서.
  */
 export function parseStatusOptions(args) {
-  const options = { account: null };
-  for (let i = 0; i < (args ?? []).length; i += 1) {
-    const arg = args[i];
-    if (arg === '--account') {
-      const value = args[i + 1];
-      if (value) {
-        options.account = value;
-        i += 1;
-      }
-    }
-  }
-  return options;
+  return parseCliOptions(args, {
+    defaults: { account: null },
+    flags: {
+      '--account': { key: 'account', type: 'string' },
+    },
+  });
 }

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -259,6 +259,15 @@ describe('parseDoctorClaudeOptions', () => {
       account: null,
     });
   });
+
+  it('treats --account "" as "no value" and lets subsequent flags parse (legacy contract)', () => {
+    // 공통 helper 전환 후에도 빈 문자열은 default 유지하고 consume하지 않아
+    // 이어지는 --refresh-live가 정상 파싱되어야 한다.
+    assert.deepEqual(parseDoctorClaudeOptions(['--account', '', '--refresh-live']), {
+      refreshLive: true,
+      account: null,
+    });
+  });
 });
 
 describe('formatClaudeSection — multi-account networkUsages', () => {

--- a/packages/agent/test/cli/parse-options.test.js
+++ b/packages/agent/test/cli/parse-options.test.js
@@ -66,6 +66,28 @@ describe('parseCliOptions — string flags', () => {
     assert.equal(out.account, null);
   });
 
+  it('treats empty string as "no value" for non-trim string flag (legacy contract)', () => {
+    // 레거시 파서(`if (value)`) 호환: ''가 들어와도 default 유지.
+    const out = parseCliOptions(['--account', ''], {
+      defaults: { account: null },
+      flags: { '--account': { key: 'account', type: 'string' } },
+    });
+    assert.equal(out.account, null);
+  });
+
+  it('does not consume empty string so following flags still parse', () => {
+    // ['--account', '', '--refresh-live'] → refreshLive가 여전히 true여야 한다.
+    const out = parseCliOptions(['--account', '', '--refresh-live'], {
+      defaults: { account: null, refreshLive: false },
+      flags: {
+        '--account': { key: 'account', type: 'string' },
+        '--refresh-live': { key: 'refreshLive', type: 'boolean' },
+      },
+    });
+    assert.equal(out.account, null);
+    assert.equal(out.refreshLive, true);
+  });
+
   it('trims and ignores empty trimmed value when trim=true', () => {
     const out = parseCliOptions(['--label', '   '], {
       defaults: { label: null },

--- a/packages/agent/test/cli/parse-options.test.js
+++ b/packages/agent/test/cli/parse-options.test.js
@@ -1,0 +1,227 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseCliOptions } from '../../src/cli/parse-options.js';
+
+describe('parseCliOptions — defaults', () => {
+  it('returns a shallow copy of defaults for empty args', () => {
+    const defaults = { account: null, refreshLive: false };
+    const out = parseCliOptions([], { defaults, flags: {} });
+    assert.deepEqual(out, { account: null, refreshLive: false });
+    assert.notEqual(out, defaults);
+  });
+
+  it('accepts null/undefined args as empty', () => {
+    const spec = { defaults: { account: null }, flags: {} };
+    assert.deepEqual(parseCliOptions(undefined, spec), { account: null });
+    assert.deepEqual(parseCliOptions(null, spec), { account: null });
+  });
+
+  it('initializes warnings=[] only when collectWarnings=true', () => {
+    const spec = { defaults: { foo: null }, flags: {}, collectWarnings: true };
+    assert.deepEqual(parseCliOptions([], spec), { foo: null, warnings: [] });
+
+    const specNoWarn = { defaults: { foo: null }, flags: {} };
+    const out = parseCliOptions([], specNoWarn);
+    assert.equal('warnings' in out, false);
+  });
+});
+
+describe('parseCliOptions — boolean flags', () => {
+  it('toggles matching boolean flags to true', () => {
+    const out = parseCliOptions(['--refresh-live'], {
+      defaults: { refreshLive: false },
+      flags: { '--refresh-live': { key: 'refreshLive', type: 'boolean' } },
+    });
+    assert.equal(out.refreshLive, true);
+  });
+
+  it('leaves untoggled boolean flags at default', () => {
+    const out = parseCliOptions([], {
+      defaults: { manual: false, device: false },
+      flags: {
+        '--manual': { key: 'manual', type: 'boolean' },
+        '--device': { key: 'device', type: 'boolean' },
+      },
+    });
+    assert.equal(out.manual, false);
+    assert.equal(out.device, false);
+  });
+});
+
+describe('parseCliOptions — string flags', () => {
+  it('consumes next arg as value', () => {
+    const out = parseCliOptions(['--account', 'alice@x.com'], {
+      defaults: { account: null },
+      flags: { '--account': { key: 'account', type: 'string' } },
+    });
+    assert.equal(out.account, 'alice@x.com');
+  });
+
+  it('skips string flag with no following value', () => {
+    const out = parseCliOptions(['--account'], {
+      defaults: { account: null },
+      flags: { '--account': { key: 'account', type: 'string' } },
+    });
+    assert.equal(out.account, null);
+  });
+
+  it('trims and ignores empty trimmed value when trim=true', () => {
+    const out = parseCliOptions(['--label', '   '], {
+      defaults: { label: null },
+      flags: {
+        '--label': {
+          key: 'label',
+          type: 'string',
+          trim: true,
+          emptyMessage: '--label 값이 비어 있습니다.',
+        },
+      },
+      collectWarnings: true,
+    });
+    assert.equal(out.label, null);
+    assert.deepEqual(out.warnings, ['--label 값이 비어 있습니다.']);
+  });
+
+  it('does not push warning when collectWarnings=false even with emptyMessage', () => {
+    const out = parseCliOptions(['--label', '   '], {
+      defaults: { label: null },
+      flags: {
+        '--label': {
+          key: 'label',
+          type: 'string',
+          trim: true,
+          emptyMessage: 'noisy',
+        },
+      },
+    });
+    assert.equal(out.label, null);
+    assert.equal('warnings' in out, false);
+  });
+});
+
+describe('parseCliOptions — int flags', () => {
+  const portFlag = {
+    '--port': {
+      key: 'port',
+      type: 'int',
+      validate: (n) => n >= 0 && n <= 65535,
+      invalidMessage: '--port 값 "${value}"이(가) 유효하지 않습니다.',
+    },
+  };
+  const timeoutFlag = {
+    '--timeout': {
+      key: 'timeoutMs',
+      type: 'int',
+      validate: (n) => n > 0,
+      transform: (n) => n * 1000,
+      invalidMessage: '--timeout 값 "${value}"이(가) 유효하지 않습니다.',
+    },
+  };
+
+  it('parses valid integer', () => {
+    const out = parseCliOptions(['--port', '38123'], {
+      defaults: { port: null },
+      flags: portFlag,
+      collectWarnings: true,
+    });
+    assert.equal(out.port, 38123);
+    assert.deepEqual(out.warnings, []);
+  });
+
+  it('accepts boundary values (0, 65535) when validate passes', () => {
+    const mk = (v) =>
+      parseCliOptions(['--port', v], {
+        defaults: { port: null },
+        flags: portFlag,
+      }).port;
+    assert.equal(mk('0'), 0);
+    assert.equal(mk('65535'), 65535);
+  });
+
+  it('rejects non-integer values (1.5, "foo") with warning', () => {
+    const opts1 = parseCliOptions(['--port', '1.5'], {
+      defaults: { port: null },
+      flags: portFlag,
+      collectWarnings: true,
+    });
+    assert.equal(opts1.port, null);
+    assert.equal(opts1.warnings.length, 1);
+
+    const opts2 = parseCliOptions(['--port', 'foo'], {
+      defaults: { port: null },
+      flags: portFlag,
+      collectWarnings: true,
+    });
+    assert.equal(opts2.port, null);
+    assert.match(opts2.warnings[0], /--port 값 "foo"/);
+  });
+
+  it('rejects out-of-range values via validate', () => {
+    const mk = (v) =>
+      parseCliOptions(['--port', v], {
+        defaults: { port: null },
+        flags: portFlag,
+        collectWarnings: true,
+      });
+    assert.equal(mk('65536').port, null);
+    assert.equal(mk('65536').warnings.length, 1);
+    assert.equal(mk('-1').port, null);
+    assert.equal(mk('-1').warnings.length, 1);
+  });
+
+  it('applies transform on valid value (seconds → ms)', () => {
+    const out = parseCliOptions(['--timeout', '300'], {
+      defaults: { timeoutMs: 120_000 },
+      flags: timeoutFlag,
+      collectWarnings: true,
+    });
+    assert.equal(out.timeoutMs, 300_000);
+    assert.deepEqual(out.warnings, []);
+  });
+
+  it('keeps default and warns when validate fails (timeout <= 0)', () => {
+    const out = parseCliOptions(['--timeout', '0'], {
+      defaults: { timeoutMs: 120_000 },
+      flags: timeoutFlag,
+      collectWarnings: true,
+    });
+    assert.equal(out.timeoutMs, 120_000);
+    assert.equal(out.warnings.length, 1);
+  });
+});
+
+describe('parseCliOptions — unknown flags', () => {
+  it('silently skips unknown flags without consuming following args', () => {
+    const out = parseCliOptions(['--unknown', '--account', 'a'], {
+      defaults: { account: null },
+      flags: { '--account': { key: 'account', type: 'string' } },
+    });
+    assert.equal(out.account, 'a');
+  });
+});
+
+describe('parseCliOptions — combined', () => {
+  it('collects multiple warnings independently', () => {
+    const out = parseCliOptions(['--port', 'x', '--timeout', 'y'], {
+      defaults: { port: null, timeoutMs: 120_000 },
+      flags: {
+        '--port': {
+          key: 'port',
+          type: 'int',
+          validate: (n) => n >= 0 && n <= 65535,
+          invalidMessage: '--port 값 "${value}" invalid',
+        },
+        '--timeout': {
+          key: 'timeoutMs',
+          type: 'int',
+          validate: (n) => n > 0,
+          transform: (n) => n * 1000,
+          invalidMessage: '--timeout 값 "${value}" invalid',
+        },
+      },
+      collectWarnings: true,
+    });
+    assert.equal(out.warnings.length, 2);
+  });
+});

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -292,6 +292,11 @@ describe('parseStatusOptions', () => {
     const out = parseStatusOptions(['--unknown', '--account', 'a']);
     assert.equal(out.account, 'a');
   });
+
+  it('treats --account "" as "no value" (legacy contract)', () => {
+    // 공통 helper 전환 후에도 빈 문자열은 default 유지해야 한다.
+    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null });
+  });
 });
 
 describe('formatStatusOutput — accountFilter line', () => {


### PR DESCRIPTION
## 요약

5개 CLI 파서(`parseLoginOptions`, `parseStatusOptions`, `parseLogoutOptions`, `parseDoctorClaudeOptions`, `parseDoctorCodexOptions`)에 흩어져 있던 옵션 파싱 로직을 스펙 기반 공통 helper `parseCliOptions`로 통합. 외부 계약(각 parser 반환 shape, 동작)은 그대로 유지.

closes #61

## 변경 내용

1. `packages/agent/src/cli/parse-options.js` 신설
   - 스펙 기반 `parseCliOptions(args, { defaults, flags, collectWarnings })` 도입
   - 지원 타입: `boolean` / `string` (+ `trim`) / `int` (+ `validate`, `transform`)
   - unknown flag silent skip, warnings 수집은 opt-in
   - pure 함수 단위 테스트 17개 추가 (`parse-options.test.js`)
2. 기존 5개 파서 전환
   - `status-command.js::parseStatusOptions`
   - `auth-logout-command.js::parseLogoutOptions`
   - `doctor-command.js::parseDoctorClaudeOptions` / `parseDoctorCodexOptions` (+ `DOCTOR_FLAGS` 상수 공유)
   - `login-runner.js::parseLoginOptions` (내부 `parsePortValue` / `parseTimeoutSeconds` 제거)
3. `docs/codebase-guide.md §5.3` 신설 — 공통 파서 위치/규약, 플래그 스펙, 새 플래그 추가 지침 정리

## 변경 이유

- 5개 파서가 유사한 `--account` 로직을 독립 구현하고 있어 일관성 유지 비용 누적
- `status`에 `--provider` / `--json` / 서브커맨드별 `--help` 같은 옵션을 추가하려 해도 공통 파서가 없어 커맨드마다 중복이 필요했던 상황 해소
- 파서 단위 테스트를 일부는 커맨드별로, 일부는 통합 기반으로 재편 가능하도록 기반 마련

## 영향 범위

- [x] `packages/agent` (cli 레이어만)
- [ ] `packages/provider-adapters`
- [ ] `packages/schemas`
- [x] `docs` (codebase-guide §5.3 신설)

## 테스트 / 확인

- `npm test`: 523/523 통과 (기존 506 + 신규 helper 17)
- 기존 `parseLoginOptions` / `parseDoctorClaudeOptions` / `parseStatusOptions` 테스트 그대로 통과 — 외부 계약 비변경 확인
- login-runner.js 351 → 321 LOC로 축소

## 리뷰 포인트

- `parseCliOptions` spec shape가 충분히 범용인지 (추후 `--provider`, `--help` 추가 시 그대로 재사용 가능한지)
- `collectWarnings` opt-in 방식이 기존 파서 계약(warnings를 쓰지 않는 파서는 반환 객체에 `warnings` 키가 없음)과 일치하는지
- `DOCTOR_FLAGS` 상수를 `doctor-command.js` 내부에 둔 선택이 적절한지 (필요 시 `parse-options.js`쪽으로 옮길 수도 있음)

## 참고 사항

- #61 후속으로 `status --provider`, `--json`, 서브커맨드별 `--help` 추가 작업이 예정됨 (본 PR은 그 선행 리팩터)