### PR TITLE
[chore] SECURITY.md / CODE_OF_CONDUCT.md / 템플릿 보강

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,11 @@ assignees: []
 - [ ] `repo`
 - [ ] `docs`
 
+## 민감 정보 점검
+
+- [ ] 첨부한 로그, 스크린샷, 명령 출력에서 access token / refresh token / id token / session cookie / accountKey 같은 **민감값을 redact** 했음
+- [ ] 토큰을 본문에 포함했다면 즉시 revoke 후 신규 발급할 것 — 자세한 절차는 [SECURITY.md](../../SECURITY.md) 참고
+
 ## 환경 정보
 
 - 브랜치:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 - [ ] 관련 스크립트 또는 기능을 로컬에서 확인
 - [ ] 필요한 문서 업데이트 반영
 - [ ] schema / provider / CLI 영향 범위를 직접 점검
+- [ ] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음
 
 ## 리뷰 포인트
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# 행동 강령 (Code of Conduct)
+
+이 프로젝트는 [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)을 따릅니다.
+
+전문(영문)은 위 링크에서 확인할 수 있으며, 한국어 번역본은 https://www.contributor-covenant.org/ko/version/2/1/code_of_conduct/ 에서 볼 수 있습니다.
+
+## 신고 채널
+
+행동 강령 위반 또는 부적절한 행동을 발견하면 [SECURITY.md](./SECURITY.md)에 안내된 비공개 신고 채널을 통해 알려주세요. 토큰/자격증명 같은 보안 이슈와 동일한 경로로 처리됩니다.
+
+신고는 비공개로 다루어지며, 메인테이너가 영업일 기준 5일 이내에 1차 응답합니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,3 +135,10 @@ PR 본문에는 최소한 아래 내용을 포함한다.
 - PR 본문도 한글 기준
 - `dev`를 통합 브랜치로 우선 사용
 - `main`은 비교적 안정적인 상태만 반영
+
+## 7. 행동 강령 / 보안
+
+- 모든 기여자는 [Code of Conduct](./CODE_OF_CONDUCT.md)를 준수한다.
+- 보안 이슈(토큰 유출, 자격증명 처리 결함 등)는 GitHub Issue에 직접 작성하지 말고 [SECURITY.md](./SECURITY.md)에 안내된 비공개 신고 채널을 사용한다.
+- PR / issue 본문에 access token / refresh token / id token / session cookie / accountKey 같은 민감값을 절대 첨부하지 않는다. 실수로 노출한 경우 즉시 revoke 후 재발급한다(절차는 SECURITY.md).
+- 새로운 토큰성 필드를 provider adapter / auth schema에 도입하는 PR은 동일 PR 안에서 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`를 갱신하고 redaction 회귀 테스트를 추가한다 (`docs/cli-json-output.md` §한계 참고).

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ CI(`.github/workflows/ci.yml`):
 - code-base 구조 리팩터 (중복되는 provider adapter shape 통합)
 - keychain 연동 / device code flow / revoke endpoint 조사
 
+## 보안 신고
+
+OAuth access/refresh/id token 같은 자격증명을 다루는 도구이므로, 보안 이슈는 공개 이슈에 작성하지 말고 [SECURITY.md](./SECURITY.md)에 안내된 비공개 채널로 신고해 주세요. 토큰을 실수로 노출했을 때 즉시 revoke하는 절차도 같은 문서에 정리되어 있습니다.
+
+행동 강령은 [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)를 따릅니다.
+
 ## 라이선스
 
 추후 결정.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# 보안 정책
+
+이 도구는 OAuth access token / refresh token / id token 같은 자격증명을 로컬에서 다룹니다. 보안 이슈는 공개 이슈 트래커가 아닌 비공개 채널로 신고해 주세요.
+
+## 지원 버전
+
+| Version | Supported |
+| --- | --- |
+| `0.1.x` | ✅ |
+| 그 이전 | ❌ |
+
+## 비공개 신고 채널
+
+GitHub Security Advisory를 통해 비공개로 신고해 주세요.
+
+- 신고 페이지: https://github.com/LLagoon3/ai-usage-agent/security/advisories/new
+- 평균 응답 SLA: 영업일 기준 5일 이내 1차 답변
+- 심각도가 높은 경우(원격 토큰 유출, 자격증명 노출 등) 우선 대응
+
+## 토큰을 실수로 공개 위치에 첨부했을 때
+
+GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, refresh token, id token, session cookie, account key가 그대로 들어간 경우:
+
+1. 즉시 해당 위치에서 토큰을 삭제(또는 issue/PR을 비공개로 전환)합니다.
+2. 해당 자격증명을 즉시 **revoke** 합니다.
+   - Codex (OpenAI): https://platform.openai.com/account/api-keys 또는 chatgpt.com 세션 로그아웃
+   - Claude (Anthropic): https://console.anthropic.com 또는 Claude CLI 재로그인
+3. `ai-usage-agent auth logout <provider>`로 로컬 store에서도 제거 후 재로그인합니다.
+
+토큰 복구 / 자동 revoke 기능은 제공하지 않습니다 (provider revoke endpoint 미통합 상태).
+
+## 새 토큰성 필드를 추가할 때 (메인테이너 / 기여자용)
+
+`status --json` 출력은 토큰 키 blacklist 기반 redaction을 적용합니다 (`docs/cli-json-output.md` §한계 참고). 새 토큰 필드를 provider adapter / auth schema에 추가하는 PR에서는 다음을 함께 수행해야 합니다.
+
+- `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 새 키 등록
+- `--json` 출력 회귀 테스트(가짜 토큰 주입 → JSON에 누출 없음 검증) 추가
+
+이 절차를 빠뜨리면 외부 소비자에게 그대로 노출될 수 있습니다.

--- a/packages/agent/test/integration/repo-policy.test.js
+++ b/packages/agent/test/integration/repo-policy.test.js
@@ -1,0 +1,65 @@
+/**
+ * Repo-level 정책 회귀 가드.
+ *
+ * 보안/템플릿/라이선스/publish 메타데이터 같은 repo 차원의 contract가 우발적으로
+ * 깨지는 것을 막기 위한 파일시스템 단위 검증. 이 파일은 worker 패키지 코드를
+ * 임포트하지 않고, 순수하게 repo root에서 파일/문자열을 읽어 검증한다.
+ *
+ * 추가/변경 시 docs/codebase-guide.md / SECURITY.md / docs/cli-json-output.md 등의
+ * 정책과 함께 갱신할 것.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+// packages/agent/test/integration/ 에서 repo root까지 4단계 상위.
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function readRepoFile(relPath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+}
+
+function repoFileExists(relPath) {
+  return fs.existsSync(path.join(REPO_ROOT, relPath));
+}
+
+describe('repo-policy — security/templates 메타 파일 (PR #78)', () => {
+  it('SECURITY.md 가 repo 루트에 존재한다', () => {
+    assert.equal(repoFileExists('SECURITY.md'), true);
+  });
+
+  it('CODE_OF_CONDUCT.md 가 repo 루트에 존재한다', () => {
+    assert.equal(repoFileExists('CODE_OF_CONDUCT.md'), true);
+  });
+
+  it('SECURITY.md 가 GitHub Security Advisory URL을 포함한다', () => {
+    const body = readRepoFile('SECURITY.md');
+    assert.match(body, /security\/advisories\/new/);
+  });
+
+  it('bug_report 템플릿이 토큰 redaction 안내를 포함한다', () => {
+    const body = readRepoFile('.github/ISSUE_TEMPLATE/bug_report.md');
+    // "민감값" / "redact" 둘 중 하나는 반드시 노출되어야 한다.
+    assert.match(body, /민감값|redact/);
+  });
+
+  it('PR 템플릿이 토큰 redaction 체크리스트를 포함한다', () => {
+    const body = readRepoFile('.github/pull_request_template.md');
+    assert.match(body, /민감값|redact/);
+  });
+
+  it('README 가 "## 보안 신고" 섹션을 가지며 SECURITY.md 링크를 포함한다', () => {
+    const body = readRepoFile('README.md');
+    assert.match(body, /## 보안 신고/);
+    assert.match(body, /SECURITY\.md/);
+  });
+
+  it('CONTRIBUTING 이 행동 강령 / 보안 단락을 포함한다', () => {
+    const body = readRepoFile('CONTRIBUTING.md');
+    assert.match(body, /행동 강령|Code of Conduct/);
+    assert.match(body, /SECURITY\.md/);
+  });
+});


### PR DESCRIPTION
## 요약

공개 npm 출시 준비(epic #79)의 T2 항목인 **보안 신고 채널 / 외부 기여자 템플릿**을 정비. SECURITY.md, CODE_OF_CONDUCT.md를 신규 작성하고 기존 ISSUE_TEMPLATE / PR template / README / CONTRIBUTING에 토큰 redaction 안내를 끼워 넣었다. 회귀 가드 테스트 1개 신설.

closes #78

## 변경 내용

1. `SECURITY.md` 신규 — 지원 버전(`0.1.x`), GitHub Security Advisory 비공개 신고 링크, 응답 SLA, 토큰 실수 노출 시 revoke 절차, 새 토큰 필드 추가 시 `SENSITIVE_KEYS` 동기화 의무.
2. `CODE_OF_CONDUCT.md` 신규 — Contributor Covenant v2.1 참조 + 신고 채널은 SECURITY.md와 동일.
3. `.github/ISSUE_TEMPLATE/bug_report.md` 보강 — `## 민감 정보 점검` 섹션 추가, redaction 체크박스 + revoke 안내 링크.
4. `.github/pull_request_template.md` 보강 — `## 테스트 / 확인` 체크리스트에 redaction 항목 추가.
5. `README.md` — `## 라이선스` 직전에 `## 보안 신고` 단락 신규.
6. `CONTRIBUTING.md` — `## 7. 행동 강령 / 보안` 섹션 신규.
7. `packages/agent/test/integration/repo-policy.test.js` 신설 — 위 파일들이 우발적으로 깨지는 것을 막는 파일시스템 단위 회귀 가드 (검증 7건).

## 변경 이유

- 토큰을 다루는 도구라 외부 기여자가 issue/PR에 token을 그대로 첨부하는 사고가 흔한데, 사전 안내가 전무한 상태였다.
- GitHub Security Advisory 비공개 채널을 사용하면 신고가 외부에 노출되지 않으면서 메인테이너에게 직접 도착한다 — 별도 메일 채널 신설 비용 없이 운영 가능.
- 가드 테스트가 없으면 메타 파일이 누군가의 PR로 우발적으로 사라지거나 핵심 문구가 빠질 수 있어 같은 PR에 회귀 테스트를 동봉.

## 영향 범위

- [ ] `packages/agent` (test 추가만, 동작 영향 없음)
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [x] `repo` (메타 파일 / 템플릿 / README / CONTRIBUTING)
- [x] `docs` (간접 — SECURITY.md가 cli-json-output.md의 SENSITIVE_KEYS 의무를 인용)

## 스크린샷 / 데모

- 새 GitHub Issue 작성 시 bug_report 템플릿에서 "## 민감 정보 점검" 섹션이 노출되는지 확인 필요 (머지 후 GitHub UI에서 검증).
- repo 진입 시 "Security policy" 탭 자동 표시 + "Code of conduct" 표시 확인 필요.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 630/630 통과 (기존 623 + 신규 7건 가드).
- [x] 필요한 문서 업데이트 반영
- [x] schema / provider / CLI 영향 범위를 직접 점검 — 코드 변경 없음.
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음 — 본 PR엔 토큰 데이터 없음.

## 리뷰 포인트

- `SECURITY.md`의 응답 SLA를 "영업일 기준 5일"로 잡았는데 실 운영 가능한 수준인지 확인.
- bug_report 템플릿 `## 민감 정보 점검` 섹션 위치를 `## 환경 정보` 직전에 배치 — 사용자 입력이 가장 많이 들어가는 직전 단계라 노출도가 높지만, 흐름이 끊기는 느낌이 있다면 더 위(`## 문제 요약` 다음)로 이동도 고려 가능.
- `repo-policy.test.js`는 다음 두 PR(#69, #70)에서 점진적으로 확장될 예정. 본 PR에서는 보안/템플릿 case만 검증.

## 참고 사항

- 후속 PR-69(라이선스), PR-70(publish 정비 + Token Weather 리네임)이 같은 epic(#79)에서 이어진다.
- GitHub repo 이름 변경은 본 plan에서 범위 밖. SECURITY.md의 advisory URL은 GitHub의 자동 redirect를 가정.

> PR 제목은 `[feat]`, `[fix]`, `[docs]`처럼 타입은 영어로 유지하고, 뒤의 설명은 한글로 작성하는 것을 기본 규칙으로 합니다.