### PR TITLE
[feat] status/usage --provider scope 옵션

### DIFF
--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -218,6 +218,15 @@ resolveAuthSource(agentAccounts, [
 - agent-store 계정에 대해서만 `usage-auto-refresh.js`가 preflight refresh와 `auth` bucket 재시도를 담당한다.
 - import source는 store를 갱신할 수 없으므로 자동 refresh 대상이 아니다.
 
+### 4.1.2 RunOptions
+
+`runProviderSnapshots(config, options)` / `getStatusSnapshot(options)`가 받는 옵션:
+
+- `accountFilter` — `--account <id>` 결과. provider 내부에서 `filterProfilesByAccount`를 통해 매치된 real 계정만 사용한다.
+- `providerFilter` — `--provider <id>` 결과. registry의 `id`(`'codex'` | `'claude'`)와 정확히 일치하면 해당 provider만 실행, 그 외 id는 빈 결과(`{}`)를 반환한다. 사용자 노출 검증은 CLI 레이어(`status-command.js`)가 `PROVIDER_IDS`로 미리 수행한다.
+
+이 두 필터는 독립적이며 동시 사용 가능 (`--provider codex --account work`).
+
 ### 4.2 Provider spec (registry용)
 
 ```js

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -1,4 +1,5 @@
 import { getStatusSnapshot } from '../services/status-service.js';
+import { PROVIDER_IDS } from '../services/provider-registry.js';
 import { parseCliOptions } from './parse-options.js';
 
 // 포맷터는 status-formatters.js에서 관리. 기존 import 경로 호환을 위해 re-export.
@@ -27,7 +28,17 @@ export async function runStatusCommand(command, args = []) {
     for (const line of formatStatusHelp(command)) console.log(line);
     return;
   }
-  const snapshot = await getStatusSnapshot({ accountFilter: options.account });
+  if (options.provider && !PROVIDER_IDS.includes(options.provider)) {
+    console.error(
+      `알 수 없는 provider: ${options.provider} (사용 가능: ${PROVIDER_IDS.join(', ')})`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const snapshot = await getStatusSnapshot({
+    accountFilter: options.account,
+    providerFilter: options.provider,
+  });
   for (const line of formatStatusOutput(command, snapshot)) {
     console.log(line);
   }
@@ -38,9 +49,10 @@ export async function runStatusCommand(command, args = []) {
  */
 export function parseStatusOptions(args) {
   return parseCliOptions(args, {
-    defaults: { account: null },
+    defaults: { account: null, provider: null },
     flags: {
       '--account': { key: 'account', type: 'string' },
+      '--provider': { key: 'provider', type: 'string' },
     },
     includeHelp: true,
   });
@@ -50,6 +62,7 @@ export function parseStatusOptions(args) {
  * `status` / `usage` 커맨드의 --help 출력 줄을 반환한다. Pure function.
  */
 export function formatStatusHelp(command = 'status') {
+  const providerList = PROVIDER_IDS.join(', ');
   return [
     `ai-usage-agent ${command} [options]`,
     '',
@@ -57,7 +70,8 @@ export function formatStatusHelp(command = 'status') {
     '여러 계정이 저장되어 있으면 기본적으로 모두 병렬 조회합니다.',
     '',
     'Options:',
-    '  --account <id>   특정 계정만 조회 (email / accountKey / label, case-insensitive)',
-    '  -h, --help       이 도움말 출력',
+    '  --account <id>     특정 계정만 조회 (email / accountKey / label, case-insensitive)',
+    `  --provider <id>    특정 provider만 조회 (사용 가능: ${providerList})`,
+    '  -h, --help         이 도움말 출력',
   ];
 }

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -28,7 +28,10 @@ export async function runStatusCommand(command, args = []) {
     for (const line of formatStatusHelp(command)) console.log(line);
     return;
   }
-  if (options.provider && !PROVIDER_IDS.includes(options.provider)) {
+  // --account가 case-insensitive(`resolveAccountByIdentifier`)인 것과 일관되게,
+  // --provider 값도 case-insensitive로 정규화한 뒤 PROVIDER_IDS와 비교한다.
+  const providerFilter = normalizeProviderFilter(options.provider);
+  if (options.provider && providerFilter === null) {
     console.error(
       `알 수 없는 provider: ${options.provider} (사용 가능: ${PROVIDER_IDS.join(', ')})`,
     );
@@ -37,11 +40,24 @@ export async function runStatusCommand(command, args = []) {
   }
   const snapshot = await getStatusSnapshot({
     accountFilter: options.account,
-    providerFilter: options.provider,
+    providerFilter,
   });
   for (const line of formatStatusOutput(command, snapshot)) {
     console.log(line);
   }
+}
+
+/**
+ * --provider 입력값을 trim+lowercase한 뒤 PROVIDER_IDS와 매치되면 그 id를,
+ * 입력이 없거나 매치되지 않으면 null을 반환한다. (case-insensitive)
+ *
+ * Pure helper — runner 외부에서 검증 단위 테스트로 호출 가능.
+ */
+export function normalizeProviderFilter(raw) {
+  if (raw === null || raw === undefined) return null;
+  const normalized = String(raw).trim().toLowerCase();
+  if (normalized === '') return null;
+  return PROVIDER_IDS.includes(normalized) ? normalized : null;
 }
 
 /**
@@ -71,7 +87,7 @@ export function formatStatusHelp(command = 'status') {
     '',
     'Options:',
     '  --account <id>     특정 계정만 조회 (email / accountKey / label, case-insensitive)',
-    `  --provider <id>    특정 provider만 조회 (사용 가능: ${providerList})`,
+    `  --provider <id>    특정 provider만 조회 (사용 가능: ${providerList}, case-insensitive)`,
     '  -h, --help         이 도움말 출력',
   ];
 }

--- a/packages/agent/src/cli/status-formatters.js
+++ b/packages/agent/src/cli/status-formatters.js
@@ -7,6 +7,10 @@
 
 /**
  * 전체 status 출력 라인 배열.
+ *
+ * `snapshot.providerFilter`가 지정되어 있으면 매칭되지 않는 provider 섹션은
+ * 출력하지 않는다 (해당 provider snapshot 자체가 없으므로 안전하게 skip).
+ * 헤더의 "Codex 사용 / Claude 사용" 라인은 config 기반이라 그대로 노출한다.
  */
 export function formatStatusOutput(command, snapshot) {
   const lines = [
@@ -21,12 +25,15 @@ export function formatStatusOutput(command, snapshot) {
   if (snapshot.accountFilter) {
     lines.push(`계정 필터: ${snapshot.accountFilter}`);
   }
-  lines.push(
-    '',
-    ...formatCodexSection(snapshot.codex),
-    '',
-    ...formatClaudeSection(snapshot.claude),
-  );
+  if (snapshot.providerFilter) {
+    lines.push(`provider 필터: ${snapshot.providerFilter}`);
+  }
+  if (snapshot.codex) {
+    lines.push('', ...formatCodexSection(snapshot.codex));
+  }
+  if (snapshot.claude) {
+    lines.push('', ...formatClaudeSection(snapshot.claude));
+  }
   return lines;
 }
 

--- a/packages/agent/src/services/provider-registry.js
+++ b/packages/agent/src/services/provider-registry.js
@@ -15,6 +15,8 @@ import { getClaudeSnapshot } from './claude-provider.js';
  * @typedef {object} RunOptions
  * @property {string} [accountFilter] - email / accountKey (추후 label 포함) 중 하나.
  *   지정 시 각 provider는 매치되는 real 계정만 조회.
+ * @property {string} [providerFilter] - registry id (현재 'codex' | 'claude').
+ *   지정 시 해당 provider 한 곳만 snapshot을 만든다. 미일치 id는 빈 결과(`{}`).
  */
 
 /** @type {ReadonlyArray<ProviderSpec>} */
@@ -23,18 +25,28 @@ export const PROVIDER_REGISTRY = Object.freeze([
   { id: 'claude', getSnapshot: getClaudeSnapshot },
 ]);
 
+/** registry에 등록된 provider id 목록(snapshot 키). */
+export const PROVIDER_IDS = Object.freeze(PROVIDER_REGISTRY.map((p) => p.id));
+
 /**
- * Run all registered providers with the given config and return keyed snapshots.
+ * Run registered providers with the given config and return keyed snapshots.
  * CLI로 전달된 accountFilter가 있으면 그 값을 우선 적용하고, 없으면
  * config.defaults.profiles.<provider>로 fallback한다.
+ *
+ * `options.providerFilter`가 지정되면 해당 id의 provider만 실행한다.
+ * (registry에 없는 id면 빈 객체를 반환 — CLI 레이어에서 미리 검증 권장.)
  *
  * @param {object} config
  * @param {RunOptions} [options]
  * @returns {Promise<Record<string, object>>}
  */
 export async function runProviderSnapshots(config, options = {}) {
+  const filter = options.providerFilter ?? null;
+  const targets = filter
+    ? PROVIDER_REGISTRY.filter((p) => p.id === filter)
+    : PROVIDER_REGISTRY;
   const entries = await Promise.all(
-    PROVIDER_REGISTRY.map(async (p) => {
+    targets.map(async (p) => {
       const providerOptions = {
         ...options,
         accountFilter:

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -22,7 +22,8 @@ export {
  * Build the top-level status snapshot by loading config and calling every
  * registered provider. New providers go through provider-registry.js, not here.
  *
- * @param {{ accountFilter?: string }} [options]
+ * @param {{ accountFilter?: string, providerFilter?: string }} [options]
+ *   `providerFilter`가 지정되면 해당 provider 한 곳의 snapshot만 포함된다.
  */
 export async function getStatusSnapshot(options = {}) {
   const configPath = resolveAgentConfigPath();
@@ -35,6 +36,7 @@ export async function getStatusSnapshot(options = {}) {
     providers: config.providers,
     sync: config.sync,
     accountFilter: options.accountFilter ?? null,
+    providerFilter: options.providerFilter ?? null,
     ...providerSnapshots,
   };
 }

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -277,11 +277,11 @@ describe('formatClaudeSection — networkUsages array support', () => {
 
 describe('parseStatusOptions', () => {
   it('returns { account: null } for empty args', () => {
-    assert.deepEqual(parseStatusOptions([]), { account: null, help: false });
+    assert.deepEqual(parseStatusOptions([]), { account: null, provider: null, help: false });
   });
 
   it('handles null/undefined args', () => {
-    assert.deepEqual(parseStatusOptions(undefined), { account: null, help: false });
+    assert.deepEqual(parseStatusOptions(undefined), { account: null, provider: null, help: false });
   });
 
   it('parses --account <value>', () => {
@@ -296,13 +296,24 @@ describe('parseStatusOptions', () => {
 
   it('treats --account "" as "no value" (legacy contract)', () => {
     // 공통 helper 전환 후에도 빈 문자열은 default 유지해야 한다.
-    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null, help: false });
+    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null, provider: null, help: false });
   });
 
   it('recognizes --help and -h', () => {
     assert.equal(parseStatusOptions(['--help']).help, true);
     assert.equal(parseStatusOptions(['-h']).help, true);
     assert.equal(parseStatusOptions([]).help, false);
+  });
+
+  it('parses --provider <id>', () => {
+    assert.equal(parseStatusOptions(['--provider', 'codex']).provider, 'codex');
+    assert.equal(parseStatusOptions(['--provider', 'claude']).provider, 'claude');
+  });
+
+  it('--provider and --account can coexist', () => {
+    const out = parseStatusOptions(['--provider', 'codex', '--account', 'work']);
+    assert.equal(out.provider, 'codex');
+    assert.equal(out.account, 'work');
   });
 });
 
@@ -317,10 +328,17 @@ describe('formatStatusHelp', () => {
     assert.match(lines[0], /ai-usage-agent status/);
   });
 
-  it('lists --account and --help in Options section', () => {
+  it('lists --account, --provider and --help in Options section', () => {
     const body = formatStatusHelp('usage').join('\n');
     assert.match(body, /--account/);
+    assert.match(body, /--provider <id>/);
     assert.match(body, /-h, --help/);
+  });
+
+  it('shows registered provider ids in --provider hint', () => {
+    const body = formatStatusHelp().join('\n');
+    assert.match(body, /codex/);
+    assert.match(body, /claude/);
   });
 });
 

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -11,6 +11,7 @@ import {
   formatWindow,
   formatStatusHelp,
   parseStatusOptions,
+  normalizeProviderFilter,
   STATUS_COMMANDS,
 } from '../../src/cli/status-command.js';
 
@@ -317,6 +318,38 @@ describe('parseStatusOptions', () => {
   });
 });
 
+describe('normalizeProviderFilter', () => {
+  it('returns null for null/undefined/empty input', () => {
+    assert.equal(normalizeProviderFilter(null), null);
+    assert.equal(normalizeProviderFilter(undefined), null);
+    assert.equal(normalizeProviderFilter(''), null);
+    assert.equal(normalizeProviderFilter('   '), null);
+  });
+
+  it('passes registered ids through unchanged', () => {
+    assert.equal(normalizeProviderFilter('codex'), 'codex');
+    assert.equal(normalizeProviderFilter('claude'), 'claude');
+  });
+
+  it('matches case-insensitively (Codex / CLAUDE / cLaUdE)', () => {
+    assert.equal(normalizeProviderFilter('Codex'), 'codex');
+    assert.equal(normalizeProviderFilter('CLAUDE'), 'claude');
+    assert.equal(normalizeProviderFilter('cLaUdE'), 'claude');
+  });
+
+  it('trims whitespace before lookup', () => {
+    assert.equal(normalizeProviderFilter('  codex  '), 'codex');
+    assert.equal(normalizeProviderFilter('\tclaude\n'), 'claude');
+  });
+
+  it('returns null when normalized value is not a registered id', () => {
+    assert.equal(normalizeProviderFilter('gemini'), null);
+    // accountKey-prefix 변형은 의도적으로 받지 않는다 (별도 결정 사안).
+    assert.equal(normalizeProviderFilter('openai-codex'), null);
+    assert.equal(normalizeProviderFilter('anthropic-claude'), null);
+  });
+});
+
 describe('formatStatusHelp', () => {
   it('returns first line with command name and [options]', () => {
     const lines = formatStatusHelp('status');
@@ -339,6 +372,10 @@ describe('formatStatusHelp', () => {
     const body = formatStatusHelp().join('\n');
     assert.match(body, /codex/);
     assert.match(body, /claude/);
+  });
+
+  it('mentions case-insensitive matching for --provider', () => {
+    assert.match(formatStatusHelp().join('\n'), /case-insensitive/);
   });
 });
 

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -379,6 +379,53 @@ describe('formatStatusOutput — accountFilter line', () => {
   });
 });
 
+describe('formatStatusOutput — providerFilter scope', () => {
+  const baseSnapshot = {
+    configPath: '/x',
+    providers: { codex: { enabled: true }, claude: { enabled: true } },
+    sync: { enabled: false },
+  };
+  const codexSnap = { enabled: false };
+  const claudeSnap = {
+    authSource: 'not-found',
+    detected: false,
+    selectedAccount: null,
+    networkUsages: [],
+    usage: { source: 'not-found' },
+  };
+
+  it('renders only Codex usage section when providerFilter=codex (no claude key)', () => {
+    const lines = formatStatusOutput('status', {
+      ...baseSnapshot,
+      providerFilter: 'codex',
+      codex: codexSnap,
+    });
+    assert.ok(lines.includes('provider 필터: codex'));
+    assert.ok(lines.some((l) => l === 'Codex usage'));
+    assert.ok(!lines.some((l) => l === 'Claude usage'));
+  });
+
+  it('renders only Claude usage section when providerFilter=claude (no codex key)', () => {
+    const lines = formatStatusOutput('usage', {
+      ...baseSnapshot,
+      providerFilter: 'claude',
+      claude: claudeSnap,
+    });
+    assert.ok(lines.includes('provider 필터: claude'));
+    assert.ok(lines.some((l) => l === 'Claude usage'));
+    assert.ok(!lines.some((l) => l === 'Codex usage'));
+  });
+
+  it('omits "provider 필터" line when not set', () => {
+    const lines = formatStatusOutput('status', {
+      ...baseSnapshot,
+      codex: codexSnap,
+      claude: claudeSnap,
+    });
+    assert.ok(!lines.some((l) => l.startsWith('provider 필터:')));
+  });
+});
+
 describe('formatCodexSection — accountFilter empty result', () => {
   it('shows filter-specific message when filteredOut=true and snapshots empty', () => {
     const lines = formatCodexSection({

--- a/packages/agent/test/services/provider-registry.test.js
+++ b/packages/agent/test/services/provider-registry.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { PROVIDER_REGISTRY, runProviderSnapshots } from '../../src/services/provider-registry.js';
+import { PROVIDER_REGISTRY, PROVIDER_IDS, runProviderSnapshots } from '../../src/services/provider-registry.js';
 
 describe('PROVIDER_REGISTRY', () => {
   it('is frozen (cannot be mutated)', () => {
@@ -57,5 +57,44 @@ describe('runProviderSnapshots', () => {
       providers: { codex: { enabled: false } },
       defaults: { profiles: { codex: 'config-default' } },
     });
+  });
+
+  it('runs only the matching provider when providerFilter=codex', async () => {
+    const out = await runProviderSnapshots(
+      { providers: { codex: { enabled: false }, claude: { enabled: false } } },
+      { providerFilter: 'codex' },
+    );
+    assert.ok('codex' in out);
+    assert.equal('claude' in out, false);
+  });
+
+  it('runs only the matching provider when providerFilter=claude', async () => {
+    const out = await runProviderSnapshots(
+      { providers: { codex: { enabled: false }, claude: { enabled: false } } },
+      { providerFilter: 'claude' },
+    );
+    assert.ok('claude' in out);
+    assert.equal('codex' in out, false);
+  });
+
+  it('returns empty object when providerFilter does not match any registered id', async () => {
+    const out = await runProviderSnapshots(
+      { providers: {} },
+      { providerFilter: 'unknown' },
+    );
+    assert.deepEqual(out, {});
+  });
+});
+
+describe('PROVIDER_IDS', () => {
+  it('mirrors PROVIDER_REGISTRY ids in declaration order', () => {
+    assert.deepEqual(
+      [...PROVIDER_IDS],
+      PROVIDER_REGISTRY.map((p) => p.id),
+    );
+  });
+
+  it('is frozen', () => {
+    assert.throws(() => PROVIDER_IDS.push('extra'));
   });
 });


### PR DESCRIPTION
## 요약

`status` / `usage`에 `--provider <id>` 옵션을 추가해 단일 provider snapshot만 조회/출력 가능하게 함. provider-registry / status-service / formatter / parser 한 줄로 흐르도록 정리.

closes #64

## 변경 내용

1. **services**
   - `provider-registry.js`에 `PROVIDER_IDS` export 추가, `runProviderSnapshots`가 `options.providerFilter`로 단일 provider만 실행하도록 분기. 매칭되지 않으면 빈 객체 반환.
   - `status-service.js`의 `getStatusSnapshot`이 `providerFilter`를 받고 결과 객체에 노출.
2. **CLI**
   - `parseStatusOptions`에 `--provider <id>` 추가 (string).
   - `runStatusCommand`가 알 수 없는 id 입력 시 stderr에 사용 가능 목록을 출력하고 `process.exitCode = 1`.
   - `formatStatusHelp`에 `--provider` 줄 추가 (`PROVIDER_IDS` 기반 안내).
3. **formatter**
   - `formatStatusOutput`이 `snapshot.codex` / `snapshot.claude` 누락 시 해당 섹션을 생략. `providerFilter` 있으면 헤더에 노출.
4. **docs**
   - `codebase-guide.md §4.1.2`에 `RunOptions`(accountFilter / providerFilter) 정리 단락 추가.
5. **tests**
   - registry: codex/claude 단독 실행, unknown filter, `PROVIDER_IDS` shape (5건)
   - parser: `--provider` 단독, `--account`와 동시 사용 (2건)
   - formatter: 부분 snapshot 3가지 (3건)
   - help 라인 갱신 (1건)

## 변경 이유

- `config.providers.{id}.enabled`를 켰다 끄는 우회 없이 단일 provider 조회가 가능해야 함.
- 후속 `--json` 출력에서도 filter 결과가 자연스럽게 한 provider만 포함되도록 흐름을 미리 정리.

## 영향 범위

- [x] `packages/agent/src/services` (registry + status-service)
- [x] `packages/agent/src/cli` (parser + formatter)
- [x] `docs` (codebase-guide §4.1.2)
- [ ] `packages/provider-adapters`
- [ ] `packages/schemas`

## 테스트 / 확인

- `npm test`: **585/585 통과** (574 + 신규 11).
- CLI smoke:
  - `ai-usage-agent status --provider codex` → Codex 섹션만 출력 + 헤더에 "provider 필터: codex"
  - `ai-usage-agent status --provider claude` → Claude 섹션만 출력
  - `ai-usage-agent status --provider gemini` → stderr `알 수 없는 provider: gemini (사용 가능: codex, claude)` + exit 1
  - `ai-usage-agent status --account work --provider codex` → 두 필터 동시 적용
- 기본 동작(`--provider` 없을 때)은 비변경 — 기존 회귀 테스트 그대로 통과.

## 리뷰 포인트

- provider id 매핑 — registry 키(`'codex'`/`'claude'`)를 그대로 CLI 인터페이스로 사용. account key prefix(`openai-codex`, `anthropic-claude`)는 받지 않음. 의도가 맞는지 확인.
- unknown id에서 stderr + exit 1을 택함. issue 본문이 두 가지 경로(stderr 경고 / formatter 섹션 출력)를 제시했는데, **CLI 레벨 fail-fast**가 자동화 친화적이라 판단.
- 헤더에 `provider 필터: <id>` 줄을 추가했는데 (기존 `계정 필터:` 패턴 따름), formatter 출력 라인 수가 한 줄 늘어남 — 시각적 노이즈 우려가 있으면 알려주세요.
- `runProviderSnapshots`는 unknown filter에 대해 빈 객체를 반환합니다. CLI가 미리 검증하므로 정상 흐름에선 닿지 않지만, 직접 호출하는 다른 진입점(예: 테스트)이 생길 경우 정책을 명확히 하는 것이 좋겠습니다.

## 참고 사항

- 선행: #61 (공통 parser), #63 (`--help`) — dev 머지 완료.
- 후속: #65 (`--json`) — provider 필터 결과를 JSON 모드로도 깨끗이 출력해야 함.