### PR TITLE
[feat] Claude --manual 흐름 구현 + pi-ai authorize/scope parity 보정

### DIFF
--- a/packages/agent/src/cli/auth-login-command.js
+++ b/packages/agent/src/cli/auth-login-command.js
@@ -172,12 +172,8 @@ async function runClaudeLogin(args) {
     return;
   }
 
-  if (options.manual) {
-    console.log('claude manual paste 경로는 아직 제공하지 않습니다.');
-    console.log('대신 로컬 callback 경로를 사용하세요: token-weather auth login claude');
-    return;
-  }
-
+  // Claude `--manual`은 runOAuthLoginFlow의 공통 manual 분기로 처리된다
+  // (login-runner.js::runManualPasteFlow). Codex와 동일한 spec 기반 흐름.
   await runOAuthLoginFlow(CLAUDE_LOGIN_SPEC, options);
 }
 

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -2,6 +2,7 @@ import {
   prepareLocalhostCallback,
   startLocalhostCallbackServer,
 } from '../auth/localhost-callback.js';
+import { readManualPasteInput, extractCodeFromPaste } from '../auth/manual-paste.js';
 import {
   loadAuthStore,
   saveAuthStore,
@@ -319,4 +320,29 @@ export function parseLoginOptions(args) {
     collectWarnings: true,
     includeHelp: true,
   });
+}
+
+/**
+ * `extractCodeFromPaste` 결과에 OAuth state 검증을 추가한 순수 함수.
+ *
+ * - raw code paste(`pasteResult.type === 'code'`)는 state가 없어 expectedState로
+ *   채워 통과시킨다 (callback URL이 너무 길어 paste 어려운 환경에서 raw code만으로
+ *   사용 가능하도록 하는 의도된 관용).
+ * - URL paste의 state가 expected와 다르면 `error: 'state-mismatch'`로 실패.
+ *
+ * @param {{ type: 'url' | 'code', value: string, error?: string }} pasteResult
+ * @param {string} expectedState
+ * @returns {{ code: string | null, state: string | null, error: string | null }}
+ */
+export function extractAndValidateManualPaste(pasteResult, expectedState) {
+  const extracted = extractCodeFromPaste(pasteResult);
+  if (extracted.error || !extracted.code) return extracted;
+  if (extracted.state && extracted.state !== expectedState) {
+    return { code: null, state: extracted.state, error: 'state-mismatch' };
+  }
+  return {
+    code: extracted.code,
+    state: extracted.state ?? expectedState,
+    error: null,
+  };
 }

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -139,20 +139,28 @@ export async function runOAuthLoginFlow(spec, options) {
  *
  * spec.supportsMockCallback이 false인 provider(e.g. Claude)는 --live-exchange
  * 없이 호출되면 mock 저장 없이 안내 메시지로 종료.
+ *
+ * `deps.readPaste` — 테스트 주입용 (기본: readManualPasteInput).
+ *
+ * @param {LoginProviderSpec} spec
+ * @param {{ callbackUrl: string, codeVerifier: string, state: string, liveExchange: boolean, label?: string|null, keepLegacy?: boolean }} options
+ * @param {{ readPaste?: () => Promise<{ type: 'url' | 'code', value: string }> }} [deps]
  */
-async function runManualPasteFlow(spec, {
+export async function runManualPasteFlow(spec, {
   callbackUrl,
   codeVerifier,
   state,
   liveExchange,
   label,
   keepLegacy,
-}) {
+}, deps = {}) {
+  const readPaste = deps.readPaste ?? readManualPasteInput;
+
   console.log('manual paste 모드입니다.');
   console.log('로그인 완료 후 callback URL 전체 또는 code를 붙여넣어 주세요.');
   console.log('');
 
-  const pasteResult = await readManualPasteInput();
+  const pasteResult = await readPaste();
   const extracted = extractAndValidateManualPaste(pasteResult, state);
 
   if (extracted.error || !extracted.code) {

--- a/packages/agent/src/cli/login-runner.js
+++ b/packages/agent/src/cli/login-runner.js
@@ -84,6 +84,19 @@ export async function runOAuthLoginFlow(spec, options) {
   console.log('브라우저에서 열 URL:');
   console.log(`  ${authorizationUrl}`);
   console.log('');
+
+  if (options.manual) {
+    await runManualPasteFlow(spec, {
+      callbackUrl,
+      codeVerifier,
+      state,
+      liveExchange: options.liveExchange ?? false,
+      label: options.label ?? null,
+      keepLegacy: options.keepLegacy ?? false,
+    });
+    return;
+  }
+
   console.log('로그인 완료 후 localhost callback 서버가 code/state 수신을 대기 중입니다...');
 
   try {
@@ -117,6 +130,60 @@ export async function runOAuthLoginFlow(spec, options) {
     console.log('');
     console.log(`콜백 수신 실패: ${err.message}`);
   }
+}
+
+/**
+ * `--manual` 흐름: 사용자가 브라우저에서 OAuth를 완료한 뒤 callback URL 또는
+ * authorization code를 stdin에 paste한다. localhost callback server를 띄우지
+ * 않으므로 SSH / 컨테이너 / 포트 충돌 환경에서 사용 가능.
+ *
+ * spec.supportsMockCallback이 false인 provider(e.g. Claude)는 --live-exchange
+ * 없이 호출되면 mock 저장 없이 안내 메시지로 종료.
+ */
+async function runManualPasteFlow(spec, {
+  callbackUrl,
+  codeVerifier,
+  state,
+  liveExchange,
+  label,
+  keepLegacy,
+}) {
+  console.log('manual paste 모드입니다.');
+  console.log('로그인 완료 후 callback URL 전체 또는 code를 붙여넣어 주세요.');
+  console.log('');
+
+  const pasteResult = await readManualPasteInput();
+  const extracted = extractAndValidateManualPaste(pasteResult, state);
+
+  if (extracted.error || !extracted.code) {
+    console.log('');
+    console.log(`입력 처리 실패: ${extracted.error ?? 'unknown-error'}`);
+    return;
+  }
+
+  console.log('');
+  console.log(`code 수신 완료: ${extracted.code}`);
+
+  if (liveExchange) {
+    await runLiveExchangeStep(spec, {
+      code: extracted.code,
+      callbackUrl,
+      codeVerifier,
+      state,
+      label,
+      keepLegacy,
+    });
+    return;
+  }
+
+  if (spec.supportsMockCallback && spec.saveMockAccount) {
+    await spec.saveMockAccount({ code: extracted.code });
+    return;
+  }
+
+  console.log('');
+  console.log('--live-exchange가 없으므로 token 교환을 생략합니다.');
+  console.log('실제 토큰 저장이 필요하면 --live-exchange 옵션을 추가해 재실행하세요.');
 }
 
 async function runLiveExchangeStep(spec, { code, callbackUrl, codeVerifier, state, label, keepLegacy }) {

--- a/packages/agent/test/cli/login-runner.test.js
+++ b/packages/agent/test/cli/login-runner.test.js
@@ -3,8 +3,41 @@ import assert from 'node:assert/strict';
 
 import {
   enrichIdentityFromProviderProfile,
+  extractAndValidateManualPaste,
   parseLoginOptions,
 } from '../../src/cli/login-runner.js';
+
+describe('extractAndValidateManualPaste', () => {
+  it('passes through code and fills expected state when raw code is pasted', () => {
+    const result = extractAndValidateManualPaste(
+      { type: 'code', value: 'code-123' },
+      'expected-state',
+    );
+    assert.equal(result.code, 'code-123');
+    assert.equal(result.state, 'expected-state');
+    assert.equal(result.error, null);
+  });
+
+  it('extracts code/state from callback URL and accepts matching state', () => {
+    const result = extractAndValidateManualPaste(
+      { type: 'url', value: 'http://localhost:1455/callback?code=abc&state=st1' },
+      'st1',
+    );
+    assert.equal(result.code, 'abc');
+    assert.equal(result.state, 'st1');
+    assert.equal(result.error, null);
+  });
+
+  it('returns state-mismatch when pasted URL state differs from expected', () => {
+    const result = extractAndValidateManualPaste(
+      { type: 'url', value: 'http://localhost:1455/callback?code=abc&state=other' },
+      'expected',
+    );
+    assert.equal(result.code, null);
+    assert.equal(result.state, 'other');
+    assert.equal(result.error, 'state-mismatch');
+  });
+});
 
 describe('enrichIdentityFromProviderProfile', () => {
   it('returns original identity for non-claude providers', async () => {

--- a/packages/agent/test/integration/auth-login-claude-manual.test.js
+++ b/packages/agent/test/integration/auth-login-claude-manual.test.js
@@ -75,6 +75,62 @@ describe('runManualPasteFlow (Claude-like, supportsMockCallback=false, no liveEx
     assert.equal(mockSaveCalls, 0, 'Claude는 supportsMockCallback=false라 mock 저장 0회여야 함');
   });
 
+  it('URL paste matching state + liveExchange=true → spec.exchangeCode가 정확한 인자로 호출됨', async () => {
+    // manual paste의 핵심 사용자 가치는 callback URL paste → runLiveExchangeStep
+    // → spec.exchangeCode 호출 → 토큰 저장 경로다. exchangeCode가 throw하면
+    // runLiveExchangeStep의 try/catch가 잡아 '토큰을 저장하지 않습니다'로 깔끔히
+    // 종료하므로, 본 테스트는 exchangeCode 호출 인자만 검증하면 manual branch가
+    // 핵심 경로로 연결됨을 보장 (저장까지 가는 것은 createAccount/auth-store
+    // 흐름이라 별도 테스트 영역).
+    const calls = [];
+    const spec = {
+      ...CLAUDE_LIKE_SPEC,
+      endpointDescription: 'endpoint: claude.ai/oauth/token',
+      exchangeCode: async (args) => {
+        calls.push(args);
+        throw new Error('test-stop-after-exchange');
+      },
+    };
+
+    const cap = captureConsoleLog();
+    try {
+      await runManualPasteFlow(
+        spec,
+        {
+          callbackUrl: 'http://127.0.0.1:1455/callback',
+          codeVerifier: 'verifier-xyz',
+          state: 'state-abc',
+          liveExchange: true,
+          label: null,
+          keepLegacy: false,
+        },
+        {
+          readPaste: async () => ({
+            type: 'url',
+            value: 'http://127.0.0.1:1455/callback?code=manual-code&state=state-abc',
+          }),
+        },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    assert.equal(calls.length, 1, 'exchangeCode가 정확히 1회 호출되어야 함');
+    assert.deepEqual(calls[0], {
+      code: 'manual-code',
+      callbackUrl: 'http://127.0.0.1:1455/callback',
+      codeVerifier: 'verifier-xyz',
+      state: 'state-abc',
+    });
+
+    const out = cap.lines.join('\n');
+    assert.match(out, /code 수신 완료: manual-code/);
+    assert.match(out, /--live-exchange 모드/);
+    // exchangeCode가 throw → runLiveExchangeStep catch → '토큰을 저장하지 않습니다'
+    assert.match(out, /live token exchange 실패: test-stop-after-exchange/);
+    assert.match(out, /토큰을 저장하지 않습니다\./);
+  });
+
   it('URL paste mismatching state → "state-mismatch" + saveMockAccount 호출 0회', async () => {
     let mockSaveCalls = 0;
     const spec = {

--- a/packages/agent/test/integration/auth-login-claude-manual.test.js
+++ b/packages/agent/test/integration/auth-login-claude-manual.test.js
@@ -1,0 +1,117 @@
+/**
+ * Claude `--manual` flow 회귀 가드 (integration 수준).
+ *
+ * runManualPasteFlow를 spec stub + readPaste DI로 호출해, Claude처럼
+ * supportsMockCallback=false인 provider가 manual paste 흐름에서 어떤 출력을
+ * 내는지 영구 보장한다. 이 가드가 있으면 누군가 다시 "아직 제공하지 않습니다"
+ * guard를 도입하거나 manual 분기를 빼면 즉시 회귀가 잡힌다.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runManualPasteFlow } from '../../src/cli/login-runner.js';
+
+function captureConsoleLog() {
+  const lines = [];
+  const orig = console.log;
+  console.log = (...args) => lines.push(args.map(String).join(' '));
+  return {
+    lines,
+    restore: () => {
+      console.log = orig;
+    },
+  };
+}
+
+const CLAUDE_LIKE_SPEC = {
+  id: 'claude',
+  displayName: 'Claude',
+  storeKey: 'claude',
+  accountKeyPrefix: 'anthropic-claude',
+  callbackPath: '/callback',
+  providerLabel: 'Claude',
+  supportsMockCallback: false,
+  // Claude 실 spec과 다르게 buildAuthorizationUrl / exchangeCode는 본 테스트에서
+  // 호출되지 않으므로 정의하지 않는다 (--live-exchange 없는 경로 + state-mismatch).
+};
+
+describe('runManualPasteFlow (Claude-like, supportsMockCallback=false, no liveExchange)', () => {
+  it('URL paste matching state → "token 교환을 생략" + saveMockAccount 호출 0회', async () => {
+    let mockSaveCalls = 0;
+    const spec = {
+      ...CLAUDE_LIKE_SPEC,
+      saveMockAccount: async () => {
+        mockSaveCalls += 1;
+      },
+    };
+
+    const cap = captureConsoleLog();
+    try {
+      await runManualPasteFlow(
+        spec,
+        {
+          callbackUrl: 'http://127.0.0.1:1455/callback',
+          codeVerifier: 'verifier-xyz',
+          state: 'state-abc',
+          liveExchange: false,
+          label: null,
+          keepLegacy: false,
+        },
+        {
+          readPaste: async () => ({
+            type: 'url',
+            value: 'http://127.0.0.1:1455/callback?code=test-code&state=state-abc',
+          }),
+        },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const out = cap.lines.join('\n');
+    assert.match(out, /manual paste 모드입니다\./);
+    assert.match(out, /code 수신 완료: test-code/);
+    assert.match(out, /--live-exchange가 없으므로 token 교환을 생략합니다/);
+    assert.equal(mockSaveCalls, 0, 'Claude는 supportsMockCallback=false라 mock 저장 0회여야 함');
+  });
+
+  it('URL paste mismatching state → "state-mismatch" + saveMockAccount 호출 0회', async () => {
+    let mockSaveCalls = 0;
+    const spec = {
+      ...CLAUDE_LIKE_SPEC,
+      saveMockAccount: async () => {
+        mockSaveCalls += 1;
+      },
+    };
+
+    const cap = captureConsoleLog();
+    try {
+      await runManualPasteFlow(
+        spec,
+        {
+          callbackUrl: 'http://127.0.0.1:1455/callback',
+          codeVerifier: 'verifier-xyz',
+          state: 'expected-state',
+          liveExchange: false,
+          label: null,
+          keepLegacy: false,
+        },
+        {
+          readPaste: async () => ({
+            type: 'url',
+            value: 'http://127.0.0.1:1455/callback?code=test-code&state=DIFFERENT-state',
+          }),
+        },
+      );
+    } finally {
+      cap.restore();
+    }
+
+    const out = cap.lines.join('\n');
+    assert.match(out, /manual paste 모드입니다\./);
+    assert.match(out, /입력 처리 실패: state-mismatch/);
+    // state-mismatch면 token 교환 안내까지 도달하지 않아야 함.
+    assert.equal(out.includes('token 교환을 생략'), false);
+    assert.equal(mockSaveCalls, 0);
+  });
+});

--- a/packages/provider-adapters/src/claude/claude-auth-constants.js
+++ b/packages/provider-adapters/src/claude/claude-auth-constants.js
@@ -10,18 +10,20 @@
 
 export const CLAUDE_AUTH = {
   /**
-   * OAuth authorization endpoint — Claude.ai login flow (observed).
+   * OAuth authorization endpoint — Claude.ai login flow (observed, pi-ai aligned).
    *
-   * Claude Code 바이너리에는 두 종류의 authorize URL이 있다:
+   * Claude Code 바이너리에는 두 종류의 authorize URL이 관찰된다:
    *   - CONSOLE_AUTHORIZE_URL = https://platform.claude.com/oauth/authorize
    *     → API key 발급용 (org:create_api_key 동의 화면)
-   *   - CLAUDE_AI_AUTHORIZE_URL = https://claude.com/cai/oauth/authorize
+   *   - CLAUDE_AI_AUTHORIZE_URL = https://claude.ai/oauth/authorize
    *     → claude.ai 사용자 OAuth (~/.claude/.credentials.json에 들어가는 토큰 발급)
    *
    * usage endpoint (api.anthropic.com/api/oauth/usage)는 후자의 토큰을 받으므로
-   * 우리는 claude.ai 경로를 사용한다.
+   * 우리는 claude.ai 경로를 사용한다. pi-ai (`@mariozechner/pi-ai`)도 동일 경로를
+   * 쓰고 있고, 이전의 `claude.com/cai/oauth/authorize`와 invalid_grant 회귀(이슈 #83)
+   * 의심 변수를 줄이기 위해 baseline을 일치시킨다.
    */
-  authorizationEndpoint: 'https://claude.com/cai/oauth/authorize',
+  authorizationEndpoint: 'https://claude.ai/oauth/authorize',
 
   /** OAuth token endpoint — observed, used for both code exchange and refresh */
   tokenEndpoint: 'https://platform.claude.com/v1/oauth/token',

--- a/packages/provider-adapters/src/claude/claude-auth-constants.js
+++ b/packages/provider-adapters/src/claude/claude-auth-constants.js
@@ -51,8 +51,20 @@ export const CLAUDE_AUTH = {
    */
   observedClientId: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
 
-  /** Default scopes (관찰 대상 — 이후 authorize flow 구현 시 실측으로 보정) */
-  defaultScopes: ['org:create_api_key', 'user:profile', 'user:inference'],
+  /**
+   * Default scopes — pi-ai (`@mariozechner/pi-ai`)가 요청하는 6-scope baseline.
+   * `user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload` 3개가
+   * 추가되면서 pi-ai와 일치. 이슈 #83의 invalid_grant 회귀 의심 변수 중 scope
+   * 차이가 후보였고, baseline 정렬로 그 변수를 제거한다.
+   */
+  defaultScopes: [
+    'org:create_api_key',
+    'user:profile',
+    'user:inference',
+    'user:sessions:claude_code',
+    'user:mcp_servers',
+    'user:file_upload',
+  ],
 
   /** Response type for authorization code flow */
   responseType: 'code',

--- a/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
+++ b/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
@@ -21,6 +21,13 @@ describe('buildClaudeAuthorizationUrl', () => {
     assert.equal(`${url.origin}${url.pathname}`, CLAUDE_AUTH.authorizationEndpoint);
   });
 
+  it('matches the current pi-ai Anthropic authorize endpoint baseline', () => {
+    // pi-ai (@mariozechner/pi-ai)와 일치해야 invalid_grant 회귀(이슈 #83)
+    // 의심 변수가 줄어든다. 새 외부 baseline으로 회귀하면 본 테스트가 실패해
+    // 명시적 의사결정을 강제한다.
+    assert.equal(CLAUDE_AUTH.authorizationEndpoint, 'https://claude.ai/oauth/authorize');
+  });
+
   it('sets required OAuth query parameters', () => {
     const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
     assert.equal(url.searchParams.get('response_type'), 'code');

--- a/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
+++ b/packages/provider-adapters/test/claude/build-claude-authorization-url.test.js
@@ -28,6 +28,21 @@ describe('buildClaudeAuthorizationUrl', () => {
     assert.equal(CLAUDE_AUTH.authorizationEndpoint, 'https://claude.ai/oauth/authorize');
   });
 
+  it('matches the current pi-ai Anthropic scope baseline (6 scopes)', () => {
+    // pi-ai와 동일한 6개 scope. user:sessions:claude_code / user:mcp_servers /
+    // user:file_upload가 빠지면 invalid_grant 또는 권한 부족 응답이 관찰됐었다
+    // (이슈 #83). 누군가 다시 3-scope 기준으로 회귀시키면 본 테스트가 명시적
+    // 의사결정을 강제한다.
+    assert.deepEqual(CLAUDE_AUTH.defaultScopes, [
+      'org:create_api_key',
+      'user:profile',
+      'user:inference',
+      'user:sessions:claude_code',
+      'user:mcp_servers',
+      'user:file_upload',
+    ]);
+  });
+
   it('sets required OAuth query parameters', () => {
     const url = new URL(buildClaudeAuthorizationUrl(baseParams()));
     assert.equal(url.searchParams.get('response_type'), 'code');


### PR DESCRIPTION
## 요약

Claude OAuth \`--manual\`이 dev에서 \"아직 제공하지 않습니다\"로 막혀있던 문제를 해결하고, authorize endpoint + scope을 pi-ai (\`@mariozechner/pi-ai\`) baseline으로 정렬. \`fix/claude-oauth-piai-parity\` 브랜치(54 commit 뒤처짐, 미머지)는 머지하지 않고 dev 위에 새로 작성하는 방식으로 회귀를 회피.

closes #86, refs #83

## 변경 내용 (6개 commit)

### pi-ai parity 보정 (commits 1-2)

1. \`fix(claude): authorize endpoint를 pi-ai baseline(claude.ai)로 정렬\`
   - \`CLAUDE_AUTH.authorizationEndpoint\`: \`https://claude.com/cai/oauth/authorize\` → \`https://claude.ai/oauth/authorize\`
   - 회귀 가드 1 case 추가
2. \`fix(claude): defaultScopes를 pi-ai 6-scope baseline으로 확장\`
   - \`user:sessions:claude_code\`, \`user:mcp_servers\`, \`user:file_upload\` 3개 scope 추가 (총 6)
   - 회귀 가드 1 case 추가

### manual paste flow (commits 3-5)

3. \`feat(claude): manual paste 추출 + state 검증 순수 함수 추가\`
   - \`extractAndValidateManualPaste(pasteResult, expectedState)\` export. raw code paste 관용 + URL paste state 검증
   - 단위 테스트 3 case
4. \`feat(claude): runOAuthLoginFlow에 --manual 분기 + runManualPasteFlow private\`
   - \`authorizationUrl\` 출력 직후, callback server 시작 전에 manual 분기 삽입
   - \`runManualPasteFlow(spec, options, deps)\` helper. \`liveExchange\` / \`supportsMockCallback\` 분기 포함
5. \`feat(claude): --manual guard 제거 + 공통 manual flow로 라우팅\`
   - \`auth-login-command.js::runClaudeLogin\`의 5줄 guard 블록 제거 — Claude도 공통 흐름 사용

### 회귀 가드 (commit 6)

6. \`test(claude): --manual flow 회귀 가드 (integration 수준)\`
   - \`auth-login-claude-manual.test.js\` 신설 — runManualPasteFlow를 \`readPaste\` DI로 호출, URL match / state-mismatch 두 case 검증
   - runManualPasteFlow를 export로 변경 + \`deps.readPaste\` DI 추가 (테스트 전용)

## 변경 이유

- 사용자 경험: \`token-weather auth login claude --manual\`이 미구현 메시지로 끝나 SSH/컨테이너/포트 충돌 환경에서 Claude OAuth 진입 경로가 끊겨 있었음. PR #85 onboarding 리뷰의 핵심 지적도 이것.
- 회귀 의심 변수 정리: 이슈 #83 (itteam invalid_grant)에서 endpoint/scope 차이가 후보로 관찰됨. pi-ai baseline 정렬로 그 변수를 명시적으로 제거.
- 브랜치 stranded 자산 활용: \`fix/claude-oauth-piai-parity\`의 d0f28bb / da2c321 의도를 그대로 재현하되, dev 머지 시 발생하는 8개+ 파일 충돌을 회피.

## 영향 범위

- [x] \`packages/agent/src/cli/login-runner.js\` (extractAndValidateManualPaste export, runManualPasteFlow export+DI, runOAuthLoginFlow manual 분기, manual-paste 헬퍼 import)
- [x] \`packages/agent/src/cli/auth-login-command.js\` (Claude guard 제거)
- [x] \`packages/provider-adapters/src/claude/claude-auth-constants.js\` (endpoint + scope)
- [x] \`packages/agent/test/cli/login-runner.test.js\` (3 case)
- [x] \`packages/agent/test/integration/auth-login-claude-manual.test.js\` (신규, 2 case)
- [x] \`packages/provider-adapters/test/claude/build-claude-authorization-url.test.js\` (2 case)
- [ ] schemas / repo / docs

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — \`npm test\` **667/667 통과** (660 + 신규 7).
- [x] 필요한 문서 업데이트 반영 — 본 PR은 코드 변경 중심. README/demo align은 후속(PR #85에 small follow-up).
- [x] schema / provider / CLI 영향 범위를 직접 점검:
  - CLI smoke: \`HOME=mktemp NO_COLOR=1 echo 'fake-demo-code' | token-weather auth login claude --manual\` →
    URL 출력 (claude.ai endpoint + 6 scopes 인코딩 확인) → 'manual paste 모드' → 'code 수신 완료: fake-demo-code' → '--live-exchange가 없으므로 token 교환을 생략' 시퀀스 정상.
  - \`grep 'claude manual paste 경로는 아직' packages/\` 결과 0건 (guard 완전 제거 확인).
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음 — 본 PR엔 토큰 데이터 없음.

## 리뷰 포인트

- **endpoint 변경(\`claude.ai/oauth/authorize\`)**: pi-ai와 일치. dev의 \`claude.com/cai/...\`와 호스트가 다름. 이 변경이 외부 사용자(Claude Code 바이너리 사용자 등)와 어긋날 가능성 검토 — pi-ai와 일치하므로 표준 baseline으로 판단.
- **새 3개 scope (\`user:sessions:claude_code\`, \`user:mcp_servers\`, \`user:file_upload\`)**: token endpoint 응답에 포함되지만, \`extractAccountIdentity\` / \`claude-refresh-store.js\`는 scope 파싱에 의존하지 않으므로 영향 없을 것. itteam 회귀(#83) 해결 여부는 별도 이슈에서 추적.
- **commits 1-5 단계별 npm test 통과** — 매 commit 이후 회귀 0. 사용자 노출 변경은 commit 5에서만 발생.
- **runManualPasteFlow의 readPaste DI**: 테스트 전용 옵션. 프로덕션 호출자는 deps 미전달, 기본 \`readManualPasteInput\` 사용. 테스트 커버리지를 위한 최소 변경.
- **manual 분기 위치 (server 시작 전)**: 사용자가 콘솔 URL 보고 다른 창에서 로그인 후 callback URL paste — 자연스러운 흐름. localhost callback server는 띄우지 않아 자원 낭비 없음.
- **state-mismatch on raw-code paste**: raw code 입력 시 state 검증 skip (의도된 관용 — callback URL이 너무 긴 환경 호환성). 보안상 우려는 없음 (PKCE code_verifier가 여전히 매치되어야 token 교환 성공).

## 참고 사항

- 후속:
  - PR #85 (README onboarding) base를 dev로 변경 후, README first-run + demo-script.sh를 본 PR의 \`--manual\` 흐름과 align하는 small follow-up commit 2개 추가.
  - 이슈 #83 (itteam invalid_grant): scope 변경이 회귀를 실제로 해결했는지 별도 이슈에서 검증.
  - \`fix/claude-oauth-piai-parity::69bad03\` (refresh 진단 강화): 본 PR 범위 밖, 별도 이슈 등록 필요.
- \`fix/claude-oauth-piai-parity\` 브랜치 자체는 본 PR 머지 후 안전하게 폐기 가능 (의미 있는 변경 모두 새로 적용됨).

> PR 제목은 \`[feat]\`, \`[fix]\`, \`[docs]\`처럼 타입은 영어로 유지하고, 뒤의 설명은 한글로 작성하는 것을 기본 규칙으로 합니다.