### PR TITLE
[feat] TypeScript 타입 정의(.d.ts) 동봉

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,6 @@ jobs:
 
       - run: npm install --no-package-lock
 
+      - run: npm run build:types
+
       - run: npm test

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -8,6 +8,7 @@
 - `docs/auth-architecture.md` — 인증 상세 설계
 - `docs/auth-cli.md` — auth CLI 명령 / 정책
 - `docs/provider-notes.md` — provider별 observed 값과 endpoint
+- `docs/typescript-consumers.md` — `.d.ts` 동봉 정책 + JSDoc 보강 시 따를 규약
 
 ---
 

--- a/docs/typescript-consumers.md
+++ b/docs/typescript-consumers.md
@@ -13,7 +13,7 @@ npm install @token-weather/schemas @token-weather/provider-adapters
 ```ts
 import { getStatusSnapshot } from '@token-weather/cli';
 import { validateUsageSnapshot, SCHEMA_VERSION } from '@token-weather/schemas';
-import { fetchClaudeUsage } from '@token-weather/provider-adapters/src/claude/fetch-claude-usage.js';
+import { fetchClaudeUsage } from '@token-weather/provider-adapters';
 
 const snapshot = await getStatusSnapshot({ providerFilter: 'claude' });
 //    ^? StatusSnapshot — schemaVersion / configPath / providers / claude? / ...
@@ -21,6 +21,8 @@ const snapshot = await getStatusSnapshot({ providerFilter: 'claude' });
 const result = validateUsageSnapshot(payload);
 //    ^? { valid: boolean; errors: string[] }
 ```
+
+> **Import 경로 규약**: 본 PR이 보장하는 타입 계약은 **각 패키지의 root entry**(`package.json::types`가 가리키는 `./dist/types/index.d.ts`) 기준입니다. 위 예시는 모두 `@token-weather/{cli,schemas,provider-adapters}` root에서 import. **subpath import**(`@token-weather/provider-adapters/src/claude/fetch-claude-usage.js` 같은 형태)는 동작은 하지만 본 PR의 타입 계약에 포함되지 않으며, 향후 `exports`/`typesVersions` 도입 시 별도 설계가 필요합니다. 안정적인 사용은 root import를 우선하세요.
 
 ## 타입 동봉 정책
 
@@ -106,5 +108,6 @@ code .
 ## 한계
 
 - 본 d.ts emission은 **JSDoc 커버리지에 의존**합니다. 미보강 export는 정확한 타입을 받지 못합니다 (any로 노출).
+- **타입 계약 범위는 package root entry만**: `package.json::types`가 가리키는 `./dist/types/index.d.ts`만 stable. subpath import (`@token-weather/.../src/...`)는 동작하지만 본 PR scope 외이고, 후속에서 `exports` 필드와 `typesVersions`로 공식 지원 여부 결정 (현재 main 사용 중이라 도입은 별도 PR로).
 - TypeScript 자체 컨버전은 본 정책 범위가 아닙니다.
 - 자동 sanity check (CI에 외부 TS project 컴파일 step) 도입은 후속 이슈에서 검토 (T2 #75 install smoke와 함께 묶일 수 있음).

--- a/docs/typescript-consumers.md
+++ b/docs/typescript-consumers.md
@@ -1,0 +1,110 @@
+# TypeScript 사용자용 가이드
+
+Token Weather 패키지는 JS+JSDoc 소스로 작성되었지만, publish 시 `tsc --emitDeclarationOnly`로 생성한 `.d.ts`가 함께 동봉됩니다. TypeScript 프로젝트에서 그대로 import하면 자동완성·타입 추론이 동작합니다.
+
+## 사용
+
+```bash
+npm install @token-weather/cli
+# 또는 (라이브러리만 사용 시)
+npm install @token-weather/schemas @token-weather/provider-adapters
+```
+
+```ts
+import { getStatusSnapshot } from '@token-weather/cli';
+import { validateUsageSnapshot, SCHEMA_VERSION } from '@token-weather/schemas';
+import { fetchClaudeUsage } from '@token-weather/provider-adapters/src/claude/fetch-claude-usage.js';
+
+const snapshot = await getStatusSnapshot({ providerFilter: 'claude' });
+//    ^? StatusSnapshot — schemaVersion / configPath / providers / claude? / ...
+
+const result = validateUsageSnapshot(payload);
+//    ^? { valid: boolean; errors: string[] }
+```
+
+## 타입 동봉 정책
+
+- 빌드 단계는 `tsc --emitDeclarationOnly --allowJs --declaration` 한 단계.
+- 각 패키지의 `dist/types/index.d.ts`가 `package.json::types`로 노출됨.
+- `npm publish` 시 `files` 화이트리스트에 `dist/types`가 포함되어 tarball에 자동 포함.
+- 소스는 그대로 JS+JSDoc — TypeScript 컨버전 없음.
+
+## 현재 d.ts 품질
+
+핵심 export 5개는 본 PR(#73)에서 JSDoc을 보강해 정확한 타입으로 추론됩니다:
+
+- `getStatusSnapshot` — `Promise<StatusSnapshot>`
+- `runCli` — `(argv: string[]) => Promise<void>`
+- `formatStatusJson` — snapshot/meta param이 inline shape로 명시
+- `fetchClaudeUsage` — `Promise<{ source, authType, confidence, usageWindows, ... }>`
+- `exchangeClaudeAuthorizationCode` — `Promise<{ accessToken, refreshToken, idToken, ... }>`
+
+그 외 export(예: `auth/`, `codex-provider`, 일부 helper)는 JSDoc이 부분적이라 `any` 또는 의미 없는 `Promise<object>`로 추론될 수 있습니다. 후속 chore PR에서 점진적으로 개선 예정.
+
+새 토큰성 필드를 provider adapter / auth schema에 추가하는 PR은 동시에 JSDoc도 보강해 d.ts 품질이 떨어지지 않도록 합니다 (`docs/codebase-guide.md` 참고).
+
+## Manual sanity check 절차 (메인테이너)
+
+publish 직전 외부 TypeScript 프로젝트에서 import / 추론이 동작하는지 수동 검증:
+
+```bash
+# 1. tarball 생성
+npm pack --workspace=@token-weather/cli
+npm pack --workspace=@token-weather/provider-adapters
+npm pack --workspace=@token-weather/schemas
+# → token-weather-{cli,provider-adapters,schemas}-0.1.0.tgz 생성됨
+
+# 2. 임시 디렉토리에 minimal TS project
+TMP=$(mktemp -d -t tw-ts-sanity-XXXXXX)
+cd "$TMP"
+npm init -y
+npm install typescript --save-dev
+npm install /path/to/token-weather-cli-0.1.0.tgz \
+            /path/to/token-weather-provider-adapters-0.1.0.tgz \
+            /path/to/token-weather-schemas-0.1.0.tgz
+
+# 3. tsconfig.json + index.ts
+cat > tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}
+EOF
+
+cat > index.ts <<'EOF'
+import { getStatusSnapshot } from '@token-weather/cli';
+import { validateUsageSnapshot, SCHEMA_VERSION } from '@token-weather/schemas';
+
+async function main() {
+  const snapshot = await getStatusSnapshot();
+  console.log(snapshot.schemaVersion);
+  const result = validateUsageSnapshot({});
+  if (!result.valid) console.error(result.errors);
+}
+
+void main();
+EOF
+
+# 4. 검증: 타입 에러 0건이어야 함
+npx tsc --noEmit
+
+# 5. (선택) IDE에서 import 자동완성 확인
+code .
+```
+
+타입 추론이 정상 동작하면:
+- `snapshot.schemaVersion`이 `string`으로 자동완성에 노출
+- `result.valid`가 `boolean`, `result.errors`가 `string[]`
+- 미보강 export는 `any`로 표시되지만 컴파일 에러는 없음
+
+## 한계
+
+- 본 d.ts emission은 **JSDoc 커버리지에 의존**합니다. 미보강 export는 정확한 타입을 받지 못합니다 (any로 노출).
+- TypeScript 자체 컨버전은 본 정책 범위가 아닙니다.
+- 자동 sanity check (CI에 외부 TS project 컴파일 step) 도입은 후속 이슈에서 검토 (T2 #75 install smoke와 함께 묶일 수 있음).

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "cli:status": "node ./packages/agent/bin/token-weather.js status",
     "cli:usage": "node ./packages/agent/bin/token-weather.js usage",
     "cli:doctor": "node ./packages/agent/bin/token-weather.js doctor",
-    "cli:config:init": "node ./packages/agent/bin/token-weather.js config init"
+    "cli:config:init": "node ./packages/agent/bin/token-weather.js config init",
+    "build:types": "npm -w @token-weather/schemas run build:types && npm -w @token-weather/provider-adapters run build:types && npm -w @token-weather/cli run build:types"
   },
   "devDependencies": {
     "typescript": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "cli:usage": "node ./packages/agent/bin/token-weather.js usage",
     "cli:doctor": "node ./packages/agent/bin/token-weather.js doctor",
     "cli:config:init": "node ./packages/agent/bin/token-weather.js config init"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "dev": "node ./bin/token-weather.js status",
     "status": "node ./bin/token-weather.js status",
-    "doctor": "node ./bin/token-weather.js doctor"
+    "doctor": "node ./bin/token-weather.js doctor",
+    "build:types": "tsc -p ./tsconfig.json"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,9 +8,11 @@
     "token-weather": "./bin/token-weather.js"
   },
   "main": "./src/index.js",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "bin",
-    "src"
+    "src",
+    "dist/types"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/agent/src/cli/run-cli.js
+++ b/packages/agent/src/cli/run-cli.js
@@ -6,6 +6,12 @@ import { runAuthListCommand, formatAuthListHelp } from './auth-list-command.js';
 import { runAuthLogoutCommand, formatAuthLogoutHelp } from './auth-logout-command.js';
 import { runAuthImportCommand, formatAuthImportHelp } from './auth-import-command.js';
 
+/**
+ * CLI 진입점. `bin/token-weather.js`가 process.argv.slice(2)를 그대로 전달.
+ *
+ * @param {string[]} argv - CLI 인자 배열 (`['status', '--json']` 등).
+ * @returns {Promise<void>} 모든 서브커맨드는 stdout/stderr로 출력하고 void 반환.
+ */
 export async function runCli(argv) {
   const [command = 'status', ...rest] = argv;
 

--- a/packages/agent/src/cli/status-json.js
+++ b/packages/agent/src/cli/status-json.js
@@ -112,9 +112,16 @@ export function redactSensitive(value) {
  * provider id는 `--provider <id>`가 받는 registry id(`codex`/`claude`)와 동일.
  * 출력 line 끝에 newline은 붙이지 않는다 (호출자가 결정).
  *
- * @param {object} snapshot - getStatusSnapshot 결과
- * @param {{ command?: string, generatedAt?: string|Date }} [meta]
- * @returns {string}
+ * @param {{
+ *   schemaVersion?: string,
+ *   configPath?: string,
+ *   accountFilter?: string|null,
+ *   providerFilter?: string|null,
+ *   codex?: object,
+ *   claude?: object
+ * }} snapshot - `getStatusSnapshot` 결과 (`StatusSnapshot` typedef과 동일 shape).
+ * @param {{ command?: 'status'|'usage', generatedAt?: string|Date }} [meta]
+ * @returns {string} single-line JSON.
  */
 export function formatStatusJson(snapshot, meta = {}) {
   const command = meta.command ?? 'status';

--- a/packages/agent/src/services/status-service.js
+++ b/packages/agent/src/services/status-service.js
@@ -19,11 +19,24 @@ export {
 } from './claude-provider.js';
 
 /**
+ * @typedef {object} StatusSnapshot
+ * @property {string} schemaVersion - `@token-weather/schemas`의 SCHEMA_VERSION 통과값.
+ * @property {string} configPath - resolved config 파일 경로.
+ * @property {object} providers - config.providers (provider별 enabled flag).
+ * @property {object} sync - config.sync.
+ * @property {string|null} accountFilter - `--account <id>` 입력 (case-insensitive 매칭은 별도).
+ * @property {string|null} providerFilter - `--provider <id>` 입력 (lowercase 정규화된 값).
+ * @property {object} [codex] - Codex provider snapshot (providerFilter가 codex만 지정 시 codex만 존재).
+ * @property {object} [claude] - Claude provider snapshot (동일 규칙).
+ */
+
+/**
  * Build the top-level status snapshot by loading config and calling every
  * registered provider. New providers go through provider-registry.js, not here.
  *
  * @param {{ accountFilter?: string, providerFilter?: string }} [options]
  *   `providerFilter`가 지정되면 해당 provider 한 곳의 snapshot만 포함된다.
+ * @returns {Promise<StatusSnapshot>}
  */
 export async function getStatusSnapshot(options = {}) {
   const configPath = resolveAgentConfigPath();

--- a/packages/agent/test/integration/repo-policy-types.test.js
+++ b/packages/agent/test/integration/repo-policy-types.test.js
@@ -1,0 +1,111 @@
+/**
+ * Repo-level TypeScript types 정책 회귀 가드.
+ *
+ * .d.ts 동봉 정책(#73)의 핵심 메타데이터(tsconfig / scripts.build:types /
+ * package.json types 필드 / files dist/types / typescript devDep)이 우발적으로
+ * 깨지는 회귀를 막는 파일시스템 단위 검증.
+ *
+ * `repo-policy-publish.test.js`(publish 메타), `repo-policy-license.test.js`,
+ * `repo-policy-readme.test.js`와 도메인이 달라 별도 파일로 분리.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function readPackageJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8'));
+}
+
+function repoFileExists(relPath) {
+  return fs.existsSync(path.join(REPO_ROOT, relPath));
+}
+
+const ROOT = readPackageJson('package.json');
+const AGENT = readPackageJson('packages/agent/package.json');
+const ADAPTERS = readPackageJson('packages/provider-adapters/package.json');
+const SCHEMAS = readPackageJson('packages/schemas/package.json');
+
+const PUBLISHABLE = [
+  ['agent', AGENT, 'packages/agent'],
+  ['provider-adapters', ADAPTERS, 'packages/provider-adapters'],
+  ['schemas', SCHEMAS, 'packages/schemas'],
+];
+
+describe('repo-policy/types — typescript devDep + base tsconfig (PR #73)', () => {
+  it('루트 package.json에 typescript devDep 선언', () => {
+    assert.ok(ROOT.devDependencies, 'devDependencies 누락');
+    assert.equal(typeof ROOT.devDependencies.typescript, 'string');
+  });
+
+  it('루트 scripts.build:types 가 존재한다', () => {
+    assert.ok(ROOT.scripts);
+    assert.equal(typeof ROOT.scripts['build:types'], 'string');
+    // 의존 순서가 명시적으로 들어있는지 (schemas → adapters → cli)
+    assert.match(
+      ROOT.scripts['build:types'],
+      /schemas.*provider-adapters.*cli/s,
+      '루트 build:types는 schemas → provider-adapters → cli 순차여야 함',
+    );
+  });
+
+  it('tsconfig.base.json 이 존재하며 emitDeclarationOnly + declaration 활성화', () => {
+    assert.equal(repoFileExists('tsconfig.base.json'), true);
+    const base = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, 'tsconfig.base.json'), 'utf8'),
+    );
+    assert.equal(base.compilerOptions?.declaration, true);
+    assert.equal(base.compilerOptions?.emitDeclarationOnly, true);
+    assert.equal(base.compilerOptions?.allowJs, true);
+  });
+});
+
+describe('repo-policy/types — 패키지별 tsconfig + types 필드 (PR #73)', () => {
+  for (const [label, pkg, dir] of PUBLISHABLE) {
+    it(`${label} 의 tsconfig.json 이 존재한다`, () => {
+      assert.equal(repoFileExists(`${dir}/tsconfig.json`), true);
+    });
+
+    it(`${label} 의 tsconfig 가 base를 extends 한다`, () => {
+      const cfg = JSON.parse(
+        fs.readFileSync(path.join(REPO_ROOT, `${dir}/tsconfig.json`), 'utf8'),
+      );
+      assert.match(cfg.extends ?? '', /tsconfig\.base\.json$/);
+    });
+
+    it(`${label} package.json 에 types: "./dist/types/index.d.ts"`, () => {
+      assert.equal(pkg.types, './dist/types/index.d.ts');
+    });
+
+    it(`${label} files 배열에 "dist/types" 포함`, () => {
+      assert.ok(pkg.files);
+      assert.ok(
+        pkg.files.includes('dist/types'),
+        `${label} files: ${JSON.stringify(pkg.files)} (dist/types 누락)`,
+      );
+    });
+
+    it(`${label} scripts.build:types 존재`, () => {
+      assert.ok(pkg.scripts);
+      assert.equal(typeof pkg.scripts['build:types'], 'string');
+    });
+  }
+});
+
+// CI 전용: build:types 산출물(.d.ts) 실제 존재 검증.
+// local에서 build:types를 안 돌리고 npm test만 실행하면 dist/types가 없을 수
+// 있어 false positive를 만든다. CI에서는 'npm run build:types' 다음에
+// 'npm test'가 실행되므로 산출물이 항상 존재.
+const CI_ONLY = process.env.CI === 'true';
+
+describe('repo-policy/types — build 산출물 (CI gate)', { skip: !CI_ONLY }, () => {
+  for (const [label, _pkg, dir] of PUBLISHABLE) {
+    it(`${label} 의 dist/types/index.d.ts 가 build:types 후 존재`, () => {
+      assert.equal(repoFileExists(`${dir}/dist/types/index.d.ts`), true);
+    });
+  }
+});

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/types"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["test/**", "**/*.test.js", "dist/**", "node_modules"]
+}

--- a/packages/provider-adapters/package.json
+++ b/packages/provider-adapters/package.json
@@ -30,5 +30,8 @@
   ],
   "dependencies": {
     "@token-weather/schemas": "^0.1.0"
+  },
+  "scripts": {
+    "build:types": "tsc -p ./tsconfig.json"
   }
 }

--- a/packages/provider-adapters/package.json
+++ b/packages/provider-adapters/package.json
@@ -5,8 +5,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./dist/types/index.d.ts",
   "files": [
-    "src"
+    "src",
+    "dist/types"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
+++ b/packages/provider-adapters/src/claude/exchange-claude-authorization-code.js
@@ -27,6 +27,15 @@ const CLIENT_ID_NOTE =
  *   tokenEndpoint?: string,
  *   fetchImpl?: typeof fetch,
  * }} params
+ * @returns {Promise<{
+ *   accessToken: string,
+ *   refreshToken: string|null,
+ *   idToken: string|null,
+ *   expiresIn: number|null,
+ *   tokenType: string|null,
+ *   scope: string|null
+ * }>} 정규화된 token 응답 shape (`shared/oauth-token-endpoint.js::postToTokenEndpoint`가 제공).
+ *   `allowLiveExchange: false`(기본값) 시 `liveExchangeDisabledError` throw.
  */
 export async function exchangeClaudeAuthorizationCode({
   code,

--- a/packages/provider-adapters/src/claude/fetch-claude-usage.js
+++ b/packages/provider-adapters/src/claude/fetch-claude-usage.js
@@ -24,6 +24,17 @@ const PROVIDER_ID = 'anthropic-claude';
  *
  * @param {{ id: string, accessToken: string, accountId?: string|null, email?: string|null }} profile
  * @param {{ fetchImpl?: typeof fetch, capturedAt?: Date, timeoutMs?: number }} [options]
+ * @returns {Promise<{
+ *   source: string,
+ *   authType: string,
+ *   confidence: 'high'|'medium'|'low',
+ *   capturedAt: string,
+ *   provider: { id: string, displayName: string },
+ *   account: object,
+ *   status: { ok: boolean, httpStatus: number|null, bucket: string, message?: string|null },
+ *   usageWindows: Array<{ kind: string, usedPercent: number|null, resetAt: string|null }>,
+ *   raw?: object
+ * }>} 정규화된 usage snapshot. 실패 시 `status.ok: false` + `usageWindows: []`.
  */
 export async function fetchClaudeUsage(profile, options = {}) {
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/packages/provider-adapters/tsconfig.json
+++ b/packages/provider-adapters/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/types"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["test/**", "**/*.test.js", "dist/**", "node_modules"]
+}

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -29,5 +29,8 @@
     "ai",
     "usage",
     "schema"
-  ]
+  ],
+  "scripts": {
+    "build:types": "tsc -p ./tsconfig.json"
+  }
 }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -5,11 +5,13 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "src",
     "usage-event.schema.json",
     "usage-snapshot.schema.json",
-    "examples"
+    "examples",
+    "dist/types"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/types"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["test/**", "**/*.test.js", "dist/**", "node_modules"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## 요약

3개 publishable 패키지(`@token-weather/cli`, `@token-weather/provider-adapters`, `@token-weather/schemas`)에 `.d.ts` 동봉. 소스는 JS+JSDoc 그대로 유지하면서 `tsc --emitDeclarationOnly --allowJs` 한 단계만 거쳐 d.ts emit. TS 사용자가 import 시 자동완성/타입 추론 동작.

closes #73

## 변경 내용 (8 commits)

### 인프라 (commits 1-2)
1. `chore(deps): add typescript devDep at workspace root` — root `package.json`에 `typescript ^5.6.0` (5.9.3 install). hoist로 모든 패키지에서 `tsc` 사용.
2. `chore(types): add tsconfig.base.json + 3 package tsconfigs` — base는 compilerOptions만 (`module: NodeNext`, `allowJs`, `declaration`, `emitDeclarationOnly`). 각 패키지 tsconfig에 rootDir/outDir/include/exclude override.

### JSDoc 보강 (commit 3)
3. `chore(jsdoc): 5개 핵심 export return shape JSDoc 보강` — publish 차단 우선순위 5개:
   - `getStatusSnapshot` — `@typedef StatusSnapshot` + `@returns Promise<StatusSnapshot>`
   - `runCli` — `@param {string[]} argv` + `@returns {Promise<void>}`
   - `formatStatusJson` — snapshot inline shape
   - `fetchClaudeUsage` — `@returns` normalized usage shape
   - `exchangeClaudeAuthorizationCode` — `@returns` token 응답 shape

### 빌드 + 메타 (commits 4-5)
4. `chore(types): add build:types scripts (root + 3 packages)` — 루트는 schemas → adapters → cli 명시 순차 호출.
5. `chore(types): add types field + dist/types to files in 3 packages` — 3개 모두 `types: "./dist/types/index.d.ts"` + `files`에 `dist/types`.

### 검증 (commits 6-7)
6. `test(repo-policy): TypeScript types 정책 회귀 가드 추가` — `repo-policy-types.test.js` 신설 (검증 18 case). CI gate 분리 (`process.env.CI === 'true'`)로 dist/types 산출물 존재 검증.
7. `ci: run build:types before npm test` — `.github/workflows/ci.yml`에 step 1줄.

### 문서 (commit 8)
8. `docs: TypeScript consumer guide + sanity check 절차` — `docs/typescript-consumers.md` 신설 (외부 TS 프로젝트 import 예시 + manual sanity check 6 step + 한계). codebase-guide 관련 문서 목록에 링크.

## 변경 이유

- TS 사용자가 본 패키지를 import하면 `any`로 보이는 상태였음. JSDoc은 풍부하나 d.ts 부재로 IDE/`tsc --noEmit` 검사 무력화.
- T1 시리즈(#73 → #74 → #53)의 첫 단계. 본 PR이 머지되면 #74에서 d.ts breaking change 분류 기준을 바로 활용 가능.
- 무빌드 정책 유지 — TS 컨버전 없이 emit 한 단계만.

## 영향 범위

- [x] `packages/agent`, `packages/provider-adapters`, `packages/schemas` (publish 대상)
- [x] `repo` (root `package.json`, `tsconfig.base.json`, CI workflow, .gitignore에 dist 이미 포함)
- [x] `docs` (typescript-consumers.md 신설, codebase-guide 한 줄)
- [ ] `schemas` JSON 파일 변경 없음

## 테스트 / 확인

- [x] `npm test` **713/713 통과** (PR #87 후 695 + 신규 18 가드).
- [x] `npm run build:types` 실행:
  - `packages/schemas/dist/types/{index,validate}.d.ts` 정상 생성
  - `packages/provider-adapters/dist/types/index.d.ts` + 하위 디렉토리 d.ts
  - `packages/agent/dist/types/index.d.ts` + 하위 디렉토리 d.ts
- [x] `npm pack --dry-run --workspace=@token-weather/schemas` 출력에 `dist/types/index.d.ts` (113B) + `dist/types/validate.d.ts` (836B) 포함 확인.
- [x] 5개 보강 export에서 `tsc emit 결과가 의미 있는 타입`임을 확인 — 예: `getStatusSnapshot` `Promise<{ schemaVersion: string; configPath: string; ...; codex?: object; claude?: object; }>` 형태.
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 **민감값을 redact** 했음.

## 리뷰 포인트

- **base tsconfig에 compilerOptions만 두고 include/rootDir/outDir은 패키지별 override**: extends가 base 위치 기준으로 경로를 해석하는 tsc 동작 때문. 이게 의도대로 가장 단순한 구성.
- **루트 build:types 명시 순차 호출** vs `npm -ws run`: 후자는 의존 순서 보장 안 함. schemas → adapters → cli 명시가 안전. PR 본문에 근거 명시.
- **JSDoc 보강 5개로 좁힘**: "publish 차단 항목"만. 그 외 (auth/, codex-provider, parse-options 외 helper 등)는 후속 chore PR. 본 PR scope 폭주 방지.
- **회귀 가드 CI gate 분리**: `process.env.CI === 'true'`에서만 dist/types 산출물 존재 검증. local에서 build:types 안 돌리고 npm test만 실행 시 false positive 회피.
- **types 필드 path가 build 후에만 존재**: `npm install` 직후에는 `dist/types/index.d.ts` 부재. publish는 항상 build:types 거친 산출물이라 외부 영향 없음. 단 본 PR 머지 직후 dev 사용자가 build:types를 한 번 실행해야 함.
- **외부 TS sanity check 자동화 미포함**: 사용자 결정으로 docs에 manual 절차만. T2 #75 install smoke와 함께 후속.

## 참고 사항

- 후속 chore PR 후보: 미보강 export JSDoc 점진 개선 (auth/, codex-provider, fetch-codex-usage 등).
- T1 다음: #74 (CHANGELOG + semver). d.ts breaking change 분류 기준이 정의됨.
- T2: #75 (install smoke), #76 (릴리스 자동화), #77 (provenance) — T1 완료 후.

> PR 제목은 `[feat]`, `[fix]`, `[docs]`처럼 타입은 영어로 유지하고, 뒤의 설명은 한글로 작성하는 것을 기본 규칙으로 합니다.