### PR TITLE
[chore] Apache-2.0 라이선스 적용

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,3 +142,11 @@ PR 본문에는 최소한 아래 내용을 포함한다.
 - 보안 이슈(토큰 유출, 자격증명 처리 결함 등)는 GitHub Issue에 직접 작성하지 말고 [SECURITY.md](./SECURITY.md)에 안내된 비공개 신고 채널을 사용한다.
 - PR / issue 본문에 access token / refresh token / id token / session cookie / accountKey 같은 민감값을 절대 첨부하지 않는다. 실수로 노출한 경우 즉시 revoke 후 재발급한다(절차는 SECURITY.md).
 - 새로운 토큰성 필드를 provider adapter / auth schema에 도입하는 PR은 동일 PR 안에서 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`를 갱신하고 redaction 회귀 테스트를 추가한다 (`docs/cli-json-output.md` §한계 참고).
+
+## 8. 기여자 라이선스
+
+이 저장소는 [Apache License 2.0](./LICENSE)으로 배포됩니다.
+
+PR을 제출하시면 본인의 기여(코드, 문서, 설정 등)가 동일하게 Apache-2.0 조건으로 라이선스됨에 동의한 것으로 간주됩니다. 별도의 CLA / DCO 절차는 운영하지 않습니다 — Apache-2.0 §5(Submission of Contributions)에 따른 묵시적 grant를 그대로 따릅니다.
+
+다른 라이선스로 기여하고자 하는 경우, PR 본문에 명시해 주시면 별도로 검토합니다.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 LLagoon3
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -206,4 +206,6 @@ OAuth access/refresh/id token 같은 자격증명을 다루는 도구이므로, 
 
 ## 라이선스
 
-추후 결정.
+[Apache License 2.0](./LICENSE) — 자세한 내용은 LICENSE 파일을 참고하세요.
+
+기여하신 내용은 동일 라이선스로 제공됨에 동의한 것으로 간주됩니다 (자세한 내용은 [CONTRIBUTING.md §8](./CONTRIBUTING.md)).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "CLI agent and packages for monitoring AI service usage and auth status",
+  "license": "Apache-2.0",
   "packageManager": "npm@11.6.2",
   "workspaces": [
     "packages/*"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "로컬 AI 사용량 수집 및 확인용 CLI 에이전트",
+  "license": "Apache-2.0",
   "type": "module",
   "bin": {
     "ai-usage-agent": "./bin/ai-usage-agent.js"

--- a/packages/agent/test/integration/repo-policy-license.test.js
+++ b/packages/agent/test/integration/repo-policy-license.test.js
@@ -1,0 +1,75 @@
+/**
+ * Repo-level 라이선스 정책 회귀 가드.
+ *
+ * 4개 package.json의 license 필드, 루트 LICENSE 파일, README/CONTRIBUTING의
+ * 라이선스 단락이 우발적으로 깨지는 것을 막는 파일시스템 단위 검증.
+ *
+ * `repo-policy.test.js`(보안/템플릿 가드)와 도메인이 달라 별도 파일로 분리.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function readRepoFile(relPath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+}
+
+function repoFileExists(relPath) {
+  return fs.existsSync(path.join(REPO_ROOT, relPath));
+}
+
+function readPackageJson(relPath) {
+  return JSON.parse(readRepoFile(relPath));
+}
+
+const PUBLISHABLE_PACKAGES = [
+  'package.json',
+  'packages/agent/package.json',
+  'packages/provider-adapters/package.json',
+  'packages/schemas/package.json',
+];
+
+describe('repo-policy/license — Apache-2.0 (PR #69)', () => {
+  it('LICENSE 파일이 repo 루트에 존재한다', () => {
+    assert.equal(repoFileExists('LICENSE'), true);
+  });
+
+  it('LICENSE 가 Apache License 2.0임을 첫 줄에서 식별 가능', () => {
+    const body = readRepoFile('LICENSE');
+    assert.match(body, /Apache License/);
+    assert.match(body, /Version 2\.0/);
+  });
+
+  it('루트 + 3개 publishable package.json 모두 license 필드가 Apache-2.0', () => {
+    for (const relPath of PUBLISHABLE_PACKAGES) {
+      const pkg = readPackageJson(relPath);
+      assert.equal(
+        pkg.license,
+        'Apache-2.0',
+        `${relPath} license 필드가 Apache-2.0 이 아님: ${pkg.license}`,
+      );
+    }
+  });
+
+  it('README 에 "추후 결정" 문구가 남아있지 않다', () => {
+    const body = readRepoFile('README.md');
+    assert.equal(body.includes('추후 결정'), false);
+  });
+
+  it('README 에 LICENSE 파일 링크가 존재한다', () => {
+    const body = readRepoFile('README.md');
+    // (./LICENSE) 또는 (LICENSE) 형태로 링크
+    assert.match(body, /\((?:\.\/)?LICENSE\)/);
+  });
+
+  it('CONTRIBUTING 에 Apache-2.0 키워드와 기여자 라이선스 단락이 존재', () => {
+    const body = readRepoFile('CONTRIBUTING.md');
+    assert.match(body, /Apache-2\.0/);
+    assert.match(body, /기여자 라이선스|Submission of Contributions/);
+  });
+});

--- a/packages/provider-adapters/package.json
+++ b/packages/provider-adapters/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "provider별 인증/endpoint 연결 및 usage 정규화 어댑터",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js"
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "공통 데이터 계약 (usage snapshot, usage event JSON Schema)",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js"
 }


### PR DESCRIPTION
## 요약

공개 npm 출시 준비(epic #79)의 T0 블로커인 **라이선스**를 Apache-2.0으로 확정. LICENSE 파일 + 4개 package.json의 license 필드 + README/CONTRIBUTING 단락을 한 묶음으로 정리하고, 회귀 가드 테스트 1개 신설.

closes #69

## 변경 내용

1. `LICENSE` 신규 — Apache License 2.0 표준 전문 (201 LOC). Copyright 라인은 \"2026 LLagoon3\".
2. 4개 `package.json`(루트 + agent + provider-adapters + schemas) 모두 `\"license\": \"Apache-2.0\"` 추가.
3. README `## 라이선스` 섹션 갱신 — \"추후 결정\" 제거, Apache-2.0 + LICENSE 링크 + CONTRIBUTING §8 안내.
4. CONTRIBUTING `## 8. 기여자 라이선스` 섹션 신규 — Apache-2.0 §5 기반 묵시적 grant, 별도 CLA/DCO 운영하지 않음 명시.
5. `packages/agent/test/integration/repo-policy-license.test.js` 신설 — LICENSE 존재 + 4개 package.json license 필드 + README/CONTRIBUTING 라이선스 단락을 파일시스템 단위로 검증 (검증 6건).

## 변경 이유

- npm publish 시 `license` 필드가 없으면 `UNLICENSED`로 처리되어 사용처 대부분이 install을 거부합니다. 공개 출시 전 반드시 박혀야 하는 T0 블로커.
- 토큰을 다루는 도구라 면책 조항이 강한 Apache-2.0이 적합. MIT와 비교해 특허 grant 명시(§3) + Contribution submission 정책(§5) 표준화.
- 회귀 가드 테스트가 없으면 누군가의 PR로 license 필드가 누락되거나 README \"추후 결정\"이 다시 들어올 수 있어 동일 PR에 동봉.

## 영향 범위

- [ ] `packages/agent` (test 추가만, 동작 영향 없음)
- [ ] `packages/schemas` (license 필드만 추가)
- [ ] `packages/provider-adapters` (license 필드만 추가)
- [x] `repo` (LICENSE 신규, 루트 package.json license 필드)
- [x] `docs` (README, CONTRIBUTING)

## 스크린샷 / 데모

- 머지 후 GitHub repo 우상단에 \"Apache-2.0\" 라벨 표시 확인 필요.
- npm publish 시(별도 PR-70/76 진행 후) `license` 필드 인식 확인.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 629/629 통과 (PR-78 머지 전 기준 기존 623 + 신규 6건 가드).
- [x] 필요한 문서 업데이트 반영 — README + CONTRIBUTING.
- [x] schema / provider / CLI 영향 범위를 직접 점검 — 코드 변경 없음.
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음 — 본 PR엔 토큰 데이터 없음.

## 리뷰 포인트

- LICENSE 본문은 Apache 공식 표준 그대로 + Copyright 라인만 \"2026 LLagoon3\"로 채움. 회사/단체로 출시한다면 holder 변경 필요.
- 소스 파일에 Apache-2.0 보일러플레이트 헤더(`Licensed under the Apache License, Version 2.0 ...`)는 추가하지 않음 — 현재 헤더 0개 상태에서 일괄 추가는 후속 PR-70(publish 정비) 디프와 시각적 충돌. 필요 시 별도 chore PR로 분리 가능.
- NOTICE 파일도 추가하지 않음 — 외부 라이선스 의존성 0이라 §4(d) 의무 발생하지 않음.
- 가드 테스트 파일을 `repo-policy-license.test.js`로 분리 — PR-78의 `repo-policy.test.js`(보안/템플릿 가드)와 도메인이 달라 독립 유지. PR-70에서 publish 메타데이터 가드도 별도 파일로 추가 예정.

## 참고 사항

- 본 PR은 PR-78(SECURITY/CoC)과 병렬 작업. 두 PR은 다른 파일을 다루므로 충돌 없음 (각자 독립 가드 테스트 파일).
- 후속 PR-70(publish 정비 + Token Weather 리네임)이 같은 epic(#79)에서 이어진다.

> PR 제목은 `[feat]`, `[fix]`, `[docs]`처럼 타입은 영어로 유지하고, 뒤의 설명은 한글로 작성하는 것을 기본 규칙으로 합니다.