### PR TITLE
[feat] status/usage --json 출력 포맷 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ ai-usage-agent config init
 - `docs/codebase-guide.md` — 다른 Claude 세션 / 기여자가 구조적 일관성을 유지하며 작업할 수 있도록 정리한 상세 가이드 (패키지 레이아웃, shared/ 헬퍼 사용법, provider adapter 패턴, 네이밍 / 테스트 / 커밋 규칙, anti-patterns, 새 기능 체크리스트).
 - `docs/architecture.md` — 고수준 구조 요약.
 - `docs/auth-cli.md` — CLI 명령 / 정책.
+- `docs/cli-json-output.md` — `status` / `usage` `--json` 출력 contract와 redaction 규약.
 - `docs/provider-notes.md` — provider별 observed endpoint / client_id.
 - `CONTRIBUTING.md` — 브랜치 / 커밋 / PR 규칙.
 

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -1,0 +1,75 @@
+# CLI JSON 출력 (`--json`)
+
+`status` / `usage` 커맨드는 `--json` 플래그로 정규화된 JSON 한 줄을 stdout에 출력한다. 자동화 / 대시보드 / 백엔드 수집기가 텍스트 포매팅을 다시 파싱하지 않고 직접 소비할 수 있도록 한 명세다.
+
+이 문서는 출력 shape의 **stable contract**다. 변경 시 schema bump이 필요하다(현재 `schemaVersion`은 `packages/schemas`와 공유).
+
+## 사용
+
+```bash
+ai-usage-agent status --json
+ai-usage-agent usage  --json
+ai-usage-agent status --json --provider codex
+ai-usage-agent status --json --account work@example.com --provider claude
+```
+
+- stdout에는 **JSON 한 줄**만 흐른다 (개행 1개로 종료).
+- 안내·경고·실패 메시지는 stderr로 흐른다 (자동화는 stdout만 파싱하면 된다).
+- 알 수 없는 `--provider` 입력은 기존 텍스트 모드와 동일하게 stderr 메시지 + `exit 1`. JSON으로 fallback하지 않는다 (호출자가 명시적으로 실패를 인지하도록).
+
+## Top-level shape
+
+```json
+{
+  "command": "status",
+  "generatedAt": "2026-04-25T08:30:00.000Z",
+  "schemaVersion": 1,
+  "configPath": "/home/user/.config/ai-usage-agent/config.json",
+  "accountFilter": null,
+  "providerFilter": null,
+  "providers": [
+    { "id": "codex",  "snapshot": { ... } },
+    { "id": "claude", "snapshot": { ... } }
+  ]
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `command` | `"status"` \| `"usage"` | 호출된 커맨드 이름. |
+| `generatedAt` | ISO-8601 string | snapshot 직렬화 시각(client-side). |
+| `schemaVersion` | int \| null | `packages/schemas/src/index.js::SCHEMA_VERSION`을 그대로 통과. |
+| `configPath` | string \| null | resolved config 파일 경로. |
+| `accountFilter` | string \| null | `--account <id>` 입력 (case-insensitive 매치는 별도). |
+| `providerFilter` | string \| null | `--provider <id>` 입력. lowercase 정규화된 값. |
+| `providers` | array | 아래 §providers 참고. |
+
+## providers
+
+`providers`는 `[{ id, snapshot }]` 배열이다. `id`는 registry id(`codex` / `claude`)로, `--provider`가 받는 값과 동일.
+
+`providerFilter`가 지정되면 매칭되는 provider만 배열에 포함된다 (다른 provider는 snapshot 자체가 만들어지지 않으므로 누락). 미지정 시 등록 순서대로 모두 포함.
+
+`snapshot`은 각 provider builder(`getCodexSnapshot` / `getClaudeSnapshot`)가 반환하는 객체에서 **민감 키를 제거한 deep clone**이다.
+
+### 제거되는 민감 키 (redaction)
+
+다음 key가 객체 / 배열 어느 깊이에 있든 출력에서 빠진다 (전체 subtree 제거):
+
+- `accessToken`, `refreshToken`, `idToken`, `tokens`
+- `sessionKey`, `sessionCookie`
+- `codeVerifier`, `client_secret`
+
+추가되는 토큰성 필드는 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 등록한다. 신규 provider 추가 시 토큰 필드 명을 이 목록과 맞춰야 자동으로 redact된다.
+
+## 안정성
+
+- 신규 키 추가는 **non-breaking** (소비자는 unknown 필드 무시 권장).
+- 키 제거 / 의미 변경 / shape 재구성은 **breaking** — `schemaVersion` 증가가 필요.
+- `providers[].id` 식별자는 `PROVIDER_REGISTRY`와 동기화되며, 추가/삭제는 schema bump 사유.
+
+## 보안 원칙
+
+- 토큰류는 stdout/stderr 어느 곳으로도 출력 금지 (텍스트 모드도 동일).
+- `--json` 모드는 redaction을 거치므로 logging 파이프라인 또는 외부 시스템에 그대로 보내도 안전한 contract를 목표로 한다.
+- 추가로 `raw` 같은 자유 형식 필드를 도입할 때는 토큰 누출 여부를 케이스별로 검토한다.

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -54,13 +54,26 @@ ai-usage-agent status --json --account work@example.com --provider claude
 
 ### 제거되는 민감 키 (redaction)
 
-다음 key가 객체 / 배열 어느 깊이에 있든 출력에서 빠진다 (전체 subtree 제거):
+다음 key가 객체 / 배열 어느 깊이에 있든 출력에서 빠진다 (전체 subtree 제거).
+매칭은 **case-insensitive** (`AccessToken` / `ACCESSTOKEN` 모두 동일하게 차단).
 
-- `accessToken`, `refreshToken`, `idToken`, `tokens`
-- `sessionKey`, `sessionCookie`
-- `codeVerifier`, `client_secret`
+- OAuth tokens (camelCase + snake_case): `accessToken`, `refreshToken`, `idToken`, `tokens`, `access_token`, `refresh_token`, `id_token`
+- OAuth client secret / verifier: `client_secret`, `clientSecret`, `codeVerifier`, `code_verifier`
+- Session / cookie 자료: `sessionKey`, `sessionCookie`, `session_key`, `session_cookie`
+- HTTP credential 헤더: `authorization`, `cookie`
+- 일반 API key / password: `apiKey`, `api_key`, `password`
 
-추가되는 토큰성 필드는 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 등록한다. 신규 provider 추가 시 토큰 필드 명을 이 목록과 맞춰야 자동으로 redact된다.
+신규 provider/스키마가 새 토큰 필드를 도입할 때는 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 함께 등록한다.
+
+### 한계 (key-name match list, value detector 아님)
+
+본 redaction은 **정확한 key 이름**을 기준으로 동작한다(case-insensitive 비교는 하지만 정규식이나 값 패턴 검사는 하지 않는다). 즉:
+
+- 위 목록에 없는 이름으로 토큰성 데이터가 들어오면 자동으로 걸러지지 **않는다** (예: `bearer`, `access-key`, `secretToken` 등 신규 식별자).
+- 객체의 `raw` / `meta` 같은 자유 형식 subtree에 토큰을 직렬로 넣지 말 것 — 또는 SENSITIVE_KEYS에 해당 이름을 등록할 것.
+- JWT 같은 값 패턴이 `notes`나 `description` 같은 임의 키에 박혀 들어오면 redact되지 않는다 — provider adapter 단에서 토큰 값을 그런 자유 필드에 복사하지 않도록 책임이 있다.
+
+이 한계는 `--json` contract가 *값 검사기*가 아닌 *명시적 명시 누출 차단기*라는 설계상의 결정이다. 새 식별자가 발견되면 PR로 SENSITIVE_KEYS를 갱신하면 된다.
 
 ## 안정성
 

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -300,6 +300,17 @@ Provider spec shape(`LoginProviderSpec`):
 
 호출자는 `options.warnings.length > 0`이면 stderr로 출력 후 조기 리턴한다 (`auth-login-command.js::reportAndGuardOptionWarnings` 참고).
 
+### 5.2.1 status --json 모드
+
+`status` / `usage`는 `--json`으로 정규화된 JSON 한 줄을 stdout에 출력할 수 있다.
+출력 shape와 redaction 규약은 `docs/cli-json-output.md`에 stable contract로 정리되어 있다.
+
+구현 위치: `cli/status-json.js`
+- `redactSensitive(value)` — 토큰성 키(SENSITIVE_KEYS) 제거 deep clone, Date 통과
+- `formatStatusJson(snapshot, { command, generatedAt })` — single-line JSON 직렬화
+
+신규 토큰 필드를 provider adapter / auth schema에 추가할 때는 이 모듈의 `SENSITIVE_KEYS`에도 동시에 등록할 것. 누락되면 `--json` 출력에 그대로 노출된다.
+
 ### 5.3 공통 option parser
 
 모든 CLI 파서(`parseLoginOptions`, `parseStatusOptions`, `parseLogoutOptions`,

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -1,6 +1,7 @@
 import { getStatusSnapshot } from '../services/status-service.js';
 import { PROVIDER_IDS } from '../services/provider-registry.js';
 import { parseCliOptions } from './parse-options.js';
+import { formatStatusJson } from './status-json.js';
 
 // 포맷터는 status-formatters.js에서 관리. 기존 import 경로 호환을 위해 re-export.
 export {
@@ -42,6 +43,13 @@ export async function runStatusCommand(command, args = []) {
     accountFilter: options.account,
     providerFilter,
   });
+
+  if (options.json) {
+    // 자동화 친화: stdout에는 JSON 한 줄만, 안내·경고는 stderr로.
+    console.log(formatStatusJson(snapshot, { command }));
+    return;
+  }
+
   for (const line of formatStatusOutput(command, snapshot)) {
     console.log(line);
   }

--- a/packages/agent/src/cli/status-command.js
+++ b/packages/agent/src/cli/status-command.js
@@ -65,10 +65,11 @@ export function normalizeProviderFilter(raw) {
  */
 export function parseStatusOptions(args) {
   return parseCliOptions(args, {
-    defaults: { account: null, provider: null },
+    defaults: { account: null, provider: null, json: false },
     flags: {
       '--account': { key: 'account', type: 'string' },
       '--provider': { key: 'provider', type: 'string' },
+      '--json': { key: 'json', type: 'boolean' },
     },
     includeHelp: true,
   });
@@ -88,6 +89,7 @@ export function formatStatusHelp(command = 'status') {
     'Options:',
     '  --account <id>     특정 계정만 조회 (email / accountKey / label, case-insensitive)',
     `  --provider <id>    특정 provider만 조회 (사용 가능: ${providerList}, case-insensitive)`,
+    '  --json             정규화된 JSON 한 줄을 stdout에 출력 (자동화/대시보드용)',
     '  -h, --help         이 도움말 출력',
   ];
 }

--- a/packages/agent/src/cli/status-json.js
+++ b/packages/agent/src/cli/status-json.js
@@ -16,20 +16,59 @@ import { PROVIDER_IDS } from '../services/provider-registry.js';
 
 /**
  * JSON 출력에서 제거할 민감 키 목록.
- * 신규 토큰 필드가 추가되면 여기에 등록한다.
+ * 신규 토큰/credential 필드가 추가되면 여기에 등록한다.
+ *
+ * 매칭은 `isSensitiveKey`에서 **case-insensitive**로 수행한다. 즉
+ * `accessToken` 한 항목으로 `AccessToken`/`accesstoken`도 같이 걸린다. 단,
+ * snake_case와 camelCase는 lowercase 후에도 다른 문자열이므로(`access_token` vs
+ * `accesstoken`) 두 변종은 모두 명시적으로 등록한다.
+ *
+ * 한계: 이 모듈은 **key-name 정확 매치(case-insensitive)** 기반이며 값
+ * 패턴(JWT 같은 형태) 감지는 하지 않는다. 새 provider/스키마가 본 목록에 없는
+ * 이름으로 토큰성 데이터를 도입하면 자동으로 걸러지지 않는다. `raw` 같은 자유
+ * 형식 subtree에 토큰을 넣지 말 것 — 또는 본 목록을 갱신할 것.
  */
 export const SENSITIVE_KEYS = Object.freeze(
   new Set([
+    // OAuth tokens (camelCase + snake_case)
     'accessToken',
     'refreshToken',
     'idToken',
     'tokens',
+    'access_token',
+    'refresh_token',
+    'id_token',
+    // OAuth client secret / verifier
+    'client_secret',
+    'clientSecret',
+    'codeVerifier',
+    'code_verifier',
+    // Session / cookie material
     'sessionKey',
     'sessionCookie',
-    'codeVerifier',
-    'client_secret',
+    'session_key',
+    'session_cookie',
+    // HTTP header / cookie value (raw passthrough 사고 방지)
+    'authorization',
+    'cookie',
+    // Generic API key / password
+    'apiKey',
+    'api_key',
+    'password',
   ]),
 );
+
+const SENSITIVE_KEYS_LC = new Set([...SENSITIVE_KEYS].map((k) => k.toLowerCase()));
+
+/**
+ * 주어진 키가 SENSITIVE_KEYS와 case-insensitive로 매치되는지 검사.
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isSensitiveKey(key) {
+  return SENSITIVE_KEYS_LC.has(String(key).toLowerCase());
+}
 
 /**
  * 객체를 재귀 순회하며 SENSITIVE_KEYS 항목을 빼고 deep clone을 반환한다.
@@ -45,7 +84,7 @@ export function redactSensitive(value) {
   if (Array.isArray(value)) return value.map(redactSensitive);
   const out = {};
   for (const [k, v] of Object.entries(value)) {
-    if (SENSITIVE_KEYS.has(k)) continue;
+    if (isSensitiveKey(k)) continue;
     out[k] = redactSensitive(v);
   }
   return out;

--- a/packages/agent/src/cli/status-json.js
+++ b/packages/agent/src/cli/status-json.js
@@ -1,0 +1,108 @@
+/**
+ * status / usage --json 출력 모듈.
+ *
+ * 두 가지 책임:
+ * 1) `redactSensitive(value)` — 객체를 재귀적으로 walk하면서 토큰/세션 계열
+ *    민감 키를 제거한 사본을 반환한다. 원본은 변경하지 않는다.
+ * 2) `formatStatusJson(snapshot, { command, generatedAt })` — status snapshot을
+ *    {command, generatedAt, providerFilter, accountFilter, providers[]} shape의
+ *    JSON 문자열 한 줄로 직렬화한다.
+ *
+ * stdout은 자동화/대시보드가 파싱 가능한 단일 line이어야 하므로 indent하지 않는다.
+ * 추가 안내·헤더는 모두 stderr 또는 비-json 모드에서만 출력해야 한다.
+ */
+
+import { PROVIDER_IDS } from '../services/provider-registry.js';
+
+/**
+ * JSON 출력에서 제거할 민감 키 목록.
+ * 신규 토큰 필드가 추가되면 여기에 등록한다.
+ */
+export const SENSITIVE_KEYS = Object.freeze(
+  new Set([
+    'accessToken',
+    'refreshToken',
+    'idToken',
+    'tokens',
+    'sessionKey',
+    'sessionCookie',
+    'codeVerifier',
+    'client_secret',
+  ]),
+);
+
+/**
+ * 객체를 재귀 순회하며 SENSITIVE_KEYS 항목을 빼고 deep clone을 반환한다.
+ * Date 인스턴스는 직렬화 시 toJSON으로 처리되므로 그대로 통과시킨다.
+ *
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+export function redactSensitive(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date) return value;
+  if (Array.isArray(value)) return value.map(redactSensitive);
+  const out = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (SENSITIVE_KEYS.has(k)) continue;
+    out[k] = redactSensitive(v);
+  }
+  return out;
+}
+
+/**
+ * status snapshot을 JSON 출력용 문자열로 직렬화한다.
+ *
+ * 출력 shape:
+ * ```
+ * {
+ *   "command": "status" | "usage",
+ *   "generatedAt": "<ISO-8601>",
+ *   "schemaVersion": <int>,
+ *   "configPath": <string>,
+ *   "accountFilter": <string|null>,
+ *   "providerFilter": <string|null>,
+ *   "providers": [
+ *     { "id": "codex" | "claude", "snapshot": { ... } },
+ *     ...
+ *   ]
+ * }
+ * ```
+ *
+ * provider id는 `--provider <id>`가 받는 registry id(`codex`/`claude`)와 동일.
+ * 출력 line 끝에 newline은 붙이지 않는다 (호출자가 결정).
+ *
+ * @param {object} snapshot - getStatusSnapshot 결과
+ * @param {{ command?: string, generatedAt?: string|Date }} [meta]
+ * @returns {string}
+ */
+export function formatStatusJson(snapshot, meta = {}) {
+  const command = meta.command ?? 'status';
+  const generatedAt = formatGeneratedAt(meta.generatedAt);
+
+  const providers = [];
+  for (const id of PROVIDER_IDS) {
+    if (id in snapshot && snapshot[id] !== undefined) {
+      providers.push({ id, snapshot: redactSensitive(snapshot[id]) });
+    }
+  }
+
+  const out = {
+    command,
+    generatedAt,
+    schemaVersion: snapshot.schemaVersion ?? null,
+    configPath: snapshot.configPath ?? null,
+    accountFilter: snapshot.accountFilter ?? null,
+    providerFilter: snapshot.providerFilter ?? null,
+    providers,
+  };
+
+  return JSON.stringify(out);
+}
+
+function formatGeneratedAt(input) {
+  if (input instanceof Date) return input.toISOString();
+  if (typeof input === 'string' && input.length > 0) return input;
+  return new Date().toISOString();
+}

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -278,11 +278,11 @@ describe('formatClaudeSection — networkUsages array support', () => {
 
 describe('parseStatusOptions', () => {
   it('returns { account: null } for empty args', () => {
-    assert.deepEqual(parseStatusOptions([]), { account: null, provider: null, help: false });
+    assert.deepEqual(parseStatusOptions([]), { account: null, provider: null, json: false, help: false });
   });
 
   it('handles null/undefined args', () => {
-    assert.deepEqual(parseStatusOptions(undefined), { account: null, provider: null, help: false });
+    assert.deepEqual(parseStatusOptions(undefined), { account: null, provider: null, json: false, help: false });
   });
 
   it('parses --account <value>', () => {
@@ -297,7 +297,7 @@ describe('parseStatusOptions', () => {
 
   it('treats --account "" as "no value" (legacy contract)', () => {
     // 공통 helper 전환 후에도 빈 문자열은 default 유지해야 한다.
-    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null, provider: null, help: false });
+    assert.deepEqual(parseStatusOptions(['--account', '']), { account: null, provider: null, json: false, help: false });
   });
 
   it('recognizes --help and -h', () => {
@@ -313,6 +313,18 @@ describe('parseStatusOptions', () => {
 
   it('--provider and --account can coexist', () => {
     const out = parseStatusOptions(['--provider', 'codex', '--account', 'work']);
+    assert.equal(out.provider, 'codex');
+    assert.equal(out.account, 'work');
+  });
+
+  it('parses --json as boolean true', () => {
+    assert.equal(parseStatusOptions(['--json']).json, true);
+    assert.equal(parseStatusOptions([]).json, false);
+  });
+
+  it('--json combines with --provider / --account', () => {
+    const out = parseStatusOptions(['--json', '--provider', 'codex', '--account', 'work']);
+    assert.equal(out.json, true);
     assert.equal(out.provider, 'codex');
     assert.equal(out.account, 'work');
   });
@@ -361,10 +373,11 @@ describe('formatStatusHelp', () => {
     assert.match(lines[0], /ai-usage-agent status/);
   });
 
-  it('lists --account, --provider and --help in Options section', () => {
+  it('lists --account, --provider, --json and --help in Options section', () => {
     const body = formatStatusHelp('usage').join('\n');
     assert.match(body, /--account/);
     assert.match(body, /--provider <id>/);
+    assert.match(body, /--json/);
     assert.match(body, /-h, --help/);
   });
 

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -1,0 +1,292 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  redactSensitive,
+  formatStatusJson,
+  SENSITIVE_KEYS,
+} from '../../src/cli/status-json.js';
+
+describe('SENSITIVE_KEYS', () => {
+  it('contains the expected token fields', () => {
+    assert.ok(SENSITIVE_KEYS.has('accessToken'));
+    assert.ok(SENSITIVE_KEYS.has('refreshToken'));
+    assert.ok(SENSITIVE_KEYS.has('idToken'));
+    assert.ok(SENSITIVE_KEYS.has('tokens'));
+    assert.ok(SENSITIVE_KEYS.has('sessionKey'));
+    assert.ok(SENSITIVE_KEYS.has('sessionCookie'));
+    assert.ok(SENSITIVE_KEYS.has('codeVerifier'));
+    assert.ok(SENSITIVE_KEYS.has('client_secret'));
+  });
+});
+
+describe('redactSensitive — primitives', () => {
+  it('passes through null/undefined/boolean/number/string', () => {
+    assert.equal(redactSensitive(null), null);
+    assert.equal(redactSensitive(undefined), undefined);
+    assert.equal(redactSensitive(true), true);
+    assert.equal(redactSensitive(0), 0);
+    assert.equal(redactSensitive('hello'), 'hello');
+  });
+
+  it('passes through Date as-is (will serialize via toJSON)', () => {
+    const d = new Date('2026-04-25T00:00:00Z');
+    assert.equal(redactSensitive(d), d);
+  });
+});
+
+describe('redactSensitive — objects', () => {
+  it('removes top-level sensitive keys', () => {
+    const out = redactSensitive({
+      email: 'a@b.com',
+      accessToken: 'xxx',
+      refreshToken: 'yyy',
+      idToken: 'zzz',
+    });
+    assert.deepEqual(out, { email: 'a@b.com' });
+  });
+
+  it('removes the entire `tokens` subtree', () => {
+    const out = redactSensitive({
+      accountKey: 'k',
+      tokens: { accessToken: 'a', refreshToken: 'b' },
+    });
+    assert.deepEqual(out, { accountKey: 'k' });
+  });
+
+  it('removes nested sensitive keys at any depth', () => {
+    const out = redactSensitive({
+      claude: {
+        selectedAccount: {
+          accountKey: 'k',
+          tokens: { accessToken: 'a' },
+          accessToken: 'top',
+        },
+      },
+    });
+    assert.deepEqual(out, {
+      claude: {
+        selectedAccount: { accountKey: 'k' },
+      },
+    });
+  });
+
+  it('walks into arrays', () => {
+    const out = redactSensitive({
+      accounts: [
+        { id: 1, accessToken: 'a' },
+        { id: 2, refreshToken: 'b' },
+      ],
+    });
+    assert.deepEqual(out, { accounts: [{ id: 1 }, { id: 2 }] });
+  });
+
+  it('does not mutate the original input', () => {
+    const original = {
+      account: { tokens: { accessToken: 'a' }, email: 'x@y.com' },
+    };
+    const snapshot = JSON.parse(JSON.stringify(original));
+    redactSensitive(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('formatStatusJson — shape', () => {
+  it('returns a single-line JSON string (no newline)', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: { enabled: false },
+    });
+    assert.equal(typeof json, 'string');
+    assert.equal(json.includes('\n'), false);
+  });
+
+  it('always emits a JSON-parseable string', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: { enabled: false },
+    });
+    assert.doesNotThrow(() => JSON.parse(json));
+  });
+
+  it('includes top-level command, generatedAt, schemaVersion, configPath', () => {
+    const json = formatStatusJson(
+      {
+        schemaVersion: 1,
+        configPath: '/cfg',
+        providers: { codex: { enabled: true }, claude: { enabled: true } },
+        sync: { enabled: false },
+      },
+      { command: 'usage', generatedAt: '2026-04-25T01:02:03Z' },
+    );
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.command, 'usage');
+    assert.equal(parsed.generatedAt, '2026-04-25T01:02:03Z');
+    assert.equal(parsed.schemaVersion, 1);
+    assert.equal(parsed.configPath, '/cfg');
+  });
+
+  it('uses now() when generatedAt not provided', () => {
+    const before = new Date();
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+    });
+    const after = new Date();
+    const parsed = JSON.parse(json);
+    const at = new Date(parsed.generatedAt);
+    assert.ok(at >= before && at <= after);
+  });
+
+  it('defaults command to "status" when not provided', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+    });
+    assert.equal(JSON.parse(json).command, 'status');
+  });
+});
+
+describe('formatStatusJson — providers array', () => {
+  it('emits providers[] with id and snapshot for each present provider', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: {},
+      codex: { enabled: true, snapshots: [] },
+      claude: { detected: false },
+    });
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.providers.length, 2);
+    assert.deepEqual(
+      parsed.providers.map((p) => p.id).sort(),
+      ['claude', 'codex'],
+    );
+    const codexEntry = parsed.providers.find((p) => p.id === 'codex');
+    assert.deepEqual(codexEntry.snapshot, { enabled: true, snapshots: [] });
+  });
+
+  it('only includes the matching provider when providerFilter is set', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: {},
+      providerFilter: 'codex',
+      codex: { enabled: true, snapshots: [] },
+      // claude key absent — runProviderSnapshots already filtered
+    });
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.providerFilter, 'codex');
+    assert.deepEqual(parsed.providers.map((p) => p.id), ['codex']);
+  });
+
+  it('exposes accountFilter at top level', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+      accountFilter: 'work',
+      codex: {},
+      claude: {},
+    });
+    assert.equal(JSON.parse(json).accountFilter, 'work');
+  });
+
+  it('emits null filters by default', () => {
+    const parsed = JSON.parse(
+      formatStatusJson({
+        schemaVersion: 1,
+        configPath: '/x',
+        providers: { codex: {}, claude: {} },
+        sync: {},
+        codex: {},
+        claude: {},
+      }),
+    );
+    assert.equal(parsed.accountFilter, null);
+    assert.equal(parsed.providerFilter, null);
+  });
+});
+
+describe('formatStatusJson — redaction (security)', () => {
+  it('strips tokens from claude.selectedAccount.tokens', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+      codex: {},
+      claude: {
+        detected: true,
+        selectedAccount: {
+          accountKey: 'k',
+          email: 'a@b.com',
+          tokens: {
+            accessToken: 'SECRET-A',
+            refreshToken: 'SECRET-R',
+            idToken: 'SECRET-I',
+          },
+        },
+      },
+    });
+    assert.equal(json.includes('SECRET-A'), false);
+    assert.equal(json.includes('SECRET-R'), false);
+    assert.equal(json.includes('SECRET-I'), false);
+
+    const parsed = JSON.parse(json);
+    const claude = parsed.providers.find((p) => p.id === 'claude').snapshot;
+    assert.equal(claude.selectedAccount.accountKey, 'k');
+    assert.equal('tokens' in claude.selectedAccount, false);
+  });
+
+  it('strips top-level accessToken on imported accounts (claude-cli-import shape)', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+      codex: {},
+      claude: {
+        selectedAccount: { accountKey: 'k', accessToken: 'TOP-LEVEL-TOKEN' },
+      },
+    });
+    assert.equal(json.includes('TOP-LEVEL-TOKEN'), false);
+  });
+
+  it('strips tokens from any nested array entry (multi-account)', () => {
+    const json = formatStatusJson({
+      schemaVersion: 1,
+      configPath: '/x',
+      providers: { codex: {}, claude: {} },
+      sync: {},
+      codex: {},
+      claude: {
+        networkUsages: [
+          {
+            accountKey: 'k1',
+            account: { tokens: { accessToken: 'A1' } },
+            snapshot: { status: { ok: true } },
+          },
+          {
+            accountKey: 'k2',
+            account: { accessToken: 'A2' },
+            snapshot: { status: { ok: true } },
+          },
+        ],
+      },
+    });
+    assert.equal(json.includes('A1'), false);
+    assert.equal(json.includes('A2'), false);
+  });
+});

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -4,11 +4,12 @@ import assert from 'node:assert/strict';
 import {
   redactSensitive,
   formatStatusJson,
+  isSensitiveKey,
   SENSITIVE_KEYS,
 } from '../../src/cli/status-json.js';
 
 describe('SENSITIVE_KEYS', () => {
-  it('contains the expected token fields', () => {
+  it('contains the expected camelCase token fields', () => {
     assert.ok(SENSITIVE_KEYS.has('accessToken'));
     assert.ok(SENSITIVE_KEYS.has('refreshToken'));
     assert.ok(SENSITIVE_KEYS.has('idToken'));
@@ -16,7 +17,46 @@ describe('SENSITIVE_KEYS', () => {
     assert.ok(SENSITIVE_KEYS.has('sessionKey'));
     assert.ok(SENSITIVE_KEYS.has('sessionCookie'));
     assert.ok(SENSITIVE_KEYS.has('codeVerifier'));
+    assert.ok(SENSITIVE_KEYS.has('clientSecret'));
+  });
+
+  it('also contains snake_case variants (OAuth-style)', () => {
+    assert.ok(SENSITIVE_KEYS.has('access_token'));
+    assert.ok(SENSITIVE_KEYS.has('refresh_token'));
+    assert.ok(SENSITIVE_KEYS.has('id_token'));
     assert.ok(SENSITIVE_KEYS.has('client_secret'));
+    assert.ok(SENSITIVE_KEYS.has('code_verifier'));
+    assert.ok(SENSITIVE_KEYS.has('session_key'));
+    assert.ok(SENSITIVE_KEYS.has('session_cookie'));
+  });
+
+  it('contains HTTP credential headers and generic API keys', () => {
+    assert.ok(SENSITIVE_KEYS.has('authorization'));
+    assert.ok(SENSITIVE_KEYS.has('cookie'));
+    assert.ok(SENSITIVE_KEYS.has('apiKey'));
+    assert.ok(SENSITIVE_KEYS.has('api_key'));
+    assert.ok(SENSITIVE_KEYS.has('password'));
+  });
+});
+
+describe('isSensitiveKey — case-insensitive matching', () => {
+  it('matches the canonical camelCase form', () => {
+    assert.equal(isSensitiveKey('accessToken'), true);
+    assert.equal(isSensitiveKey('refreshToken'), true);
+  });
+
+  it('matches different casings (AccessToken / ACCESSTOKEN / accesstoken)', () => {
+    assert.equal(isSensitiveKey('AccessToken'), true);
+    assert.equal(isSensitiveKey('ACCESSTOKEN'), true);
+    assert.equal(isSensitiveKey('accesstoken'), true);
+    assert.equal(isSensitiveKey('Refresh_Token'), true);
+    assert.equal(isSensitiveKey('AUTHORIZATION'), true);
+  });
+
+  it('returns false for unrelated keys', () => {
+    assert.equal(isSensitiveKey('email'), false);
+    assert.equal(isSensitiveKey('accountKey'), false);
+    assert.equal(isSensitiveKey('label'), false);
   });
 });
 
@@ -79,6 +119,39 @@ describe('redactSensitive — objects', () => {
       ],
     });
     assert.deepEqual(out, { accounts: [{ id: 1 }, { id: 2 }] });
+  });
+
+  it('removes snake_case variants (refresh_token / access_token / id_token)', () => {
+    const out = redactSensitive({
+      accountKey: 'k',
+      access_token: 'A',
+      refresh_token: 'R',
+      id_token: 'I',
+    });
+    assert.deepEqual(out, { accountKey: 'k' });
+  });
+
+  it('removes generic credential headers (authorization / cookie / apiKey)', () => {
+    const out = redactSensitive({
+      label: 'work',
+      authorization: 'Bearer xyz',
+      cookie: 'session=abc',
+      apiKey: 'k123',
+      api_key: 'k456',
+      password: 'p1',
+    });
+    assert.deepEqual(out, { label: 'work' });
+  });
+
+  it('matches keys case-insensitively (AccessToken / Refresh-Token style stays caught)', () => {
+    const out = redactSensitive({
+      accountKey: 'k',
+      AccessToken: 'A',
+      Refresh_Token: 'R',
+      ID_TOKEN: 'I',
+      Authorization: 'Bearer xyz',
+    });
+    assert.deepEqual(out, { accountKey: 'k' });
   });
 
   it('does not mutate the original input', () => {

--- a/packages/agent/test/integration/smoke.test.js
+++ b/packages/agent/test/integration/smoke.test.js
@@ -79,4 +79,28 @@ describe('bin/ai-usage-agent — smoke', () => {
     assert.equal(result.status, 0, `stderr: ${result.stderr}`);
     assert.match(result.stdout, /계정 필터: definitely-not-an-account/);
   });
+
+  it('status --json emits a single parseable JSON line on stdout', () => {
+    const result = runCli(['status', '--json'], { timeoutMs: 15_000 });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    // stdout은 정확히 한 줄(JSON + 단일 trailing newline)이어야 한다.
+    const lines = result.stdout.split('\n').filter((l) => l.length > 0);
+    assert.equal(lines.length, 1, `stdout had ${lines.length} non-empty lines`);
+    assert.doesNotThrow(() => JSON.parse(lines[0]));
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.command, 'status');
+    assert.ok(Array.isArray(parsed.providers));
+    // 텍스트 헤더("로컬 에이전트 상태 요약" 등)는 stdout에 절대 섞이지 않아야 함.
+    assert.equal(result.stdout.includes('로컬 에이전트 상태 요약'), false);
+  });
+
+  it('status --json --provider codex restricts providers array to codex only', () => {
+    const result = runCli(['status', '--json', '--provider', 'codex'], {
+      timeoutMs: 15_000,
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.deepEqual(parsed.providers.map((p) => p.id), ['codex']);
+    assert.equal(parsed.providerFilter, 'codex');
+  });
 });


### PR DESCRIPTION
## 요약

`status` / `usage`에 `--json` 출력 모드를 추가. stdout에 정규화된 JSON 한 줄을 흘려 자동화 / 대시보드 / 백엔드 수집기가 텍스트를 다시 파싱하지 않고 직접 소비할 수 있도록 함. 토큰성 필드는 deep-walk redaction으로 일관 제거.

closes #65

## 변경 내용

1. **parser** (`status-command.js`)
   - `parseStatusOptions`에 `--json` (boolean) 추가, `formatStatusHelp`에 한 줄 안내.
2. **JSON formatter** (`cli/status-json.js` 신설)
   - `redactSensitive(value)` — 객체/배열을 재귀 walk하여 `SENSITIVE_KEYS`(`accessToken` / `refreshToken` / `idToken` / `tokens` / `sessionKey` / `sessionCookie` / `codeVerifier` / `client_secret`) 항목을 제거한 deep clone 반환. 원본 비변경. Date 통과.
   - `formatStatusJson(snapshot, { command, generatedAt })` — single-line JSON 직렬화. shape: `{ command, generatedAt, schemaVersion, configPath, accountFilter, providerFilter, providers: [{ id, snapshot }] }`. provider id는 registry id(`codex` / `claude`).
3. **runner**
   - `runStatusCommand`가 `options.json`이면 `formatStatusJson` 결과만 stdout에 출력하고 텍스트 포맷터 호출은 skip.
4. **docs**
   - `docs/cli-json-output.md` 신설 — stable contract, redaction 규약, 보안 원칙.
   - `codebase-guide §5.2.1` 추가 — `status-json.js` 위치 + `SENSITIVE_KEYS` 동기화 의무.
   - README "기여자용 참고 문서" 목록에 신규 문서 링크.
5. **tests**
   - parser/help: 4건
   - `status-json` 단위: 20건 (redactor primitive/object/array/depth + JSON shape / filters / 토큰 누출 회귀)
   - bin smoke: 2건 (`status --json` 단독, `status --json --provider codex`)

## 변경 이유

- 출력 텍스트를 잡아서 정규식 파싱하는 것은 fragile + 자동화 친화도 낮음.
- `packages/schemas`의 snapshot validator가 이미 정규화 shape를 보증하고 있으므로 한 번의 직렬화 단계만 추가하면 백엔드 수집/대시보드 통합이 즉시 가능.
- 보안 측면: 텍스트 모드는 직접 access하지 않는 토큰 필드를 미래 변경에서 노출할 위험이 있다. `--json`은 redaction을 명시적으로 거치므로 그 리스크를 일관되게 차단.

## 영향 범위

- [x] `packages/agent/src/cli` (parser + 신규 status-json + runner 분기)
- [x] `docs` (신규 contract 문서 + codebase-guide + README)
- [ ] `packages/provider-adapters`
- [ ] `packages/schemas` (shape 재사용만, 변경 없음)

## 테스트 / 확인

- `npm test`: **615/615 통과** (591 + 24 신규).
- bin smoke 직접 실행:
  - `ai-usage-agent status --json` → stdout에 한 줄 JSON, 텍스트 헤더 비포함.
  - `ai-usage-agent status --json --provider codex` → `providers[]`가 codex 단독, `providerFilter: "codex"` 노출.
- 토큰 누출 regression: 가짜 `tokens.accessToken / refreshToken / idToken`을 주입한 snapshot에서 출력 string이 해당 값을 포함하지 않음을 직접 검증.

## 리뷰 포인트

- **provider id 결정**: 이슈 본문 예시에는 `openai-codex` / `anthropic-claude`(account-key prefix)로 표기되어 있었지만, 본 PR에서는 **registry id** (`codex` / `claude`)를 사용. 이유는 (1) `--provider <id>`가 받는 값과 1:1 일치, (2) 기존 snapshot의 키와 동일, (3) CLI 사용자가 다른 형태를 학습하지 않아도 됨. long-form prefix가 더 적절하다고 판단되면 본 단일 위치만 수정하면 됩니다.
- **redaction 정책**: deep-walk + key blacklist (`SENSITIVE_KEYS`). 새 토큰 필드를 추가할 때 이 set을 갱신하지 않으면 자동으로 누출되므로 codebase-guide §5.2.1에 동기화 의무를 명시. whitelist 방식으로 갈지(=출력 shape를 명시적으로 정의)도 고려했지만, 이슈 본문이 "기존 snapshot 구조를 그대로 담되" 라고 명시해 blacklist를 택함.
- **`raw` 필드**: account 객체의 자유 형식 `raw`는 현재 통과하고 있다. mock/import 메타만 들어가는 것으로 관찰되어 일단 유지했지만, 향후 토큰성 데이터가 raw에 들어갈 가능성이 있다면 redact 대상에 추가 필요.
- **error path**: unknown `--provider` 입력은 텍스트 모드와 동일하게 stderr + `exit 1` (JSON으로 fallback하지 않음). 자동화가 stdout만 파싱한다는 가정과 일관성 차원. 의도가 다르다면 알려주세요.

## 참고 사항

- 선행: #61 (공통 parser), #63 (`--help`), #64 (`--provider`) — 모두 dev 머지 완료.
- contract 문서가 외부 소비자에게 노출될 수 있으므로 본 PR 머지 후 schema bump 정책(`packages/schemas`와의 `schemaVersion` 동기화)에 대해 별도 논의가 필요합니다.