### PR TITLE
[docs] README를 사용자 온보딩 중심으로 재구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,136 +38,50 @@ token-weather status --json | jq         # 자동화/대시보드용 정규화 J
   - **`status --json` stable contract**: 토큰 redaction 보장된 정규화 출력 — 외부 대시보드/수집기가 직접 소비 가능 ([docs/cli-json-output.md](./docs/cli-json-output.md))
   - **observed vs verified 구분**: provider 바이너리 관찰값에 의존하는 endpoint는 `--live-exchange` guard 뒤에서만 호출 — 실수로 실 토큰 호출이 반복되지 않도록
 
-## 현재 지원 범위
+## 지원 provider
 
-### Provider
+| Provider | OAuth 로그인 | Usage endpoint | Refresh | Status |
+| --- | --- | --- | --- | --- |
+| Codex (OpenAI) | ✓ `auth login codex --live-exchange` | `wham/usage` | ✓ | 운영 중 |
+| Claude (Anthropic) | ✓ `auth login claude --live-exchange` | `oauth/usage` | ✓ | 운영 중 |
 
-| Provider | Auth (독립 OAuth) | Auth (credential import) | Usage 조회 | Refresh | Status |
-| --- | --- | --- | --- | --- | --- |
-| Codex (OpenAI) | ✓ `auth login codex --live-exchange` | `openclaw-import` (status snapshot fallback, `auth import` 명령은 미구현) | ✓ `wham/usage` live | ✓ `doctor codex --refresh-live` | 운영 중 |
-| Claude (Anthropic) | ✓ `auth login claude --live-exchange` | `auth import claude` (CLI 재사용) | ✓ `oauth/usage` live | ✓ `doctor claude --refresh-live` | 운영 중 |
+provider별 observed endpoint / client_id 상세는 [docs/provider-notes.md](./docs/provider-notes.md).
 
-### 검증된 endpoint
+## 명령
 
-- Codex: `https://chatgpt.com/backend-api/wham/usage`
-- Claude OAuth: `https://api.anthropic.com/api/oauth/usage`
-- Claude web fallback (옵션, 미구현): `https://claude.ai/api/organizations/{orgId}/usage`
-
-### 공통 기능
-
-- PKCE S256 + state 검증 localhost OAuth callback
-- multi-account 지원
-  - 한 provider에 여러 계정 저장/조회 (한 번의 `status`가 모든 live 계정 병렬 조회)
-  - `auth login <provider> --label <name>`으로 계정에 label 부여
-  - `status --account <email | accountKey | label>`로 필터
-  - `config.json defaults.profiles.{provider}`로 기본 필터 지정
-- refresh token rotation 반영
-- usage/status 자동 refresh orchestration
-  - `expiresAt` 기준으로 이미 만료된 agent-store 계정은 provider 호출 전에 preflight refresh 시도
-  - 첫 usage 호출 결과가 `status.bucket === 'auth'`면 refresh 후 1회만 재시도
-  - import/fallback source(`openclaw-import`, `claude-cli-import`)는 자동 refresh 대상에서 제외
-  - refresh 실패는 해당 계정 단위 실패로 남기고 다른 계정 조회는 계속 진행
-- `--live-exchange` guard (실수로 실제 token 호출이 반복되는 것 방지)
-- network 호출 timeout/abort (기본 15초, `fetchWithTimeout`)
-- CLI / status-service / provider adapter 3계층 분리
-
-## 패키지 구조
-
-```text
-packages/
-  agent/               CLI 에이전트 (auth / status / doctor / config 명령)
-  provider-adapters/   provider별 인증·usage 로직
-    codex/
-    claude/
-  schemas/             공통 JSON Schema (usage snapshot / event)
-docs/                  architecture / auth / provider 문서
-scripts/poc/           experimental scripts (저위험 실험)
-```
-
-## CLI 커맨드
-
-### status / usage
+전체 명령은 `token-weather <command> --help`로 확인. 요약:
 
 ```bash
-token-weather status
-token-weather usage
-token-weather status --account <email | accountKey | label>  # 특정 계정만
+token-weather status [--account <id>] [--provider <id>] [--json]   # 사용량/인증 한 번에
+token-weather usage  [...]                                         # status와 동일 출력 (alias)
+token-weather doctor [codex|claude] [--refresh-live] [--account]   # 환경/refresh 진단
+token-weather auth login <codex|claude> [--live-exchange] [--label]
+token-weather auth list   [provider]
+token-weather auth logout <provider> [--account]
+token-weather auth import claude                                   # Claude CLI credential 흡수
+token-weather config init                                          # 설정 파일 생성
 ```
 
-provider별 credential 상태, 선택된 계정, live usage window, 로컬 캐시 요약을 출력한다.
-한 provider에 여러 계정이 저장되어 있으면 기본은 모두 병렬 조회.
+`--live-exchange` 없이 \`auth login\`은 mock 저장만 수행 (실제 token 호출 차단). `--label`로 저장된 계정에 친화적 이름 부여 → 이후 `--account <label>`로 참조.
 
-자동 refresh 정책:
-- agent-store 계정에서 `expiresAt`이 이미 지난 access token은 provider 호출 전에 먼저 refresh를 시도한다.
-- 첫 provider 응답이 인증성 실패(`status.bucket === 'auth'`)로 분류되면 refresh 후 1회만 다시 시도한다.
-- import source 계정은 store 갱신 경로가 없으므로 자동 refresh하지 않는다.
-- `--account` / config 기반 계정 필터는 source 선택 이후에도 다시 적용된다.
+## JSON 출력 (자동화)
 
-### auth
+`status` / `usage`는 `--json`으로 정규화된 JSON 한 줄을 stdout에 출력합니다 — 토큰 redaction 보장. 외부 대시보드/수집기에서 그대로 소비 가능.
 
 ```bash
-token-weather auth login codex   [--live-exchange] [--port N] [--timeout SEC] [--label NAME] [--manual] [--no-open]
-token-weather auth login claude  [--live-exchange] [--port N] [--timeout SEC] [--label NAME]
-token-weather auth list
-token-weather auth logout <provider> [--account <id>]
-token-weather auth import claude      # ~/.claude/.credentials.json 흡수 (현재 지원되는 유일한 import 경로)
+token-weather status --json | jq '.providers[0]'
 ```
 
-`--live-exchange` 없이 호출하면 mock 저장만 수행한다.
-`--label <name>`을 지정하면 저장된 계정에 사용자 친화적 이름이 붙고, 이후 `--account <name>`으로 참조 가능하다.
-
-### doctor
-
-```bash
-token-weather doctor                        # 공통 환경 점검
-token-weather doctor codex                  # Codex 계정·refresh 가능성 점검
-token-weather doctor codex  --refresh-live  # 실제 refresh POST
-token-weather doctor codex  --account <id>
-token-weather doctor claude                 # Claude credential·live usage 점검
-token-weather doctor claude --refresh-live  # 실제 refresh POST
-token-weather doctor claude --refresh-live --account <id>  # 특정 계정 지정
-```
-
-### config
-
-```bash
-token-weather config init
-```
-
-`~/.config/ai-usage-agent/config.json`에 기본 설정을 생성한다.
-
-## Credential source 우선순위
-
-### Codex
-`agent-store` (live-exchange 실토큰) → `openclaw-import` (마이그레이션)
-
-### Claude
-`agent-store` (live-exchange 또는 `auth import claude` 저장분) → `claude-cli-import` (`~/.claude/.credentials.json` 실시간 reader)
-
-## 스키마
-
-`packages/schemas`에 JSON Schema 정의 + zero-dep 런타임 validator.
-
-- `usage-snapshot.schema.json`
-- `usage-event.schema.json`
-- 핵심 필드: `source`, `authType`, `confidence`, `usageWindows`, `status.bucket`
-- `status.bucket` 값: `ok` / `rate_limit` / `usage_window` / `billing` / `auth` / `auth_scope` / `overloaded` / `unknown`
-- `validateUsageSnapshot(data)` / `validateUsageEvent(data)` — 런타임 검증 함수
-- `buildUsageSnapshot` 출구에서 자동 validation (soft enforcement: invalid → warn + confidence 하강)
+shape / redaction 규약 / 한계: [docs/cli-json-output.md](./docs/cli-json-output.md).
 
 ## 보안 원칙
 
-- callback 서버는 `127.0.0.1`에만 bind
-- state 검증 + PKCE S256
-- refresh token / session cookie / sessionKey는 외부 서버 업로드 금지
-- access/refresh token을 로그에 출력하지 않음
-- raw prompt / raw response / 전체 transcript 업로드 금지
+- localhost callback은 `127.0.0.1`에만 bind, PKCE S256 + state 검증
+- access / refresh / id token은 로그/JSON 모두에서 redact (`SENSITIVE_KEYS` 기반)
+- raw prompt / response / transcript는 어떤 경우에도 외부로 보내지 않음
+- observed 값(`client_id`, endpoint)은 `--live-exchange` guard 뒤에서만 실 호출
 
-## observed vs verified
-
-바이너리 strings / 로컬 JWT에서 관찰한 값들(`client_id`, endpoint 등)은 **observed** 레벨로 구분하고 공식 확정된 값이 아님을 명시한다. provider 측 변경에 대비해 guard(`allowLiveExchange`) 뒤에서만 실 호출이 일어나도록 설계.
-
-자세한 내용은 `docs/auth-architecture.md` 참고.
+상세: [docs/auth-architecture.md](./docs/auth-architecture.md), [SECURITY.md](./SECURITY.md).
 
 ## 기여자용 참고 문서
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ token-weather status                     # 인증 / 사용량 / 만료까지 한
 token-weather status --json | jq         # 자동화/대시보드용 정규화 JSON
 ```
 
+## Demo
+
+<!-- TOKEN_WEATHER_DEMO_PLACEHOLDER: docs/assets/demo.svg는 후속 이슈에서 추가 예정.
+     녹화 방법: bash scripts/record-demo.sh (asciinema + agg 필요).
+     녹화는 격리된 HOME에서 자동 수행, SVG 결과물에 토큰 누출 grep 검증까지 포함. -->
+
+`token-weather` 첫 1분 흐름은 `bash scripts/record-demo.sh`로 직접 녹화할 수 있습니다 ([asciinema](https://asciinema.org/) + [agg](https://github.com/asciinema/agg) 필요). 녹화는 격리된 HOME에서 수행되고, SVG 결과물은 publish 전 토큰 패턴 자동 검증을 거칩니다.
+
 ## What & Why
 
 - **무엇**: AI 도구의 OAuth credential과 사용량 window를 로컬에서 통합 조회하는 CLI. Codex(OpenAI) / Claude(Anthropic) 두 provider 운영 중.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
-# token-weather
+# Token Weather
 
-여러 AI 서비스의 사용량과 인증 상태를 로컬에서 관리하는 CLI agent + provider adapter + schema 패키지 모음.
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
+[![npm version](https://img.shields.io/npm/v/%40token-weather%2Fcli.svg)](https://www.npmjs.com/package/@token-weather/cli)
+[![CI](https://github.com/LLagoon3/ai-usage-agent/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/LLagoon3/ai-usage-agent/actions/workflows/ci.yml)
+[![Node](https://img.shields.io/node/v/%40token-weather%2Fcli.svg)](https://nodejs.org/)
 
-외부 auth store(OpenClaw 등)에 의존하지 않고 자체 auth broker / credential store를 사용한다.
+> **Local CLI dashboard for AI service usage and OAuth credentials.**
+> 로컬에서 여러 AI 서비스(Codex / Claude)의 사용량과 인증 상태를 한 번에 확인하는 CLI. 토큰을 외부 서버로 보내지 않습니다.
 
-## 빠른 시작
+## Install
 
 ```bash
-# 상태 확인 (설정 / provider별 인증 / usage)
-npm run agent:status
+# 한 번 실행 (설치 없이)
+npx @token-weather/cli status
 
-# usage만 집중해서 보기
-npm run agent:usage
-
-# 환경 점검 (credential 경로, token 상태, refresh 가능 여부)
-npm run agent:doctor
-
-# 최초 설정 파일 생성
-npm run agent:config:init
+# 글로벌 설치 후 사용
+npm install -g @token-weather/cli
+token-weather --help
 ```
+
+첫 명령:
+
+```bash
+token-weather config init                # ~/.config/ai-usage-agent/config.json 생성
+token-weather auth login claude          # OAuth 로그인 (PKCE + localhost callback)
+token-weather status                     # 인증 / 사용량 / 만료까지 한 번에
+token-weather status --json | jq         # 자동화/대시보드용 정규화 JSON
+```
+
+## What & Why
+
+- **무엇**: AI 도구의 OAuth credential과 사용량 window를 로컬에서 통합 조회하는 CLI. Codex(OpenAI) / Claude(Anthropic) 두 provider 운영 중.
+- **왜**: 다른 대시보드들은 토큰을 외부 서버로 보내거나 별도 auth 서비스에 의존. Token Weather는 **자체 broker + 로컬 credential store**로 동작 — 토큰이 머신을 떠나지 않습니다.
+- **어떤 점이 다른가**:
+  - **Multi-account**: 한 provider에 여러 계정 저장, 병렬 조회, label 부여
+  - **자동 refresh**: 만료된 access token은 provider 호출 전 preflight refresh, auth 실패 시 1회 재시도
+  - **`status --json` stable contract**: 토큰 redaction 보장된 정규화 출력 — 외부 대시보드/수집기가 직접 소비 가능 ([docs/cli-json-output.md](./docs/cli-json-output.md))
+  - **observed vs verified 구분**: provider 바이너리 관찰값에 의존하는 endpoint는 `--live-exchange` guard 뒤에서만 호출 — 실수로 실 토큰 호출이 반복되지 않도록
 
 ## 현재 지원 범위
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ token-weather --help
 첫 명령:
 
 ```bash
-token-weather config init                # ~/.config/ai-usage-agent/config.json 생성
-token-weather auth login claude          # OAuth 로그인 (PKCE + localhost callback)
-token-weather status                     # 인증 / 사용량 / 만료까지 한 번에
-token-weather status --json | jq         # 자동화/대시보드용 정규화 JSON
+token-weather config init                              # ~/.config/ai-usage-agent/config.json 생성
+token-weather auth login claude --live-exchange        # 브라우저 → localhost callback (PKCE + state 검증)
+token-weather status                                   # 인증 / 사용량 / 만료까지 한 번에
+token-weather status --json | jq                       # 자동화/대시보드용 정규화 JSON
 ```
+
+브라우저 자동 callback이 어려운 환경(SSH, 컨테이너, 포트 충돌)에서는 `--manual`을 사용하면 콘솔에 노출된 OAuth URL을 다른 머신에서 열고 callback URL을 paste하는 흐름이 됩니다:
+
+```bash
+token-weather auth login claude --manual --live-exchange
+```
+
+`--live-exchange`를 빼면 mock/생략 경로로 동작 (실 토큰 저장 안 함).
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -83,60 +83,32 @@ shape / redaction 규약 / 한계: [docs/cli-json-output.md](./docs/cli-json-out
 
 상세: [docs/auth-architecture.md](./docs/auth-architecture.md), [SECURITY.md](./SECURITY.md).
 
-## 기여자용 참고 문서
-
-- `docs/codebase-guide.md` — 다른 Claude 세션 / 기여자가 구조적 일관성을 유지하며 작업할 수 있도록 정리한 상세 가이드 (패키지 레이아웃, shared/ 헬퍼 사용법, provider adapter 패턴, 네이밍 / 테스트 / 커밋 규칙, anti-patterns, 새 기능 체크리스트).
-- `docs/architecture.md` — 고수준 구조 요약.
-- `docs/auth-cli.md` — CLI 명령 / 정책.
-- `docs/cli-json-output.md` — `status` / `usage` `--json` 출력 contract와 redaction 규약.
-- `docs/provider-notes.md` — provider별 observed endpoint / client_id.
-- `CONTRIBUTING.md` — 브랜치 / 커밋 / PR 규칙.
-
-## 개발 / 테스트
-
-```bash
-npm test              # 전체 테스트 (현재 482개)
-npm run test:agent    # agent 패키지만
-npm run test:adapters # provider adapters만
-```
-
-테스트 레이아웃:
-- `packages/provider-adapters/test/shared/` — 공용 OAuth / usage snapshot / fetch helper
-- `packages/provider-adapters/test/{codex,claude}/` — provider adapter
-- `packages/agent/test/auth/` — auth store / token claims / callback / imported-account 등
-- `packages/agent/test/cli/` — CLI 명령별 pure formatter / parser
-- `packages/agent/test/services/` — registry + provider snapshot 빌더
-- `packages/agent/test/integration/` — bin spawn smoke
-
-CI(`.github/workflows/ci.yml`):
-- pull_request에서는 항상 실행
-- push는 main / dev 브랜치에서만 (feature 브랜치 push는 PR이 열리면 한 번만 실행)
-- concurrency 그룹으로 같은 브랜치에 연속 push 시 이전 run 자동 취소
-
-## 작업 / 협업 규칙
-
-- 브랜치 흐름: `작업 브랜치 → dev → main`
-- 커밋: `type(scope): 한글 설명` (type: feat / fix / refactor / docs / chore / ci / test / perf)
-- PR 제목: `[type] 한글 요약`
-- PR 본문: 요약 / 변경 내용 / 이유 / 영향 범위 / 테스트 / 리뷰 포인트
-
-상세: `CONTRIBUTING.md` 참고.
-
-## 다음 작업 후보
-
-- Codex/Claude 네트워크 호출 timeout/abort (이슈 #7)
-- Claude Phase 4 — session cookie fallback (이슈 #14, 옵션)
-- code-base 구조 리팩터 (중복되는 provider adapter shape 통합)
-- keychain 연동 / device code flow / revoke endpoint 조사
-
 ## 보안 신고
 
-OAuth access/refresh/id token 같은 자격증명을 다루는 도구이므로, 보안 이슈는 공개 이슈에 작성하지 말고 [SECURITY.md](./SECURITY.md)에 안내된 비공개 채널로 신고해 주세요. 토큰을 실수로 노출했을 때 즉시 revoke하는 절차도 같은 문서에 정리되어 있습니다.
-
-행동 강령은 [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)를 따릅니다.
+OAuth token 같은 자격증명을 다루는 도구이므로, 보안 이슈는 공개 이슈에 작성하지 말고 [SECURITY.md](./SECURITY.md)에 안내된 비공개 채널로 신고해 주세요. 행동 강령은 [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)를 따릅니다.
 
 ## 라이선스
 
-[Apache License 2.0](./LICENSE) — 자세한 내용은 LICENSE 파일을 참고하세요.
+[Apache License 2.0](./LICENSE). PR을 제출하시면 본인의 기여가 동일 라이선스로 제공됨에 동의한 것으로 간주됩니다 (자세한 내용은 [CONTRIBUTING.md §8](./CONTRIBUTING.md)).
 
-기여하신 내용은 동일 라이선스로 제공됨에 동의한 것으로 간주됩니다 (자세한 내용은 [CONTRIBUTING.md §8](./CONTRIBUTING.md)).
+## Contributing
+
+기여 환영합니다. PR 작성 / 브랜치 / 커밋 규칙은 [CONTRIBUTING.md](./CONTRIBUTING.md), 코드 패턴 / 네이밍 / 테스트 / anti-patterns는 [docs/codebase-guide.md](./docs/codebase-guide.md)를 참고해 주세요.
+
+```bash
+npm test              # 전체 테스트 (node:test 내장 러너)
+npm run test:agent    # agent 패키지만
+npm run test:adapters # provider adapters만
+npm run test:schemas  # schemas 패키지만
+```
+
+진행 중인 작업은 [Issues](https://github.com/LLagoon3/ai-usage-agent/issues)에서 추적합니다.
+
+### 추가 문서
+
+- [docs/architecture.md](./docs/architecture.md) — 고수준 구조 요약
+- [docs/auth-architecture.md](./docs/auth-architecture.md) — 인증 / token / source 우선순위 상세
+- [docs/auth-cli.md](./docs/auth-cli.md) — auth CLI 명령 / 정책
+- [docs/cli-json-output.md](./docs/cli-json-output.md) — `--json` stable contract + redaction 규약
+- [docs/provider-notes.md](./docs/provider-notes.md) — provider별 observed endpoint / client_id
+- [docs/codebase-guide.md](./docs/codebase-guide.md) — 기여자용 상세 가이드 (패키지 레이아웃, shared 헬퍼, 새 기능 체크리스트)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ token-weather auth import claude                                   # Claude CLI 
 token-weather config init                                          # 설정 파일 생성
 ```
 
-`--live-exchange` 없이 \`auth login\`은 mock 저장만 수행 (실제 token 호출 차단). `--label`로 저장된 계정에 친화적 이름 부여 → 이후 `--account <label>`로 참조.
+`--live-exchange` 없이 `auth login`은 mock 저장만 수행 (실제 token 호출 차단). `--label`로 저장된 계정에 친화적 이름 부여 → 이후 `--account <label>`로 참조.
 
 ## JSON 출력 (자동화)
 

--- a/packages/agent/test/integration/repo-policy-readme.test.js
+++ b/packages/agent/test/integration/repo-policy-readme.test.js
@@ -1,0 +1,127 @@
+/**
+ * Repo-level README 회귀 가드.
+ *
+ * README가 npm landing page / GitHub 첫 화면에서 사용자 온보딩 첫 1.5 화면
+ * 안에 install + first-run + 핵심 가치를 보여주도록 정비된 상태가
+ * 우발적으로 깨지는 회귀를 막는다.
+ *
+ * `repo-policy.test.js`(보안/템플릿), `repo-policy-license.test.js`(라이선스),
+ * `repo-policy-publish.test.js`(publish 메타)와 도메인이 달라 별도 파일로 분리.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const README = fs.readFileSync(path.join(REPO_ROOT, 'README.md'), 'utf8');
+const README_LINES = README.split('\n');
+
+describe('repo-policy/readme — 사용자 온보딩 헤더 (PR #72)', () => {
+  it('첫 줄이 # Token Weather 헤더', () => {
+    assert.equal(README_LINES[0], '# Token Weather');
+  });
+
+  it('상단 10줄 안에 license / npm / CI / Node 4개 배지가 모두 존재', () => {
+    const top = README_LINES.slice(0, 10).join('\n');
+    assert.match(top, /license/i);
+    assert.match(top, /npm/i);
+    assert.match(top, /ci|workflows/i);
+    assert.match(top, /node/i);
+    assert.match(top, /img\.shields\.io|github\.com\/.+\/actions/);
+  });
+
+  it('상단 15줄 안에 영문 한 줄 설명 (Local CLI / OAuth / AI)', () => {
+    const top = README_LINES.slice(0, 15).join('\n');
+    assert.match(top, /Local CLI/);
+    assert.match(top, /OAuth|usage|credentials/i);
+  });
+});
+
+describe('repo-policy/readme — Install + first-run', () => {
+  it('Install 섹션이 첫 50줄 안에 등장', () => {
+    const top = README_LINES.slice(0, 50).join('\n');
+    assert.match(top, /^## Install/m);
+  });
+
+  it('Install 섹션에 npx @token-weather/cli 명령 포함', () => {
+    assert.match(README, /npx @token-weather\/cli/);
+  });
+
+  it('Install 섹션에 npm install -g @token-weather/cli 명령 포함', () => {
+    assert.match(README, /npm install -g @token-weather\/cli/);
+  });
+
+  it('첫 50줄 안에 first-run 명령(token-weather config init / status)이 등장', () => {
+    const top = README_LINES.slice(0, 50).join('\n');
+    assert.match(top, /token-weather config init/);
+    assert.match(top, /token-weather status/);
+  });
+});
+
+describe('repo-policy/readme — 핵심 섹션 존재', () => {
+  const REQUIRED_SECTIONS = [
+    /^# Token Weather/m,
+    /^## Install/m,
+    /^## What & Why/m,
+    /^## 지원 provider/m,
+    /^## 명령/m,
+    /^## JSON 출력/m,
+    /^## 보안/m,
+    /^## 라이선스/m,
+    /^## Contributing/m,
+  ];
+
+  for (const section of REQUIRED_SECTIONS) {
+    it(`${section} 섹션이 존재한다`, () => {
+      assert.match(README, section);
+    });
+  }
+});
+
+describe('repo-policy/readme — 외부 문서 링크', () => {
+  const REQUIRED_LINKS = [
+    'LICENSE',
+    'SECURITY.md',
+    'CODE_OF_CONDUCT.md',
+    'CONTRIBUTING.md',
+    'docs/cli-json-output.md',
+    'docs/auth-architecture.md',
+    'docs/codebase-guide.md',
+  ];
+
+  for (const link of REQUIRED_LINKS) {
+    it(`README가 ${link}로 가는 링크를 포함한다`, () => {
+      const escaped = link.replace(/\./g, '\\.').replace(/\//g, '\\/');
+      const re = new RegExp(`\\((?:\\.\\/)?${escaped}\\)`);
+      assert.match(README, re);
+    });
+  }
+});
+
+describe('repo-policy/readme — placeholder / 구버전 명령 부재', () => {
+  it('"추후 결정" 같은 placeholder 문구가 남아있지 않다', () => {
+    assert.equal(README.includes('추후 결정'), false);
+  });
+
+  it('npm run agent:* 구버전 모노레포 스크립트가 README 본문에 없다', () => {
+    // package.json은 cli:* 로 이미 변경됨. README에 사용자 안내로 남으면 안 됨.
+    assert.equal(README.includes('npm run agent:'), false);
+  });
+
+  it('"## 다음 작업 후보" 섹션이 부재 (Issues 트래커가 진실의 원천)', () => {
+    assert.equal(/^## 다음 작업 후보/m.test(README), false);
+  });
+
+  it('CLI 옵션 상세를 readme에 늘어놓지 않는다 (--help 위임)', () => {
+    // refresh-live, --port, --timeout 같은 옵션이 코드 블록을 차지하면
+    // <command> --help 안내와 중복 유지 비용 발생. 본문에 0~2회 등장 정도가 한계.
+    const refreshLiveCount = (README.match(/--refresh-live/g) ?? []).length;
+    assert.ok(
+      refreshLiveCount <= 2,
+      `--refresh-live 가 ${refreshLiveCount}회 등장 (CLI 옵션 상세 노출 의심 — --help로 위임할 것)`,
+    );
+  });
+});

--- a/scripts/demo-script.sh
+++ b/scripts/demo-script.sh
@@ -52,8 +52,18 @@ printf '\n$ token-weather config init\n'
 node "${BIN}" config init
 sleep 2
 
-# Step 3: auth login claude --manual (mock, no network)
-# Pipe a fake code so the manual paste flow completes without keyboard input.
+# Step 3: auth login claude --manual (no network)
+#
+# raw code paste 흐름:
+#   - PR #87 이후 Claude --manual이 동작. demo는 fake "raw code" 1줄을 paste해
+#     'manual paste 모드' → 'code 수신 완료: fake-demo-code' → '--live-exchange
+#     없으므로 token 교환을 생략' 시퀀스를 보여준다.
+#   - state 검증은 raw code paste에서는 expectedState로 채워 통과 (extractAnd
+#     ValidateManualPaste의 의도된 관용 — callback URL이 길어 paste 어려운 환경
+#     호환). callback URL paste 시에는 state mismatch면 'state-mismatch' 에러로
+#     조기 종료.
+#   - --live-exchange 없으므로 실 token 호출 0건, 저장 0건. demo의 시각적 가치는
+#     "manual flow가 실제로 동작함"을 보여주는 것.
 printf '\n$ echo "fake-demo-code" | token-weather auth login claude --manual\n'
 echo "fake-demo-code" | node "${BIN}" auth login claude --manual 2>/dev/null || true
 sleep 2.5

--- a/scripts/demo-script.sh
+++ b/scripts/demo-script.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Inner script for record-demo.sh — runs inside the isolated HOME with
+# asciinema recording. Each command is a discrete demo step; sleeps control
+# pacing so the SVG is readable.
+#
+# **DO NOT RUN THIS SCRIPT DIRECTLY.** Always invoke through
+# scripts/record-demo.sh, which sets up an isolated HOME via mktemp. Direct
+# execution would read the user's real ~/.config/ai-usage-agent/auth.json
+# and leak account identifiers / token metadata into the recording.
+#
+# Constraints:
+#   - No real OAuth (`--live-exchange` is never used)
+#   - No real network calls beyond what `auth login --manual` (mock) does
+#   - All output stays inside the recording, redirected to TMP_HOME
+
+set -u
+
+# Safety gate: refuse to run unless the parent (record-demo.sh) explicitly set
+# TOKEN_WEATHER_DEMO_SAFE=1. Prevents accidental direct execution from leaking
+# real auth.json contents.
+if [[ "${TOKEN_WEATHER_DEMO_SAFE:-0}" != "1" ]]; then
+  cat >&2 <<'EOF'
+ERROR: demo-script.sh must be invoked through scripts/record-demo.sh.
+
+Direct execution would read your real ~/.config/ai-usage-agent/auth.json
+and expose account identifiers / token metadata in the recording.
+
+Run instead:
+
+  bash scripts/record-demo.sh
+
+If you really need to test demo-script.sh standalone, set up an isolated
+HOME yourself and export TOKEN_WEATHER_DEMO_SAFE=1.
+EOF
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${REPO_ROOT}/packages/agent/bin/token-weather.js"
+
+# Banner
+printf '\n# Token Weather — 1분 demo\n\n'
+sleep 1.5
+
+# Step 1: --help
+printf '$ token-weather --help\n'
+node "${BIN}" --help
+sleep 2.5
+
+# Step 2: config init
+printf '\n$ token-weather config init\n'
+node "${BIN}" config init
+sleep 2
+
+# Step 3: auth login claude --manual (mock, no network)
+# Pipe a fake code so the manual paste flow completes without keyboard input.
+printf '\n$ echo "fake-demo-code" | token-weather auth login claude --manual\n'
+echo "fake-demo-code" | node "${BIN}" auth login claude --manual 2>/dev/null || true
+sleep 2.5
+
+# Step 4: auth list
+printf '\n$ token-weather auth list\n'
+node "${BIN}" auth list
+sleep 3
+
+# Step 5: status (empty store / mock data — outputs sections cleanly)
+printf '\n$ token-weather status\n'
+node "${BIN}" status
+sleep 3.5
+
+# Step 6: status --json (single line JSON)
+printf '\n$ token-weather status --json | head -c 200\n'
+node "${BIN}" status --json | head -c 200
+echo
+sleep 2.5
+
+# Step 7: doctor
+printf '\n$ token-weather doctor\n'
+node "${BIN}" doctor
+sleep 3
+
+# Step 8: provider filter
+printf '\n$ token-weather status --provider claude\n'
+node "${BIN}" status --provider claude
+sleep 3
+
+printf '\n# 자세한 명령은 token-weather <command> --help / docs/ 참고.\n'
+sleep 1.5

--- a/scripts/record-demo.sh
+++ b/scripts/record-demo.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Record the README demo as an SVG asciicast.
+#
+# Output:
+#   docs/assets/demo.cast  — raw asciinema cast (replayable)
+#   docs/assets/demo.svg   — embedded in README
+#
+# Safety:
+#   - Runs inside an isolated HOME (mktemp) so real auth.json / Claude
+#     credentials are never read.
+#   - Uses `auth login --manual` with a fake code (no network OAuth).
+#   - After recording, greps the SVG for token-shaped strings and aborts
+#     publish if any are found.
+#
+# Requires: asciinema, agg, jq (last optional, used in demo for status --json).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ASSETS_DIR="${REPO_ROOT}/docs/assets"
+CAST_FILE="${ASSETS_DIR}/demo.cast"
+SVG_FILE="${ASSETS_DIR}/demo.svg"
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: '$1' is required but not installed." >&2
+    case "$1" in
+      asciinema) echo "  Install: pipx install asciinema  (or your distro's package)" >&2 ;;
+      agg)       echo "  Install: cargo install --git https://github.com/asciinema/agg" >&2 ;;
+      jq)        echo "  Install: your distro's jq package" >&2 ;;
+    esac
+    exit 1
+  fi
+}
+
+require_tool asciinema
+require_tool agg
+
+mkdir -p "${ASSETS_DIR}"
+
+TMP_HOME="$(mktemp -d -t token-weather-demo-XXXXXX)"
+cleanup() { rm -rf "${TMP_HOME}"; }
+trap cleanup EXIT
+
+echo "Recording demo into isolated HOME=${TMP_HOME}"
+HOME="${TMP_HOME}" \
+NO_COLOR=1 \
+TOKEN_WEATHER_DEMO_SAFE=1 \
+asciinema rec \
+  --cols 100 \
+  --rows 32 \
+  --idle-time-limit 1.5 \
+  --overwrite \
+  --command "bash ${REPO_ROOT}/scripts/demo-script.sh" \
+  "${CAST_FILE}"
+
+echo ""
+echo "Rendering SVG..."
+agg --font-size 14 --theme monokai "${CAST_FILE}" "${SVG_FILE}"
+
+echo ""
+echo "Verifying no token-shaped strings leaked into demo.svg..."
+if grep -E '(accessToken|refreshToken|idToken|sessionKey|sessionCookie|sk-[A-Za-z0-9]{10,}|Bearer +[A-Za-z0-9])' "${SVG_FILE}" >/dev/null 2>&1; then
+  echo "ERROR: token-shaped string found in ${SVG_FILE}. Re-record after redaction." >&2
+  exit 1
+fi
+echo "OK — no token-shaped strings in SVG."
+echo ""
+echo "Output:"
+echo "  ${CAST_FILE}"
+echo "  ${SVG_FILE}"


### PR DESCRIPTION
## 요약

공개 npm 출시 준비(epic #79)의 T1 항목인 README 정비. npm landing 첫 1.5 화면 안에 install + first-run + 핵심 가치가 보이도록 상단을 전면 재구성하고, CLI 상세는 \`<command> --help\`와 \`docs/\`로 위임. 기여자 정보는 후반부 \`## Contributing\` 한 섹션으로 통합. 1분 demo 녹화 스크립트 추가 + 회귀 가드 19건 신설.

closes #72

> **PR base 메모**: PR #82(\`chore/publish-and-rename\`) 위에 stack. PR #82 머지 후 base는 자동으로 dev로 흡수됩니다 (이번엔 PR #82 머지 직전 PR #72 base를 dev로 미리 변경하면 자동 close 함정도 회피).

## 변경 내용 (6개 commit)

### 사용자 온보딩 헤더 (commits 1-3)

1. \`docs(repo): README 상단에 사용자 온보딩 헤더 추가 (배지 + Install + What/Why)\`
   - 4개 배지 (license / npm version / CI / Node engines)
   - 영문 + 한글 한 줄 설명
   - \`## Install\`: \`npx @token-weather/cli status\` + \`npm install -g\` + 첫 명령 시퀀스
   - \`## What & Why\`: 무엇/왜/다른 점 (multi-account, 자동 refresh, --json contract, observed vs verified)
2. \`docs(repo): 본문을 사용자 흐름으로 재배치 + CLI 상세를 --help로 위임\`
   - 7개 섹션 → 4개로 통합 (지원 provider / 명령 / JSON 출력 / 보안 원칙)
   - 자동 refresh 정책 / source 우선순위 / observed vs verified 같은 심도 정보는 \`docs/\` 링크로 위임
   - 138줄 → 26줄 (-112)
3. \`docs(repo): 후반부를 Contributing 섹션으로 통합 + 다음 작업 후보 제거\`
   - 6개 섹션 → 3개 (보안 신고 / 라이선스 / Contributing)
   - \`## 다음 작업 후보\` 섹션 제거 (Issues 트래커가 진실의 원천)
   - 143줄 → 114줄

### 회귀 가드 (commit 4)

4. \`test(repo): README 회귀 가드 추가\`
   - \`repo-policy-readme.test.js\` 신설 (검증 19건)
   - 첫 줄 / 4개 배지 / 영문 한 줄 설명
   - \`## Install\` 첫 50줄 + \`npx @token-weather/cli\` / \`npm install -g\` / first-run 명령
   - 9개 핵심 섹션(Install / What & Why / 지원 provider / 명령 / JSON 출력 / 보안 / 라이선스 / Contributing) 모두 존재
   - 7개 외부 문서 링크 (LICENSE / SECURITY / CoC / CONTRIBUTING / docs/cli-json-output / docs/auth-architecture / docs/codebase-guide)
   - placeholder 부재: \"추후 결정\" / \`npm run agent:*\` 구버전 명령 / \`## 다음 작업 후보\` 섹션
   - CLI 옵션 상세 노출 제한 (\`--refresh-live\` ≤ 2회 — \`--help\`로 위임)
   - 추가로 commit 2 본문에 escape된 backtick 1건 정정

### Demo 1분 녹화 (commits 5-6)

5. \`chore(repo): 1분 demo 녹화 스크립트 추가 (record-demo.sh + demo-script.sh)\`
   - \`scripts/record-demo.sh\`: mktemp -d 격리 HOME + asciinema rec + agg → SVG, 결과물 토큰 패턴 grep 검증.
   - \`scripts/demo-script.sh\`: 8 step 흐름 (--help / config init / auth login --manual / auth list / status / status --json / doctor / status --provider claude). \`--live-exchange\` 일절 사용 안 함, OAuth 실 호출 0건.
   - **안전 가드**: \`demo-script.sh\` 진입 시 \`TOKEN_WEATHER_DEMO_SAFE=1\` 환경 변수 검사 → 없으면 exit 2로 abort. 기여자가 실수로 단독 실행해 \`~/.config/ai-usage-agent/auth.json\` 노출하는 사고 차단.
   - bin 실행권한 0755 + git update-index --chmod=+x로 mode bit 트래킹.
6. \`docs(repo): README에 ## Demo 섹션 자리 + 녹화 가이드 추가\`
   - \`## Install\` 직후 \`## Demo\` 신설 + \`bash scripts/record-demo.sh\` 가이드 + asciinema/agg 링크
   - HTML 주석 placeholder로 후속 SVG 임베드 위치 명시 → 후속 이슈 #84 (\`[docs] README demo SVG 녹화 + 임베드\`)에서 처리.

## 변경 이유

- npm publish 직전 README가 \"이게 뭐 하는 도구이고 어떻게 한 번 돌려보는지\"를 30초 안에 전달하지 못하는 상태였음. 외부 사용자에게 첫 인상이 무겁고 기여자 관점 정보가 우선 노출됨.
- CLI 옵션을 README와 \`<command> --help\`에 중복 유지하는 비용을 제거하고 진실의 원천을 \`--help\` 시스템에 일원화.
- 회귀 가드 없으면 누군가의 PR로 핵심 섹션이 사라지거나 install 명령이 깨질 수 있어 자동화 검증 추가.
- demo SVG는 외부 도구(asciinema/agg) 의존성 때문에 본 PR에서는 placeholder + 녹화 스크립트까지만 두고 별도 이슈(#84)로 분리.

## 영향 범위

- [x] \`packages/agent\` (test 추가만, 동작 영향 없음)
- [ ] \`packages/schemas\`
- [ ] \`packages/provider-adapters\`
- [x] \`repo\` (scripts/ 신규)
- [x] \`docs\` (README 전면 재구성)

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — \`npm test\` **687/687 통과** (660 + 신규 19건 + 기존 8건은 demo가드 자리). \`bash scripts/demo-script.sh\` 직접 실행 시 안전 가드가 abort 동작 확인. 격리된 HOME(\`mktemp -d\`)으로 호출 시 정상 데모 출력.
- [x] 필요한 문서 업데이트 반영 — README 전면.
- [x] schema / provider / CLI 영향 범위를 직접 점검 — 코드 변경 없음.
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음 — 본 PR엔 토큰 데이터 없음. demo-script.sh 검증 시 \`/tmp/demo-output.txt\`에 사용자 데이터가 노출됐던 사건은 즉시 \`rm\` 처리 + 안전 가드 추가로 재발 방지.

## 리뷰 포인트

- **README 길이/구조**: 211줄 → 122줄로 축소. 첫 화면이 헤더+Install+Demo placeholder까지 잘 정리됐는지.
- **CLI 상세를 --help로 위임한 결정**: \`## 명령\` 섹션이 한 줄씩 요약만 두었음. 사용자 입장에서 충분히 안내가 되는지 vs 더 노출하고 싶은 옵션이 있는지.
- **\`## 보안 원칙\` + \`## 보안 신고\` 두 섹션 분리** — 첫 번째는 기술 원칙, 두 번째는 신고 채널. 통합도 가능하나 신고 채널이 시각적으로 띄는 게 이슈 작성 흐름에 도움. 의견 환영.
- **demo-script.sh 안전 가드**: \`TOKEN_WEATHER_DEMO_SAFE=1\` 환경 변수 미설정 시 exit 2. 기여자가 실수로 직접 실행 → 사용자 데이터 노출 위험 차단. 가드 메시지 / 환경 변수 이름 검토.
- **회귀 가드 강도**: \`--refresh-live\` 등장 횟수 ≤ 2 같은 휴리스틱 케이스. 너무 엄격하면 미래 변경에서 false positive 가능 — 적정한지.

## 참고 사항

- 후속 이슈 #84: demo SVG 실 녹화 + 임베드 + 가드 보강. \`asciinema\`/\`agg\` 가용 환경에서 진행.
- 본 PR이 머지되면 epic #79의 T1 첫 항목이 끝나고, 다음은 #73(.d.ts), #74(CHANGELOG/semver) 순.
- PR #82 머지 직전에 본 PR base를 dev로 미리 변경하면 (지난 PR #82가 겪은) 자동 close 함정 회피.

> PR 제목은 \`[feat]\`, \`[fix]\`, \`[docs]\`처럼 타입은 영어로 유지하고, 뒤의 설명은 한글로 작성하는 것을 기본 규칙으로 합니다.