### PR TITLE
[feat] CLI 서브커맨드별 --help 지원

### DIFF
--- a/packages/agent/src/cli/auth-import-command.js
+++ b/packages/agent/src/cli/auth-import-command.js
@@ -4,18 +4,42 @@ import { loadAuthStore, saveAuthStore } from '../auth/auth-store.js';
 import { importClaudeAccountIntoStore } from '../auth/claude-imported-account.js';
 
 /**
+ * `auth import` --help 출력. Pure function.
+ */
+export function formatAuthImportHelp() {
+  return [
+    'ai-usage-agent auth import <provider>',
+    '',
+    'Provider CLI credential을 agent-store에 복사합니다.',
+    '현재 지원: claude (~/.claude/.credentials.json)',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+  ];
+}
+
+/**
  * auth import <provider>
  * 현재 지원: claude
  */
 export async function runAuthImportCommand(
   provider,
-  _args = [],
+  args = [],
   {
     claudeReadFn = readClaudeCredentials,
     loadStore = loadAuthStore,
     saveStore = saveAuthStore,
   } = {},
 ) {
+  const wantsHelp =
+    provider === '--help' ||
+    provider === '-h' ||
+    (args ?? []).some((a) => a === '--help' || a === '-h');
+  if (wantsHelp) {
+    for (const line of formatAuthImportHelp()) console.log(line);
+    return;
+  }
+
   if (!provider) {
     console.log('사용법: ai-usage-agent auth import <provider>');
     console.log('현재 지원 provider: claude');

--- a/packages/agent/src/cli/auth-list-command.js
+++ b/packages/agent/src/cli/auth-list-command.js
@@ -3,6 +3,21 @@ import { buildClaudeSnapshot } from '../services/status-service.js';
 import { resolveClaudeCredentialsPath } from '../../../provider-adapters/src/claude/read-claude-credentials.js';
 
 /**
+ * `auth list` --help 출력. Pure function.
+ */
+export function formatAuthListHelp() {
+  return [
+    'ai-usage-agent auth list [provider]',
+    '',
+    '저장된 인증 계정 목록을 출력합니다.',
+    'provider를 지정하면 해당 provider 계정만 출력합니다.',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+  ];
+}
+
+/**
  * `ai-usage-agent auth list [provider]`
  *
  * 저장된 인증 계정 목록을 출력한다.
@@ -10,6 +25,10 @@ import { resolveClaudeCredentialsPath } from '../../../provider-adapters/src/cla
  * options.claudeReadFn 을 주입하면 실제 파일시스템 대신 사용한다 (테스트용).
  */
 export async function runAuthListCommand(provider, options = {}) {
+  if (provider === '--help' || provider === '-h') {
+    for (const line of formatAuthListHelp()) console.log(line);
+    return;
+  }
   const loadStore = options.loadStore ?? loadAuthStore;
   const store = await loadStore();
   const providerIds = provider

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -15,9 +15,38 @@ import { runOAuthLoginFlow, parseLoginOptions } from './login-runner.js';
 const CODEX_STORE_KEY = 'openai-codex';
 
 /**
+ * `auth login` --help 출력. Pure function.
+ */
+export function formatAuthLoginHelp() {
+  return [
+    'ai-usage-agent auth login <provider> [options]',
+    '',
+    'Provider: codex, claude',
+    '',
+    'Options:',
+    '  --live-exchange       실제 token exchange를 수행 (기본: mock 저장)',
+    '  --port <number>       localhost callback port 지정 (0~65535)',
+    '  --timeout <seconds>   callback 대기 시간 (기본 120)',
+    '  --label <name>        계정 라벨 지정',
+    '  --manual              브라우저 자동 실행 없이 수동 붙여넣기',
+    '  --no-open             브라우저 자동 실행 안함',
+    '  --device              device code flow (미구현)',
+    '  --keep-legacy         legacy 중복 계정을 정리하지 않음',
+    '  -h, --help            이 도움말 출력',
+  ];
+}
+
+/**
  * Entry point: dispatch `auth login <provider>` to the provider branch.
  */
 export async function runAuthLoginCommand(provider, args = []) {
+  // provider 없을 때도 --help는 먼저 존중한다.
+  const wantsHelp = (args ?? []).some((a) => a === '--help' || a === '-h');
+  if (wantsHelp) {
+    for (const line of formatAuthLoginHelp()) console.log(line);
+    return;
+  }
+
   if (!provider) {
     console.log(
       '사용법: ai-usage-agent auth login <provider> [--manual] [--no-open] [--port <number>] [--timeout <seconds>] [--live-exchange] [--label <name>] [--keep-legacy]',
@@ -42,6 +71,10 @@ export async function runAuthLoginCommand(provider, args = []) {
 
 async function runCodexLogin(args) {
   const options = parseLoginOptions(args);
+  if (options.help) {
+    for (const line of formatAuthLoginHelp()) console.log(line);
+    return;
+  }
   if (!reportAndGuardOptionWarnings(options)) return;
 
   if (options.device) {
@@ -124,6 +157,10 @@ async function runCodexManualPasteFlow() {
 
 async function runClaudeLogin(args) {
   const options = parseLoginOptions(args);
+  if (options.help) {
+    for (const line of formatAuthLoginHelp()) console.log(line);
+    return;
+  }
   if (!reportAndGuardOptionWarnings(options)) return;
 
   if (options.device) {

--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -40,8 +40,12 @@ export function formatAuthLoginHelp() {
  * Entry point: dispatch `auth login <provider>` to the provider branch.
  */
 export async function runAuthLoginCommand(provider, args = []) {
-  // provider 없을 때도 --help는 먼저 존중한다.
-  const wantsHelp = (args ?? []).some((a) => a === '--help' || a === '-h');
+  // `auth login --help` (provider 자리에 help 토큰) 또는
+  // `auth login <provider> --help` (args 자리에 help 토큰) 모두 먼저 처리.
+  const wantsHelp =
+    provider === '--help' ||
+    provider === '-h' ||
+    (args ?? []).some((a) => a === '--help' || a === '-h');
   if (wantsHelp) {
     for (const line of formatAuthLoginHelp()) console.log(line);
     return;

--- a/packages/agent/src/cli/auth-logout-command.js
+++ b/packages/agent/src/cli/auth-logout-command.js
@@ -28,6 +28,12 @@ export function formatAuthLogoutHelp() {
  * 참고: revoke endpoint 호출은 아직 미구현이다. 로컬 저장소 제거만 수행한다.
  */
 export async function runAuthLogoutCommand(provider, args) {
+  // `auth logout --help` (provider 자리) 또는 `auth logout <p> --help` (args 자리) 모두 먼저 처리.
+  if (provider === '--help' || provider === '-h') {
+    for (const line of formatAuthLogoutHelp()) console.log(line);
+    return;
+  }
+
   const options = parseLogoutOptions(args);
   if (options.help) {
     for (const line of formatAuthLogoutHelp()) console.log(line);

--- a/packages/agent/src/cli/auth-logout-command.js
+++ b/packages/agent/src/cli/auth-logout-command.js
@@ -3,6 +3,22 @@ import { resolveAccount } from '../auth/account-resolver.js';
 import { parseCliOptions } from './parse-options.js';
 
 /**
+ * `auth logout` --help 출력. Pure function.
+ */
+export function formatAuthLogoutHelp() {
+  return [
+    'ai-usage-agent auth logout <provider> [options]',
+    '',
+    '지정 provider의 계정을 로컬 auth store에서 제거합니다.',
+    '참고: provider 측 revoke 호출은 아직 미구현(로컬 제거만 수행).',
+    '',
+    'Options:',
+    '  --account <id>    제거 대상 계정 (email / accountKey / label)',
+    '  -h, --help        이 도움말 출력',
+  ];
+}
+
+/**
  * `ai-usage-agent auth logout <provider> [--account <id>]`
  *
  * 지정된 provider의 계정을 auth store에서 제거한다.
@@ -12,6 +28,12 @@ import { parseCliOptions } from './parse-options.js';
  * 참고: revoke endpoint 호출은 아직 미구현이다. 로컬 저장소 제거만 수행한다.
  */
 export async function runAuthLogoutCommand(provider, args) {
+  const options = parseLogoutOptions(args);
+  if (options.help) {
+    for (const line of formatAuthLogoutHelp()) console.log(line);
+    return;
+  }
+
   if (!provider) {
     console.error(
       '사용법: ai-usage-agent auth logout <provider> [--account <email | accountKey | label>]',
@@ -19,8 +41,6 @@ export async function runAuthLogoutCommand(provider, args) {
     process.exitCode = 1;
     return;
   }
-
-  const options = parseLogoutOptions(args);
   const store = await loadAuthStore();
 
   const providerEntry = store.providers?.[provider];
@@ -67,5 +87,6 @@ function parseLogoutOptions(args) {
     flags: {
       '--account': { key: 'account', type: 'string' },
     },
+    includeHelp: true,
   });
 }

--- a/packages/agent/src/cli/config-init-command.js
+++ b/packages/agent/src/cli/config-init-command.js
@@ -2,7 +2,27 @@ import fs from 'node:fs/promises';
 import { createDefaultConfig } from '../config/default-config.js';
 import { resolveAgentConfigDir, resolveAgentConfigPath } from '../config/config-path.js';
 
-export async function runConfigInitCommand() {
+/**
+ * `config init` --help 출력. Pure function.
+ */
+export function formatConfigInitHelp() {
+  return [
+    'ai-usage-agent config init',
+    '',
+    '~/.config/ai-usage-agent/config.json에 기본 설정 파일을 생성합니다.',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+  ];
+}
+
+export async function runConfigInitCommand(args = []) {
+  const wantsHelp = (args ?? []).some((a) => a === '--help' || a === '-h');
+  if (wantsHelp) {
+    for (const line of formatConfigInitHelp()) console.log(line);
+    return;
+  }
+
   const dir = resolveAgentConfigDir();
   const file = resolveAgentConfigPath();
   const config = createDefaultConfig();

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -25,6 +25,65 @@ const DOCTOR_FLAGS = {
 };
 const DOCTOR_DEFAULTS = { refreshLive: false, account: null };
 
+function parseDoctorOptions(args) {
+  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS, includeHelp: true });
+}
+
+/**
+ * `doctor` root 서브커맨드의 --help 출력. Pure function.
+ */
+export function formatDoctorHelp() {
+  return [
+    'ai-usage-agent doctor [subcommand] [options]',
+    '',
+    '공통 환경 점검 또는 provider별 상세 진단.',
+    '',
+    'Subcommands:',
+    '  codex     Codex 계정·refresh 가능성 점검',
+    '  claude    Claude credential·live usage 점검',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+    '',
+    '예시:',
+    '  ai-usage-agent doctor',
+    '  ai-usage-agent doctor codex --refresh-live',
+    '  ai-usage-agent doctor claude --account work',
+  ];
+}
+
+/**
+ * `doctor codex` 서브커맨드의 --help 출력. Pure function.
+ */
+export function formatDoctorCodexHelp() {
+  return [
+    'ai-usage-agent doctor codex [options]',
+    '',
+    'Codex 계정 상태와 refresh 가능성을 점검합니다.',
+    '',
+    'Options:',
+    '  --refresh-live        실제 token endpoint에 refresh POST 시도',
+    '  --account <id>        특정 계정 지정 (email / accountKey / label)',
+    '  -h, --help            이 도움말 출력',
+  ];
+}
+
+/**
+ * `doctor claude` 서브커맨드의 --help 출력. Pure function.
+ */
+export function formatDoctorClaudeHelp() {
+  return [
+    'ai-usage-agent doctor claude [options]',
+    '',
+    'Claude credential 상태와 live usage를 점검합니다.',
+    '',
+    'Options:',
+    '  --refresh-live        Claude OAuth refresh token으로 실제 재발급 시도',
+    '  --account <id>        특정 계정 지정 (email / accountKey / label)',
+    '  -h, --help            이 도움말 출력',
+  ];
+}
+
 // 기존 import 경로 호환 re-export.
 export { formatClaudeSection };
 export { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
@@ -40,10 +99,15 @@ export async function runDoctorCommand(subcommand, args = []) {
     await runDoctorClaude(args);
     return;
   }
-  await runDoctorRoot();
+  await runDoctorRoot(args);
 }
 
-async function runDoctorRoot() {
+async function runDoctorRoot(args = []) {
+  const options = parseDoctorOptions(args);
+  if (options.help) {
+    for (const line of formatDoctorHelp()) console.log(line);
+    return;
+  }
   const claudeSnapshot = await getClaudeSnapshot();
   console.log('ai-usage-agent doctor');
   console.log('---------------------');
@@ -67,6 +131,10 @@ async function runDoctorRoot() {
 
 async function runDoctorClaude(args = []) {
   const options = parseDoctorClaudeOptions(args);
+  if (options.help) {
+    for (const line of formatDoctorClaudeHelp()) console.log(line);
+    return;
+  }
   const snapshot = await getClaudeSnapshot();
 
   console.log('ai-usage-agent doctor claude');
@@ -154,13 +222,17 @@ export async function resolveClaudeRefreshTargetAccount(snapshot, accountIdentif
 }
 
 export function parseDoctorClaudeOptions(args) {
-  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS });
+  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS, includeHelp: true });
 }
 
 // ─── Codex ─────────────────────────────────────────────────────────────────
 
 async function runDoctorCodex(args) {
   const options = parseDoctorCodexOptions(args);
+  if (options.help) {
+    for (const line of formatDoctorCodexHelp()) console.log(line);
+    return;
+  }
 
   console.log('ai-usage-agent doctor codex');
   console.log('---------------------------');
@@ -230,5 +302,5 @@ async function resolveCodexDoctorAccount(options) {
 }
 
 function parseDoctorCodexOptions(args) {
-  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS });
+  return parseCliOptions(args, { defaults: DOCTOR_DEFAULTS, flags: DOCTOR_FLAGS, includeHelp: true });
 }

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -91,6 +91,12 @@ export { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
 // ─── Dispatcher ────────────────────────────────────────────────────────────
 
 export async function runDoctorCommand(subcommand, args = []) {
+  // `doctor --help` 같이 subcommand 자리에 help 토큰이 오는 경우를 처리.
+  // (subcommand가 'codex'/'claude'가 아니라 '--help'/'-h'일 때)
+  if (subcommand === '--help' || subcommand === '-h') {
+    for (const line of formatDoctorHelp()) console.log(line);
+    return;
+  }
   if (subcommand === 'codex') {
     await runDoctorCodex(args);
     return;

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -317,5 +317,6 @@ export function parseLoginOptions(args) {
     defaults: LOGIN_DEFAULTS,
     flags: LOGIN_FLAGS,
     collectWarnings: true,
+    includeHelp: true,
   });
 }

--- a/packages/agent/src/cli/parse-options.js
+++ b/packages/agent/src/cli/parse-options.js
@@ -28,17 +28,30 @@
  *   defaults: Record<string, unknown>,
  *   flags: Record<string, FlagSpec>,
  *   collectWarnings?: boolean,
+ *   includeHelp?: boolean,
  * }} spec
+ *   `includeHelp: true`이면 `--help` / `-h`를 자동으로 boolean 플래그로 인식해
+ *   `options.help`에 저장한다 (defaults에 별도 선언 불필요).
  * @returns {Record<string, unknown>}
  */
 export function parseCliOptions(args, spec) {
   const options = { ...spec.defaults };
   if (spec.collectWarnings) options.warnings = [];
 
+  let flagMap = spec.flags;
+  if (spec.includeHelp) {
+    flagMap = {
+      ...spec.flags,
+      '--help': { key: 'help', type: 'boolean' },
+      '-h': { key: 'help', type: 'boolean' },
+    };
+    if (!('help' in options)) options.help = false;
+  }
+
   const list = args ?? [];
   for (let i = 0; i < list.length; i += 1) {
     const arg = list[i];
-    const flagSpec = spec.flags[arg];
+    const flagSpec = flagMap[arg];
     if (!flagSpec) continue;
 
     if (flagSpec.type === 'boolean') {

--- a/packages/agent/src/cli/run-cli.js
+++ b/packages/agent/src/cli/run-cli.js
@@ -1,13 +1,19 @@
-import { STATUS_COMMANDS, runStatusCommand } from './status-command.js';
-import { runDoctorCommand } from './doctor-command.js';
-import { runConfigInitCommand } from './config-init-command.js';
-import { runAuthLoginCommand } from './auth-login-command.js';
-import { runAuthListCommand } from './auth-list-command.js';
-import { runAuthLogoutCommand } from './auth-logout-command.js';
-import { runAuthImportCommand } from './auth-import-command.js';
+import { STATUS_COMMANDS, runStatusCommand, formatStatusHelp } from './status-command.js';
+import { runDoctorCommand, formatDoctorHelp } from './doctor-command.js';
+import { runConfigInitCommand, formatConfigInitHelp } from './config-init-command.js';
+import { runAuthLoginCommand, formatAuthLoginHelp } from './auth-login-command.js';
+import { runAuthListCommand, formatAuthListHelp } from './auth-list-command.js';
+import { runAuthLogoutCommand, formatAuthLogoutHelp } from './auth-logout-command.js';
+import { runAuthImportCommand, formatAuthImportHelp } from './auth-import-command.js';
 
 export async function runCli(argv) {
   const [command = 'status', ...rest] = argv;
+
+  // 전역 --help / -h: 커맨드 없이 주면 global help 출력.
+  if (command === '--help' || command === '-h') {
+    for (const line of formatGlobalHelp()) console.log(line);
+    return;
+  }
 
   if (STATUS_COMMANDS.includes(command)) {
     await runStatusCommand(command, rest);
@@ -48,9 +54,33 @@ export async function runCli(argv) {
     }
   }
 
-  printHelp();
+  for (const line of formatGlobalHelp()) console.log(line);
 }
 
-function printHelp() {
-  console.log(`ai-usage-agent\n\n사용법:\n  ai-usage-agent status\n  ai-usage-agent usage\n  ai-usage-agent doctor\n  ai-usage-agent config init\n  ai-usage-agent auth login <provider>\n  ai-usage-agent auth list [provider]\n  ai-usage-agent auth import <provider>\n  ai-usage-agent auth logout <provider> [--account <id>]\n  ai-usage-agent inspect <provider>    # 예정\n  ai-usage-agent sync                 # 예정`);
+/**
+ * 전역 help — 각 서브커맨드의 첫 줄(one-liner)을 모아 요약 목록을 출력한다.
+ * 상세 옵션은 각 서브커맨드의 `--help`로 확인.
+ * Pure function.
+ */
+export function formatGlobalHelp() {
+  const subcommands = [
+    formatStatusHelp('status')[0],
+    formatStatusHelp('usage')[0],
+    formatDoctorHelp()[0],
+    formatConfigInitHelp()[0],
+    formatAuthLoginHelp()[0],
+    formatAuthListHelp()[0],
+    formatAuthImportHelp()[0],
+    formatAuthLogoutHelp()[0],
+  ];
+  return [
+    'ai-usage-agent',
+    '',
+    '사용법:',
+    ...subcommands.map((line) => `  ${line}`),
+    '  ai-usage-agent inspect <provider>    # 예정',
+    '  ai-usage-agent sync                  # 예정',
+    '',
+    '각 커맨드의 상세 옵션은 `<command> --help`로 확인하세요.',
+  ];
 }

--- a/packages/agent/src/cli/run-cli.js
+++ b/packages/agent/src/cli/run-cli.js
@@ -21,9 +21,9 @@ export async function runCli(argv) {
   }
 
   if (command === 'config') {
-    const [subcommand] = rest;
+    const [subcommand, ...args] = rest;
     if (subcommand === 'init') {
-      await runConfigInitCommand();
+      await runConfigInitCommand(args);
       return;
     }
   }

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -23,6 +23,10 @@ export const STATUS_COMMANDS = ['status', 'usage'];
  */
 export async function runStatusCommand(command, args = []) {
   const options = parseStatusOptions(args);
+  if (options.help) {
+    for (const line of formatStatusHelp(command)) console.log(line);
+    return;
+  }
   const snapshot = await getStatusSnapshot({ accountFilter: options.account });
   for (const line of formatStatusOutput(command, snapshot)) {
     console.log(line);
@@ -38,5 +42,22 @@ export function parseStatusOptions(args) {
     flags: {
       '--account': { key: 'account', type: 'string' },
     },
+    includeHelp: true,
   });
+}
+
+/**
+ * `status` / `usage` 커맨드의 --help 출력 줄을 반환한다. Pure function.
+ */
+export function formatStatusHelp(command = 'status') {
+  return [
+    `ai-usage-agent ${command} [options]`,
+    '',
+    'provider별 credential 상태와 live usage window를 출력합니다.',
+    '여러 계정이 저장되어 있으면 기본적으로 모두 병렬 조회합니다.',
+    '',
+    'Options:',
+    '  --account <id>   특정 계정만 조회 (email / accountKey / label, case-insensitive)',
+    '  -h, --help       이 도움말 출력',
+  ];
 }

--- a/packages/agent/test/cli/auth-import-command.test.js
+++ b/packages/agent/test/cli/auth-import-command.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { runAuthImportCommand } from '../../src/cli/auth-import-command.js';
+import { runAuthImportCommand, formatAuthImportHelp } from '../../src/cli/auth-import-command.js';
 import { runCli } from '../../src/cli/run-cli.js';
 import { createEmptyAuthStore } from '../../src/auth/auth-store-schema.js';
 
@@ -16,6 +16,28 @@ async function captureOutput(fn) {
   }
   return lines;
 }
+
+describe('formatAuthImportHelp', () => {
+  it('first line is auth import usage', () => {
+    assert.match(formatAuthImportHelp()[0], /^ai-usage-agent auth import/);
+  });
+
+  it('mentions --help flag', () => {
+    assert.match(formatAuthImportHelp().join('\n'), /-h, --help/);
+  });
+});
+
+describe('runAuthImportCommand — --help', () => {
+  it('prints help when provider is "--help"', async () => {
+    const lines = await captureOutput(() => runAuthImportCommand('--help'));
+    assert.match(lines[0], /^ai-usage-agent auth import/);
+  });
+
+  it('prints help when --help is in args (e.g. after provider)', async () => {
+    const lines = await captureOutput(() => runAuthImportCommand('claude', ['--help']));
+    assert.match(lines[0], /^ai-usage-agent auth import/);
+  });
+});
 
 describe('runAuthImportCommand', () => {
   it('shows guidance and does not save when no selectedAccount exists', async () => {

--- a/packages/agent/test/cli/auth-list-command.test.js
+++ b/packages/agent/test/cli/auth-list-command.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   formatClaudeImportEntry,
+  formatAuthListHelp,
   runAuthListCommand,
 } from '../../src/cli/auth-list-command.js';
 
@@ -17,6 +18,28 @@ async function captureOutput(fn) {
   }
   return lines;
 }
+
+describe('formatAuthListHelp', () => {
+  it('first line is auth list usage', () => {
+    assert.match(formatAuthListHelp()[0], /^ai-usage-agent auth list/);
+  });
+
+  it('mentions --help flag', () => {
+    assert.match(formatAuthListHelp().join('\n'), /-h, --help/);
+  });
+});
+
+describe('runAuthListCommand — --help', () => {
+  it('prints help and exits when provider is "--help"', async () => {
+    const lines = await captureOutput(() => runAuthListCommand('--help'));
+    assert.match(lines[0], /^ai-usage-agent auth list/);
+  });
+
+  it('prints help when provider is "-h"', async () => {
+    const lines = await captureOutput(() => runAuthListCommand('-h'));
+    assert.match(lines[0], /^ai-usage-agent auth list/);
+  });
+});
 
 describe('formatClaudeImportEntry', () => {
   const FAKE_PATH = '/home/user/.claude/.credentials.json';

--- a/packages/agent/test/cli/auth-login-help.test.js
+++ b/packages/agent/test/cli/auth-login-help.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatAuthLoginHelp, runAuthLoginCommand } from '../../src/cli/auth-login-command.js';
+
+async function captureOutput(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...args) => lines.push(args.map(String).join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = orig;
+  }
+  return lines;
+}
+
+describe('formatAuthLoginHelp', () => {
+  it('first line is auth login usage', () => {
+    assert.match(formatAuthLoginHelp()[0], /^ai-usage-agent auth login/);
+  });
+
+  it('lists key options (--live-exchange, --port, --timeout, --label, --manual, -h)', () => {
+    const body = formatAuthLoginHelp().join('\n');
+    assert.match(body, /--live-exchange/);
+    assert.match(body, /--port/);
+    assert.match(body, /--timeout/);
+    assert.match(body, /--label/);
+    assert.match(body, /--manual/);
+    assert.match(body, /-h, --help/);
+  });
+});
+
+describe('runAuthLoginCommand — --help', () => {
+  it('prints help before provider validation when --help is in args', async () => {
+    const lines = await captureOutput(() => runAuthLoginCommand(undefined, ['--help']));
+    assert.match(lines[0], /^ai-usage-agent auth login/);
+  });
+
+  it('prints help when provider is given but args contain --help', async () => {
+    // parseLoginOptions가 options.help를 채워 early return이 일어나야 한다.
+    const lines = await captureOutput(() => runAuthLoginCommand('codex', ['--help']));
+    assert.match(lines[0], /^ai-usage-agent auth login/);
+  });
+});

--- a/packages/agent/test/cli/auth-login-help.test.js
+++ b/packages/agent/test/cli/auth-login-help.test.js
@@ -42,4 +42,15 @@ describe('runAuthLoginCommand — --help', () => {
     const lines = await captureOutput(() => runAuthLoginCommand('codex', ['--help']));
     assert.match(lines[0], /^ai-usage-agent auth login/);
   });
+
+  it('prints help when --help is in the provider slot (auth login --help)', async () => {
+    // runCli가 provider='--help', args=[]로 전달하는 경로.
+    const lines = await captureOutput(() => runAuthLoginCommand('--help', []));
+    assert.match(lines[0], /^ai-usage-agent auth login/);
+  });
+
+  it('also honors -h in the provider slot', async () => {
+    const lines = await captureOutput(() => runAuthLoginCommand('-h', []));
+    assert.match(lines[0], /^ai-usage-agent auth login/);
+  });
 });

--- a/packages/agent/test/cli/auth-logout-command.test.js
+++ b/packages/agent/test/cli/auth-logout-command.test.js
@@ -65,6 +65,23 @@ describe('runAuthLogoutCommand — --help', () => {
     // --help 경로는 exit 1을 설정하지 않는다.
     assert.notEqual(process.exitCode, 1);
   });
+
+  it('prints help when --help is in the provider slot (auth logout --help)', async () => {
+    // runCli가 provider='--help', args=[]로 전달하는 경로.
+    logs.length = 0;
+    process.exitCode = 0;
+    await runAuthLogoutCommand('--help', []);
+    assert.ok(logs.some((l) => l.startsWith('ai-usage-agent auth logout')));
+    assert.notEqual(process.exitCode, 1);
+  });
+
+  it('also honors -h in the provider slot', async () => {
+    logs.length = 0;
+    process.exitCode = 0;
+    await runAuthLogoutCommand('-h', []);
+    assert.ok(logs.some((l) => l.startsWith('ai-usage-agent auth logout')));
+    assert.notEqual(process.exitCode, 1);
+  });
 });
 
 describe('runAuthLogoutCommand — usage error', () => {

--- a/packages/agent/test/cli/auth-logout-command.test.js
+++ b/packages/agent/test/cli/auth-logout-command.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runAuthLogoutCommand } from '../../src/cli/auth-logout-command.js';
+import { runAuthLogoutCommand, formatAuthLogoutHelp } from '../../src/cli/auth-logout-command.js';
 import { saveAuthStore } from '../../src/auth/auth-store.js';
 import { createEmptyAuthStore } from '../../src/auth/auth-store-schema.js';
 
@@ -43,6 +43,29 @@ async function seedStore(providers = {}) {
   store.providers = providers;
   await saveAuthStore(store);
 }
+
+describe('formatAuthLogoutHelp', () => {
+  it('first line is auth logout usage', () => {
+    assert.match(formatAuthLogoutHelp()[0], /^ai-usage-agent auth logout/);
+  });
+
+  it('lists --account and --help', () => {
+    const body = formatAuthLogoutHelp().join('\n');
+    assert.match(body, /--account/);
+    assert.match(body, /-h, --help/);
+  });
+});
+
+describe('runAuthLogoutCommand — --help', () => {
+  withTmpHome();
+
+  it('prints help before provider validation when --help is in args', async () => {
+    await runAuthLogoutCommand(undefined, ['--help']);
+    assert.ok(logs.some((l) => l.startsWith('ai-usage-agent auth logout')));
+    // --help 경로는 exit 1을 설정하지 않는다.
+    assert.notEqual(process.exitCode, 1);
+  });
+});
 
 describe('runAuthLogoutCommand — usage error', () => {
   withTmpHome();

--- a/packages/agent/test/cli/config-init-command.test.js
+++ b/packages/agent/test/cli/config-init-command.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runConfigInitCommand } from '../../src/cli/config-init-command.js';
+import { runConfigInitCommand, formatConfigInitHelp } from '../../src/cli/config-init-command.js';
 
 let tmpHome;
 let originalHome;
@@ -27,6 +27,29 @@ function withTmpHome() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 }
+
+describe('formatConfigInitHelp', () => {
+  it('first line is config init usage', () => {
+    assert.match(formatConfigInitHelp()[0], /^ai-usage-agent config init/);
+  });
+
+  it('mentions --help flag', () => {
+    assert.match(formatConfigInitHelp().join('\n'), /-h, --help/);
+  });
+});
+
+describe('runConfigInitCommand — --help', () => {
+  withTmpHome();
+
+  it('prints help and does not create config file', async () => {
+    logged.length = 0;
+    await runConfigInitCommand(['--help']);
+    assert.ok(logged.some((l) => l.startsWith('ai-usage-agent config init')));
+    // --help 경로는 파일을 쓰지 않는다.
+    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    assert.equal(fs.existsSync(configPath), false);
+  });
+});
 
 describe('runConfigInitCommand — fresh init', () => {
   withTmpHome();

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -1,7 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { formatClaudeSection, parseDoctorClaudeOptions } from '../../src/cli/doctor-command.js';
+import {
+  formatClaudeSection,
+  parseDoctorClaudeOptions,
+  formatDoctorHelp,
+  formatDoctorCodexHelp,
+  formatDoctorClaudeHelp,
+} from '../../src/cli/doctor-command.js';
 
 // ---------------------------------------------------------------------------
 // formatClaudeSection — pure display helper
@@ -218,6 +224,7 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions([]), {
       refreshLive: false,
       account: null,
+      help: false,
     });
   });
 
@@ -225,6 +232,7 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--refresh-live']), {
       refreshLive: true,
       account: null,
+      help: false,
     });
   });
 
@@ -232,6 +240,7 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--foo', '--refresh-live', 'bar']), {
       refreshLive: true,
       account: null,
+      help: false,
     });
   });
 
@@ -239,10 +248,12 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(undefined), {
       refreshLive: false,
       account: null,
+      help: false,
     });
     assert.deepEqual(parseDoctorClaudeOptions(null), {
       refreshLive: false,
       account: null,
+      help: false,
     });
   });
 
@@ -250,6 +261,7 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--refresh-live', '--account', 'work']), {
       refreshLive: true,
       account: 'work',
+      help: false,
     });
   });
 
@@ -257,6 +269,7 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--account']), {
       refreshLive: false,
       account: null,
+      help: false,
     });
   });
 
@@ -266,7 +279,50 @@ describe('parseDoctorClaudeOptions', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--account', '', '--refresh-live']), {
       refreshLive: true,
       account: null,
+      help: false,
     });
+  });
+
+  it('recognizes --help and -h', () => {
+    assert.equal(parseDoctorClaudeOptions(['--help']).help, true);
+    assert.equal(parseDoctorClaudeOptions(['-h']).help, true);
+  });
+});
+
+describe('formatDoctorHelp', () => {
+  it('first line covers doctor with subcommand placeholder', () => {
+    const lines = formatDoctorHelp();
+    assert.match(lines[0], /^ai-usage-agent doctor \[subcommand\]/);
+  });
+
+  it('lists codex and claude subcommands', () => {
+    const body = formatDoctorHelp().join('\n');
+    assert.match(body, /codex/);
+    assert.match(body, /claude/);
+  });
+});
+
+describe('formatDoctorCodexHelp', () => {
+  it('first line targets codex', () => {
+    assert.match(formatDoctorCodexHelp()[0], /^ai-usage-agent doctor codex/);
+  });
+
+  it('lists --refresh-live and --account', () => {
+    const body = formatDoctorCodexHelp().join('\n');
+    assert.match(body, /--refresh-live/);
+    assert.match(body, /--account <id>/);
+  });
+});
+
+describe('formatDoctorClaudeHelp', () => {
+  it('first line targets claude', () => {
+    assert.match(formatDoctorClaudeHelp()[0], /^ai-usage-agent doctor claude/);
+  });
+
+  it('lists --refresh-live and --account', () => {
+    const body = formatDoctorClaudeHelp().join('\n');
+    assert.match(body, /--refresh-live/);
+    assert.match(body, /--account <id>/);
   });
 });
 

--- a/packages/agent/test/cli/login-runner.test.js
+++ b/packages/agent/test/cli/login-runner.test.js
@@ -111,7 +111,13 @@ describe('parseLoginOptions — defaults & flags', () => {
       label: null,
       keepLegacy: false,
       warnings: [],
+      help: false,
     });
+  });
+
+  it('recognizes --help and -h', () => {
+    assert.equal(parseLoginOptions(['--help']).help, true);
+    assert.equal(parseLoginOptions(['-h']).help, true);
   });
 
   it('handles null/undefined args', () => {

--- a/packages/agent/test/cli/parse-options.test.js
+++ b/packages/agent/test/cli/parse-options.test.js
@@ -223,6 +223,56 @@ describe('parseCliOptions — unknown flags', () => {
   });
 });
 
+describe('parseCliOptions — includeHelp', () => {
+  it('recognizes --help as options.help=true when includeHelp is set', () => {
+    const out = parseCliOptions(['--help'], {
+      defaults: { account: null },
+      flags: { '--account': { key: 'account', type: 'string' } },
+      includeHelp: true,
+    });
+    assert.equal(out.help, true);
+    assert.equal(out.account, null);
+  });
+
+  it('also recognizes -h alias', () => {
+    const out = parseCliOptions(['-h'], {
+      defaults: {},
+      flags: {},
+      includeHelp: true,
+    });
+    assert.equal(out.help, true);
+  });
+
+  it('leaves help=false by default when includeHelp is set but flag absent', () => {
+    const out = parseCliOptions([], {
+      defaults: { account: null },
+      flags: {},
+      includeHelp: true,
+    });
+    assert.equal(out.help, false);
+    assert.equal(out.account, null);
+  });
+
+  it('does not add help key when includeHelp is not set', () => {
+    const out = parseCliOptions(['--help'], {
+      defaults: { account: null },
+      flags: {},
+    });
+    assert.equal('help' in out, false);
+    assert.equal(out.account, null);
+  });
+
+  it('preserves caller-supplied help default when already in defaults', () => {
+    const out = parseCliOptions([], {
+      defaults: { help: 'custom' },
+      flags: {},
+      includeHelp: true,
+    });
+    // defaults에 이미 help가 있으면 덮어쓰지 않는다.
+    assert.equal(out.help, 'custom');
+  });
+});
+
 describe('parseCliOptions — combined', () => {
   it('collects multiple warnings independently', () => {
     const out = parseCliOptions(['--port', 'x', '--timeout', 'y'], {

--- a/packages/agent/test/cli/run-cli-help.test.js
+++ b/packages/agent/test/cli/run-cli-help.test.js
@@ -53,3 +53,15 @@ describe('runCli — global --help', () => {
     assert.equal(lines[0], 'ai-usage-agent');
   });
 });
+
+describe('runCli — doctor --help at subcommand position', () => {
+  it('prints doctor root help when subcommand is --help', async () => {
+    const lines = await captureOutput(() => runCli(['doctor', '--help']));
+    assert.match(lines[0], /^ai-usage-agent doctor \[subcommand\]/);
+  });
+
+  it('also honors -h at subcommand position', async () => {
+    const lines = await captureOutput(() => runCli(['doctor', '-h']));
+    assert.match(lines[0], /^ai-usage-agent doctor \[subcommand\]/);
+  });
+});

--- a/packages/agent/test/cli/run-cli-help.test.js
+++ b/packages/agent/test/cli/run-cli-help.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runCli, formatGlobalHelp } from '../../src/cli/run-cli.js';
+
+async function captureOutput(fn) {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...args) => lines.push(args.map(String).join(' '));
+  try {
+    await fn();
+  } finally {
+    console.log = orig;
+  }
+  return lines;
+}
+
+describe('formatGlobalHelp', () => {
+  it('starts with the "ai-usage-agent" header', () => {
+    assert.equal(formatGlobalHelp()[0], 'ai-usage-agent');
+  });
+
+  it('lists every top-level subcommand one-liner', () => {
+    const body = formatGlobalHelp().join('\n');
+    assert.match(body, /ai-usage-agent status/);
+    assert.match(body, /ai-usage-agent usage/);
+    assert.match(body, /ai-usage-agent doctor/);
+    assert.match(body, /ai-usage-agent config init/);
+    assert.match(body, /ai-usage-agent auth login/);
+    assert.match(body, /ai-usage-agent auth list/);
+    assert.match(body, /ai-usage-agent auth import/);
+    assert.match(body, /ai-usage-agent auth logout/);
+  });
+
+  it('hints at <command> --help for detailed options', () => {
+    assert.match(formatGlobalHelp().join('\n'), /<command> --help/);
+  });
+});
+
+describe('runCli — global --help', () => {
+  it('prints global help when invoked with --help as first arg', async () => {
+    const lines = await captureOutput(() => runCli(['--help']));
+    assert.equal(lines[0], 'ai-usage-agent');
+  });
+
+  it('prints global help when invoked with -h as first arg', async () => {
+    const lines = await captureOutput(() => runCli(['-h']));
+    assert.equal(lines[0], 'ai-usage-agent');
+  });
+
+  it('prints global help when no command matches (fallback)', async () => {
+    const lines = await captureOutput(() => runCli(['nope']));
+    assert.equal(lines[0], 'ai-usage-agent');
+  });
+});

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -9,6 +9,7 @@ import {
   formatClaudeNetworkUsages,
   formatClaudeLocalUsage,
   formatWindow,
+  formatStatusHelp,
   parseStatusOptions,
   STATUS_COMMANDS,
 } from '../../src/cli/status-command.js';
@@ -276,11 +277,11 @@ describe('formatClaudeSection — networkUsages array support', () => {
 
 describe('parseStatusOptions', () => {
   it('returns { account: null } for empty args', () => {
-    assert.deepEqual(parseStatusOptions([]), { account: null });
+    assert.deepEqual(parseStatusOptions([]), { account: null, help: false });
   });
 
   it('handles null/undefined args', () => {
-    assert.deepEqual(parseStatusOptions(undefined), { account: null });
+    assert.deepEqual(parseStatusOptions(undefined), { account: null, help: false });
   });
 
   it('parses --account <value>', () => {
@@ -295,7 +296,31 @@ describe('parseStatusOptions', () => {
 
   it('treats --account "" as "no value" (legacy contract)', () => {
     // 공통 helper 전환 후에도 빈 문자열은 default 유지해야 한다.
-    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null });
+    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null, help: false });
+  });
+
+  it('recognizes --help and -h', () => {
+    assert.equal(parseStatusOptions(['--help']).help, true);
+    assert.equal(parseStatusOptions(['-h']).help, true);
+    assert.equal(parseStatusOptions([]).help, false);
+  });
+});
+
+describe('formatStatusHelp', () => {
+  it('returns first line with command name and [options]', () => {
+    const lines = formatStatusHelp('status');
+    assert.match(lines[0], /^ai-usage-agent status \[options\]$/);
+  });
+
+  it('defaults command to "status" when not provided', () => {
+    const lines = formatStatusHelp();
+    assert.match(lines[0], /ai-usage-agent status/);
+  });
+
+  it('lists --account and --help in Options section', () => {
+    const body = formatStatusHelp('usage').join('\n');
+    assert.match(body, /--account/);
+    assert.match(body, /-h, --help/);
   });
 });
 


### PR DESCRIPTION
## 요약

모든 서브커맨드(`status`/`usage`, `doctor` root/codex/claude, `auth login/list/logout/import`, `config init`)에 `--help` / `-h` 플래그를 지원하고, 전역 `printHelp()`를 각 커맨드의 help helper 재사용 구조로 정리.

closes #63

## 변경 내용

1. **`parseCliOptions` 확장** (`parse-options.js`)
   - `spec.includeHelp: true`이면 `--help` / `-h`를 boolean 플래그로 자동 인식하고 `options.help`에 저장.
   - defaults에 `help: false`를 자동 주입(이미 있으면 덮어쓰지 않음).
2. **커맨드별 help helper + runner 분기**
   - `formatStatusHelp(command)` — `status` / `usage`
   - `formatDoctorHelp()` / `formatDoctorCodexHelp()` / `formatDoctorClaudeHelp()`
   - `formatAuthLoginHelp()` / `formatAuthListHelp()` / `formatAuthLogoutHelp()` / `formatAuthImportHelp()`
   - `formatConfigInitHelp()`
   - 각 runner는 옵션 파싱 직후 `options.help`면 helper 출력 + early return.
   - auth list / import는 parser가 없으므로 args/provider에서 `--help` 직접 감지.
3. **전역 help 통합** (`run-cli.js`)
   - 기존 하드코딩된 `printHelp()` 제거 → `formatGlobalHelp()`로 대체.
   - 각 서브커맨드 help helper의 first-line(one-liner)을 모아 요약 목록 구성(단일 source of truth).
   - `ai-usage-agent --help` / `-h` 전역 호출 지원 추가.
4. 테스트 22개 추가 (helper 단위 + runner 경로).

## 변경 이유

- 기존에는 unknown 커맨드일 때만 전역 help가 나왔고, 서브커맨드별 옵션 발견 경로가 README/source였다.
- `--provider`, `--json` 등 후속 옵션 추가 시 발견 경로가 계속 나빠지므로 선행 작업으로 help 시스템을 정비.
- #61에서 확보한 `parseCliOptions`를 재사용하여 플래그 확산을 방지.

## 영향 범위

- [x] `packages/agent` (cli 레이어)
- [ ] `packages/provider-adapters`
- [ ] `packages/schemas`
- [ ] `docs`

## 테스트 / 확인

- `npm test`: **568/568 통과** (기존 544 + 신규 help 관련 24 — helper + runner 경로).
- CLI smoke: `status --help`, `doctor --help`, `auth login --help`, `config init --help`, `ai-usage-agent --help` 모두 의도한 help 출력.
- 기존 동작(옵션 없이 실행)은 비변경.

## 리뷰 포인트

- `auth list` / `auth import`처럼 parser가 없는 커맨드는 args/provider에서 `--help`를 직접 탐색한다. parser가 없는 커맨드에도 `parseCliOptions({ defaults: {}, flags: {}, includeHelp: true })`를 최소 구성으로 쓸지 여부 — 현재는 의존성 최소화를 택함.
- 전역 `formatGlobalHelp()`가 서브커맨드 help의 first-line을 사용하는 설계 — 각 helper의 첫 줄 포맷이 사실상 "사용법 1줄 요약"의 계약이 된다. 의도가 맞는지 확인.
- `config init --help` 지원을 위해 `runConfigInitCommand(args)` 시그니처가 확장됨. `run-cli.js`의 `config init` 라우팅도 args를 넘기도록 맞춤.

## 참고 사항

- 선행: #61 (공통 parser) — dev 머지 완료.
- 후속: #64(`--provider`), #65(`--json`)에서 help 문자열에 추가 옵션 반영.