### PR TITLE
[chore] CHANGELOG + semver 정책 (Changesets) (#74)

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -15,7 +15,7 @@ npx changeset
 2. bump type 선택 (major / minor / patch — 기준은 [docs/release-policy.md](../docs/release-policy.md))
 3. 사용자 노출 변경 요약 (한 줄 markdown)
 
-생성된 `.changeset/<random-name>.md`를 PR에 함께 commit합니다. dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(version bump + CHANGELOG entry)을 자동 생성/갱신합니다.
+생성된 `.changeset/<random-name>.md`를 PR에 함께 commit합니다. dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(`packages/*/package.json` version bump + `packages/*/CHANGELOG.md`)을 자동 생성/갱신합니다. root [CHANGELOG.md](../CHANGELOG.md)는 publish 시점에 수동으로 큐레이트되는 high-level 요약입니다 — 자세한 정책은 [docs/release-policy.md §4](../docs/release-policy.md) 참고.
 
 ## 규약
 

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,25 @@
+# Changesets
+
+이 디렉토리에는 [Changesets](https://github.com/changesets/changesets)가 release version과 CHANGELOG를 자동 생성하기 위해 사용하는 파일들이 들어 있습니다.
+
+## 사용
+
+새 PR에서 사용자에게 영향이 있는 변경(public API / CLI / `--json` shape / d.ts 등)을 했다면, 다음을 실행해 changeset 파일을 추가합니다:
+
+```bash
+npx changeset
+```
+
+대화형 프롬프트가:
+1. 영향받는 패키지 선택 (3개 publishable 중 — linked되어 있어 셋이 같은 bump를 받음)
+2. bump type 선택 (major / minor / patch — 기준은 [docs/release-policy.md](../docs/release-policy.md))
+3. 사용자 노출 변경 요약 (한 줄 markdown)
+
+생성된 `.changeset/<random-name>.md`를 PR에 함께 commit합니다. dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(version bump + CHANGELOG entry)을 자동 생성/갱신합니다.
+
+## 규약
+
+- **3 패키지(linked)**: `@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas`는 항상 같은 version으로 release. v0.x 동안은 호환성 단순화 우선. 향후 stable 시 unlink 검토.
+- **bump type 기준**: [docs/release-policy.md](../docs/release-policy.md) 참고. 자기 PR이 어디 해당하는지 모르면 PR 본문에 후보를 적고 리뷰에서 결정.
+- **chore/docs only PR**: changeset 추가 안 함. CHANGELOG는 사용자 영향이 있는 변경만 기록.
+- **base branch**: `dev`. release PR은 dev → main 머지로 이어지는 흐름.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [
+    [
+      "@token-weather/cli",
+      "@token-weather/provider-adapters",
+      "@token-weather/schemas"
+    ]
+  ],
+  "access": "public",
+  "baseBranch": "dev",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+# dev 브랜치 push 시 누적된 .changeset/*.md 를 모아 release PR(version bump +
+# CHANGELOG entry)을 자동 생성/갱신한다. 본 워크플로는 release PR 작성까지만
+# 책임진다 — 실제 npm publish 자동화는 #76에서 'publish' step 추가 예정.
+#
+# 정책 / 카테고리 / SCHEMA_VERSION 기준은 docs/release-policy.md.
+
+on:
+  push:
+    branches: [dev]
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm install --no-package-lock
+
+      - uses: changesets/action@v1
+        with:
+          version: npx changeset version
+          # publish step은 #76(릴리스 자동화)에서 추가
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+본 파일은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 포맷을 따르고, 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 사용합니다. 카테고리 정의와 bump 기준은 [docs/release-policy.md](./docs/release-policy.md) 참고.
+
+3 패키지(`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas`)는 v0.x 동안 linked 되어 같은 version으로 release 됩니다.
+
+## [Unreleased]
+
+이 섹션은 [Changesets](https://github.com/changesets/changesets)가 PR 단위 changeset을 누적해 자동 갱신합니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 release note를 함께 commit 해주세요.
+
+## [0.1.0] - 2026-04-27
+
+첫 공개 publish 직전 상태 정리. v0.x 동안은 호환성 단순화를 위해 3 패키지를 linked로 유지합니다.
+
+### Added
+
+- Codex OAuth 로그인 / token exchange / live usage 조회 ([#6]).
+- Claude CLI credential import 경로 ([#16]) 및 stats-cache usage + live OAuth ([#19]).
+- multi-account 지원 — 병렬 조회, `--account` 필터, label + config default ([#43]).
+- `@token-weather/schemas` runtime validation (`validateUsageSnapshot`) ([#47]).
+- `auth refresh` 명령 + token claims 기반 계정 식별 + doctor 진단 경로 ([#6], [#43]).
+- usage/status 조회 시 OAuth access token **자동 refresh** ([#57], [#58]).
+- CLI 서브커맨드 단위 `--help` (status / usage / doctor / auth login·logout·list·refresh / config init) ([#66]).
+- `status` / `usage` 의 `--provider <id>` scope 옵션 (case-insensitive 정규화 포함) ([#67]).
+- `status` / `usage` 의 `--json` 출력 모드 — stable contract + token redaction ([#68]).
+- Claude `--manual` paste 흐름 + `--live-exchange` 흐름 통합 ([#87]).
+- 3 패키지 모두 TypeScript `.d.ts` 동봉 — `tsc --emitDeclarationOnly --allowJs` 기반 무빌드 emit ([#88]).
+
+### Changed
+
+- CLI option parser를 spec 기반 공통 helper(`parseCliOptions`)로 통일 — status / usage / doctor / login / logout / refresh ([#62]).
+- Claude OAuth flow를 pi-ai baseline(`claude.ai` authorize endpoint + 6-scope) 기준으로 정렬 ([#87]).
+- 패키지명을 `@token-weather/*`로 리네임, bin을 `token-weather`로 정렬 ([#82]).
+- repo 식별자(`ai-usage-agent` → `token-weather`) 일괄 치환 + 워크스페이스 경계 import를 `@token-weather/*` 패키지명으로 변환 ([#82]).
+
+### Fixed
+
+- `--provider` 입력 case-insensitive 정규화 ([#67]).
+- Claude 로그인 후 profile metadata 보강(누락된 account label 등) ([#55]).
+- `parseCliOptions` 빈 문자열 value skip 보강 (legacy 계약 회귀 가드 포함) ([#62]).
+
+### Security
+
+- `status --json` 출력 token redaction (`SENSITIVE_KEYS` 확장 + case-insensitive 매칭) ([#68]).
+- `SECURITY.md` / `CODE_OF_CONDUCT.md` 신설 + bug_report / PR template에 token redaction 체크 추가 ([#80]).
+- Apache-2.0 LICENSE 적용 + 4개 package.json `license` 필드 정렬 ([#81]).
+
+### Internal
+
+- monorepo 구조: `packages/{agent,provider-adapters,schemas}` 분리 + provider registry + login/doctor runner ([#29], [#51]).
+- account 선택 / auth source 선택 로직 공통화 ([#49]).
+- 테스트 커버리지 보강 (Codex 대칭 / services / CLI / smoke) ([#32]).
+- 회귀 가드 테스트: `repo-policy-{publish,license,readme,types}.test.js` + `import-discipline.test.js` ([#80], [#81], [#82], [#85], [#88]).
+- CI: `npm install --no-package-lock` → `npm run build:types` → `npm test` 흐름 정착 ([#88]).
+- README / CONTRIBUTING / `docs/codebase-guide.md` 사용자 온보딩 + 보안 신고 단락 + 라이선스 단락 ([#80], [#81], [#85]).
+
+[Unreleased]: https://github.com/LLagoon3/ai-usage-agent/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/LLagoon3/ai-usage-agent/releases/tag/v0.1.0
+
+[#6]: https://github.com/LLagoon3/ai-usage-agent/pull/6
+[#16]: https://github.com/LLagoon3/ai-usage-agent/pull/16
+[#19]: https://github.com/LLagoon3/ai-usage-agent/pull/19
+[#29]: https://github.com/LLagoon3/ai-usage-agent/pull/29
+[#32]: https://github.com/LLagoon3/ai-usage-agent/pull/32
+[#43]: https://github.com/LLagoon3/ai-usage-agent/pull/43
+[#47]: https://github.com/LLagoon3/ai-usage-agent/pull/47
+[#49]: https://github.com/LLagoon3/ai-usage-agent/pull/49
+[#51]: https://github.com/LLagoon3/ai-usage-agent/pull/51
+[#55]: https://github.com/LLagoon3/ai-usage-agent/pull/55
+[#57]: https://github.com/LLagoon3/ai-usage-agent/pull/57
+[#58]: https://github.com/LLagoon3/ai-usage-agent/pull/58
+[#62]: https://github.com/LLagoon3/ai-usage-agent/pull/62
+[#66]: https://github.com/LLagoon3/ai-usage-agent/pull/66
+[#67]: https://github.com/LLagoon3/ai-usage-agent/pull/67
+[#68]: https://github.com/LLagoon3/ai-usage-agent/pull/68
+[#80]: https://github.com/LLagoon3/ai-usage-agent/pull/80
+[#81]: https://github.com/LLagoon3/ai-usage-agent/pull/81
+[#82]: https://github.com/LLagoon3/ai-usage-agent/pull/82
+[#85]: https://github.com/LLagoon3/ai-usage-agent/pull/85
+[#87]: https://github.com/LLagoon3/ai-usage-agent/pull/87
+[#88]: https://github.com/LLagoon3/ai-usage-agent/pull/88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [Unreleased]
 
-이 섹션은 [Changesets](https://github.com/changesets/changesets)가 PR 단위 changeset을 누적해 자동 갱신합니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 release note를 함께 commit 해주세요.
+이 섹션은 publish 시점에 root에서 **수동으로 큐레이트**합니다 — 3 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 패키지별 상세 release note는 [Changesets](https://github.com/changesets/changesets)가 `packages/*/CHANGELOG.md`를 자동 생성하고, 본 문서는 publish PR에서 그 내용을 참고해 채웁니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 changeset을 함께 commit 해주세요.
 
 ## [0.1.0] - 2026-04-27
 
@@ -18,9 +18,9 @@
 - Claude CLI credential import 경로 ([#16]) 및 stats-cache usage + live OAuth ([#19]).
 - multi-account 지원 — 병렬 조회, `--account` 필터, label + config default ([#43]).
 - `@token-weather/schemas` runtime validation (`validateUsageSnapshot`) ([#47]).
-- `auth refresh` 명령 + token claims 기반 계정 식별 + doctor 진단 경로 ([#6], [#43]).
+- `doctor <provider> --refresh-live` 진단 경로 + token claims 기반 계정 식별 ([#6], [#43]).
 - usage/status 조회 시 OAuth access token **자동 refresh** ([#57], [#58]).
-- CLI 서브커맨드 단위 `--help` (status / usage / doctor / auth login·logout·list·refresh / config init) ([#66]).
+- CLI 서브커맨드 단위 `--help` (status / usage / doctor / auth login·logout·list·import / config init) ([#66]).
 - `status` / `usage` 의 `--provider <id>` scope 옵션 (case-insensitive 정규화 포함) ([#67]).
 - `status` / `usage` 의 `--json` 출력 모드 — stable contract + token redaction ([#68]).
 - Claude `--manual` paste 흐름 + `--live-exchange` 흐름 통합 ([#87]).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ PR 본문에는 최소한 아래 내용을 포함한다.
 npx changeset
 ```
 
-대화형 프롬프트가 (1) 영향받는 패키지 (3개 publishable이 linked되어 있어 셋이 같은 bump를 받음) (2) bump type (major / minor / patch) (3) 사용자 노출 변경 한 줄 요약을 묻는다. 생성된 `.changeset/<random-name>.md`를 PR에 함께 commit하면 dev 머지 시 `changesets/action`이 누적된 changeset을 모아 release PR을 자동 생성/갱신한다.
+대화형 프롬프트가 (1) 영향받는 패키지 (3개 publishable이 linked되어 있어 셋이 같은 bump를 받음) (2) bump type (major / minor / patch) (3) 사용자 노출 변경 한 줄 요약을 묻는다. 생성된 `.changeset/<random-name>.md`를 PR에 함께 commit하면 dev 머지 시 `changesets/action`이 누적된 changeset을 모아 release PR을 자동 생성/갱신한다 — 이때 `packages/<name>/CHANGELOG.md`가 자동 생성된다. root [CHANGELOG.md](./CHANGELOG.md)는 publish 시점에 release PR 작성자가 per-package CHANGELOG를 참고해 수동으로 큐레이트한다.
 
 - bump type 기준은 [docs/release-policy.md](./docs/release-policy.md). 모르면 PR 본문에 후보를 적고 리뷰에서 결정.
 - chore / docs only PR은 changeset 추가 안 함. CHANGELOG는 사용자 영향이 있는 변경만 기록.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,20 @@ PR 본문에는 최소한 아래 내용을 포함한다.
 - PR / issue 본문에 access token / refresh token / id token / session cookie / accountKey 같은 민감값을 절대 첨부하지 않는다. 실수로 노출한 경우 즉시 revoke 후 재발급한다(절차는 SECURITY.md).
 - 새로운 토큰성 필드를 provider adapter / auth schema에 도입하는 PR은 동일 PR 안에서 `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`를 갱신하고 redaction 회귀 테스트를 추가한다 (`docs/cli-json-output.md` §한계 참고).
 
-## 8. 기여자 라이선스
+## 8. Release / changeset
+
+사용자-가시 변경(public API / CLI / `--json` shape / d.ts 등)을 포함하는 PR은 [Changesets](https://github.com/changesets/changesets)로 release note를 함께 commit한다.
+
+```bash
+npx changeset
+```
+
+대화형 프롬프트가 (1) 영향받는 패키지 (3개 publishable이 linked되어 있어 셋이 같은 bump를 받음) (2) bump type (major / minor / patch) (3) 사용자 노출 변경 한 줄 요약을 묻는다. 생성된 `.changeset/<random-name>.md`를 PR에 함께 commit하면 dev 머지 시 `changesets/action`이 누적된 changeset을 모아 release PR을 자동 생성/갱신한다.
+
+- bump type 기준은 [docs/release-policy.md](./docs/release-policy.md). 모르면 PR 본문에 후보를 적고 리뷰에서 결정.
+- chore / docs only PR은 changeset 추가 안 함. CHANGELOG는 사용자 영향이 있는 변경만 기록.
+
+## 9. 기여자 라이선스
 
 이 저장소는 [Apache License 2.0](./LICENSE)으로 배포됩니다.
 

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -2,7 +2,7 @@
 
 `status` / `usage` 커맨드는 `--json` 플래그로 정규화된 JSON 한 줄을 stdout에 출력한다. 자동화 / 대시보드 / 백엔드 수집기가 텍스트 포매팅을 다시 파싱하지 않고 직접 소비할 수 있도록 한 명세다.
 
-이 문서는 출력 shape의 **stable contract**다. 변경 시 schema bump이 필요하다(현재 `schemaVersion`은 `packages/schemas`와 공유).
+이 문서는 출력 shape의 **stable contract**다. 변경 시 schema bump이 필요하다(현재 `schemaVersion`은 `packages/schemas`와 공유 — string semver, [docs/release-policy.md §3](./release-policy.md) 참고).
 
 ## 사용
 
@@ -23,7 +23,7 @@ token-weather status --json --account work@example.com --provider claude
 {
   "command": "status",
   "generatedAt": "2026-04-25T08:30:00.000Z",
-  "schemaVersion": 1,
+  "schemaVersion": "0.1.0",
   "configPath": "/home/user/.config/ai-usage-agent/config.json",
   "accountFilter": null,
   "providerFilter": null,
@@ -38,7 +38,7 @@ token-weather status --json --account work@example.com --provider claude
 | --- | --- | --- |
 | `command` | `"status"` \| `"usage"` | 호출된 커맨드 이름. |
 | `generatedAt` | ISO-8601 string | snapshot 직렬화 시각(client-side). |
-| `schemaVersion` | int \| null | `packages/schemas/src/index.js::SCHEMA_VERSION`을 그대로 통과. |
+| `schemaVersion` | string semver \| null | `packages/schemas/src/index.js::SCHEMA_VERSION`(현재 `'0.1.0'`)을 그대로 통과. 패키지 `version`과는 독립이며 bump 트리거는 [docs/release-policy.md §3](./release-policy.md). |
 | `configPath` | string \| null | resolved config 파일 경로. |
 | `accountFilter` | string \| null | `--account <id>` 입력 (case-insensitive 매치는 별도). |
 | `providerFilter` | string \| null | `--provider <id>` 입력. lowercase 정규화된 값. |

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -9,6 +9,7 @@
 - `docs/auth-cli.md` — auth CLI 명령 / 정책
 - `docs/provider-notes.md` — provider별 observed 값과 endpoint
 - `docs/typescript-consumers.md` — `.d.ts` 동봉 정책 + JSDoc 보강 시 따를 규약
+- `docs/release-policy.md` — semver / SCHEMA_VERSION / CHANGELOG 운영 규약 (사용자-가시 변경 PR 필독)
 
 ---
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,114 @@
+# Release 정책 (semver / CHANGELOG / SCHEMA_VERSION)
+
+본 문서는 `@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas` 세 패키지의 version bump 기준과 CHANGELOG 운영 규약을 정리한다. PR 리뷰 시 인용 가능한 형태로 유지.
+
+도구: [Changesets](https://github.com/changesets/changesets) — `.changeset/*.md` 파일 누적 → release PR 자동 생성. 셋업 / 기여자 절차는 [.changeset/README.md](../.changeset/README.md) 참고.
+
+## 1. semver 트리거
+
+세 패키지는 **linked** 상태라 같은 bump를 받는다 (v0.x 동안 호환성 단순화 우선).
+
+### major (X.0.0)
+
+사용자가 install 후 코드를 고쳐야 동작이 유지되는 변경:
+
+- `status --json` 출력 shape 변경 — 키 제거, 의미 변경, 중첩 구조 재구성. 신규 키 추가는 minor.
+- `packages/schemas` JSON Schema의 키 제거 / 의미 변경 / shape 재구성.
+- `SCHEMA_VERSION` bump (별도 §3 참고).
+- public d.ts breaking — export 제거, 함수 signature 변경(필수 param 추가/순서 변경/타입 narrow), `@typedef` 키 제거.
+- CLI flag 제거 또는 shorthand 의미 변경 (예: `--account` 동작 자체가 바뀜).
+- 기존 CLI 명령 제거 (예: `token-weather status` 자체를 없앰).
+- `~/.config/ai-usage-agent/` 경로 / `auth.json` 스키마의 incompatible 변경.
+
+### minor (0.X.0)
+
+기존 사용자 코드가 동작하면서 기능이 추가되는 변경:
+
+- 신규 CLI flag (예: `--json`, `--provider`) 추가.
+- 신규 provider 추가 (예: `auth login gemini`).
+- `packages/schemas`에 신규 optional 키 추가.
+- public d.ts에 신규 export 추가, 또는 기존 export의 typedef에 optional 필드 추가.
+- 신규 서브커맨드 (예: `token-weather inspect`) 추가.
+
+### patch (0.0.X)
+
+내부 변경 또는 사용자가 인지할 필요 없는 수정:
+
+- 버그 수정 (출력 포맷 오류, 잘못된 redaction 등).
+- 내부 리팩터 (export 면 변화 없음).
+- observed 값 갱신 (예: `client_id`, endpoint URL이 외부 변경에 따라 보정).
+- JSDoc 보강으로 d.ts 정확도 개선 (`any` → 구체적 타입). 기존 호환되는 타입 → 더 구체적인 타입은 patch (사용자가 코드를 고칠 필요 없음).
+- 의존성 보안 업데이트.
+- docs / 테스트 / CI 변경.
+
+## 2. 도메인별 자세한 기준
+
+### `status --json` 출력
+
+contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시되어 있다.
+
+- 키 추가: minor
+- 키 제거 / 의미 변경: major
+- redaction list(`SENSITIVE_KEYS`) 확장: patch (기존 출력에서 토큰만 더 빠지는 방향이라 비파괴적). 단 사용자가 그 키를 의도적으로 사용하고 있었다면 major로 격상 검토.
+
+### CLI flag
+
+- 신규 flag: minor
+- flag 제거: major
+- flag 동작 의미 변경 (예: `--account` case 처리 변경): major
+- flag 기본값 변경: 사용자에게 visible behavior 차이가 있으면 major, 그 외 minor
+
+### Provider adapter
+
+- 신규 provider: minor
+- 기존 provider의 endpoint / scope 변경: 사용자에게 invalid_grant 같은 회귀 위험이 있으면 major. observed 보정만으로 끝나고 사용자 영향 없으면 patch (예: PR #87의 pi-ai parity는 invalid_grant 의심을 줄이는 보정이라 minor 정도가 합리적).
+
+### d.ts (TypeScript 타입)
+
+기준: PR #88로 도입된 d.ts emission. JSDoc 커버리지에 의존하므로 정확도가 점진적으로 개선되는 영역.
+
+- 신규 export 노출: minor
+- export 제거 / signature breaking: major
+- 기존 `any`를 구체적 타입으로 narrow (사용자가 코드 변경 없이 컴파일됨): patch
+- `@typedef` 필드 추가 (optional): minor
+- `@typedef` 필드 제거 / 필수화: major
+
+### 보안 redaction
+
+- `SENSITIVE_KEYS` 확장: patch (기본적으로 토큰이 덜 노출되는 방향). consumer의 정상 사용에 영향 없음.
+- `redactSensitive` 동작 자체 변경 (어떤 키를 더 노출하는 방향): major. 단 그런 변경은 보안상 명시적 결정이 필요.
+
+## 3. SCHEMA_VERSION 규약
+
+`packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.1.0'` (string semver).
+
+- 본 패키지의 `version`과는 **독립**. 패키지가 0.5.0이어도 SCHEMA_VERSION은 0.1.0일 수 있음.
+- bump 트리거: §1의 **major** 항목 중 `status --json` shape 또는 `packages/schemas` JSON Schema의 breaking 변경이 발생할 때.
+- format: string semver (`'0.1.0'`, `'1.0.0'`). 정수가 아닌 이유는 sub-bump(예: `0.1.1`로 backward-compat schema 보강) 가능성.
+- v1.0.0 이전(현재): 사용자에게 미공개 상태로 자유롭게 변경. v1.0.0 publish 이후: 위 규약 엄격 적용.
+
+## 4. CHANGELOG 운영
+
+[CHANGELOG.md](../CHANGELOG.md) 카테고리:
+
+- **Added** — 신규 export / flag / provider / 명령
+- **Changed** — 기존 동작의 visible behavior 변경 (semver의 minor/major 트리거가 됨)
+- **Deprecated** — 다음 major에서 제거 예정 표기
+- **Removed** — 이번 release에서 제거된 항목 (major)
+- **Fixed** — 버그 수정
+- **Security** — 보안 관련 변경 (redaction list 확장 / token 처리 보강 등)
+- **Internal** — 사용자에게 노출 안 되는 리팩터 / 테스트 / CI / 의존성. 이 카테고리는 **사용자 가독성 우선**으로 자동 생성된 minor 변경 위주이고, 큰 인프라 변경은 별도 entry로 두기.
+
+각 항목은 PR 번호 링크 + 한 줄 설명. 자세한 맥락은 PR description으로 위임.
+
+## 5. release PR 흐름
+
+1. PR 작성자가 `npx changeset` 실행 → `.changeset/<name>.md` 생성 + commit.
+2. PR이 dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(version bump + CHANGELOG entry)을 자동 생성/갱신.
+3. release PR을 검토 후 머지.
+4. 실제 npm publish는 `#76`(릴리스 자동화)에서 추가될 publish step이 처리. 본 PR(#74)은 release PR 생성까지.
+5. v1.0.0 이상에서는 dev → main 머지가 release tag와 연결.
+
+## 6. 변경 이력
+
+- 2026-04-27 (#74): 초안 작성. v0.1.0 publish 직전 상태에서 정책 명문화.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -89,7 +89,12 @@ contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시�
 
 ## 4. CHANGELOG 운영
 
-[CHANGELOG.md](../CHANGELOG.md) 카테고리:
+CHANGELOG는 두 layer로 운영한다 — Changesets 기본 동작에 맞춰서.
+
+- **`packages/<name>/CHANGELOG.md`** (auto): `changesets/action`의 `version` step이 누적된 changeset을 소비해 각 publishable package에 자동 생성/갱신. PR 본문 + bump type이 그대로 반영된다.
+- **루트 [CHANGELOG.md](../CHANGELOG.md)** (manual curated): 3 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. publish 시점에 release PR 작성자가 per-package CHANGELOG들을 참고해 수동으로 채운다. 카테고리 정의는 아래.
+
+루트 CHANGELOG 카테고리:
 
 - **Added** — 신규 export / flag / provider / 명령
 - **Changed** — 기존 동작의 visible behavior 변경 (semver의 minor/major 트리거가 됨)
@@ -99,16 +104,19 @@ contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시�
 - **Security** — 보안 관련 변경 (redaction list 확장 / token 처리 보강 등)
 - **Internal** — 사용자에게 노출 안 되는 리팩터 / 테스트 / CI / 의존성. 이 카테고리는 **사용자 가독성 우선**으로 자동 생성된 minor 변경 위주이고, 큰 인프라 변경은 별도 entry로 두기.
 
-각 항목은 PR 번호 링크 + 한 줄 설명. 자세한 맥락은 PR description으로 위임.
+각 항목은 PR 번호 링크 + 한 줄 설명. 자세한 맥락은 PR description / per-package CHANGELOG로 위임.
+
+> **참고**: 향후 root CHANGELOG도 자동 집계가 필요해지면 `@changesets/changelog-github` 같은 custom changelog formatter + post-version 스크립트로 root에 모으는 step을 추가하는 방향으로 확장한다. 본 PR(#74) 시점에는 manual 운영.
 
 ## 5. release PR 흐름
 
 1. PR 작성자가 `npx changeset` 실행 → `.changeset/<name>.md` 생성 + commit.
-2. PR이 dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(version bump + CHANGELOG entry)을 자동 생성/갱신.
-3. release PR을 검토 후 머지.
+2. PR이 dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(`packages/*/package.json` version bump + `packages/*/CHANGELOG.md` 갱신)을 자동 생성/갱신.
+3. release PR을 검토하면서 root [CHANGELOG.md](../CHANGELOG.md)의 `[Unreleased]` 섹션을 per-package 변경 요약 기준으로 **수동** 갱신 후 머지.
 4. 실제 npm publish는 `#76`(릴리스 자동화)에서 추가될 publish step이 처리. 본 PR(#74)은 release PR 생성까지.
 5. v1.0.0 이상에서는 dev → main 머지가 release tag와 연결.
 
 ## 6. 변경 이력
 
 - 2026-04-27 (#74): 초안 작성. v0.1.0 publish 직전 상태에서 정책 명문화.
+- 2026-04-28 (#74 review follow-up): root CHANGELOG는 수동 큐레이트, per-package CHANGELOG는 Changesets 자동 생성으로 layer 구분 명문화.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:types": "npm -w @token-weather/schemas run build:types && npm -w @token-weather/provider-adapters run build:types && npm -w @token-weather/cli run build:types"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.0",
     "typescript": "^5.6.0"
   }
 }

--- a/packages/agent/src/cli/status-json.js
+++ b/packages/agent/src/cli/status-json.js
@@ -98,7 +98,7 @@ export function redactSensitive(value) {
  * {
  *   "command": "status" | "usage",
  *   "generatedAt": "<ISO-8601>",
- *   "schemaVersion": <int>,
+ *   "schemaVersion": <string semver>,
  *   "configPath": <string>,
  *   "accountFilter": <string|null>,
  *   "providerFilter": <string|null>,

--- a/packages/agent/test/integration/repo-policy-release.test.js
+++ b/packages/agent/test/integration/repo-policy-release.test.js
@@ -1,0 +1,104 @@
+/**
+ * Repo-level release 정책 회귀 가드.
+ *
+ * Changesets 기반 release 운영(#74)의 핵심 메타데이터가 우발적으로 깨지는
+ * 회귀를 막는 파일시스템 단위 검증:
+ *  - 루트 @changesets/cli devDep
+ *  - .changeset/config.json (linked / baseBranch / access)
+ *  - docs/release-policy.md 핵심 섹션
+ *  - CHANGELOG.md (Keep a Changelog 포맷 hint)
+ *  - .github/workflows/release.yml (changesets/action, publish step 부재)
+ *
+ * 도메인이 다른 repo-policy-{license, publish, readme, types}.test.js와
+ * 분리해 release 운영 측면만 검증.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function readJson(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8'));
+}
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+}
+
+function repoFileExists(relPath) {
+  return fs.existsSync(path.join(REPO_ROOT, relPath));
+}
+
+const ROOT = readJson('package.json');
+
+describe('repo-policy/release — Changesets 셋업 (PR #74)', () => {
+  it('루트 package.json 에 @changesets/cli devDep 이 선언되어 있다', () => {
+    assert.ok(ROOT.devDependencies, 'devDependencies 누락');
+    assert.equal(typeof ROOT.devDependencies['@changesets/cli'], 'string');
+  });
+
+  it('.changeset/config.json 이 존재한다', () => {
+    assert.equal(repoFileExists('.changeset/config.json'), true);
+  });
+
+  it('.changeset/config.json 의 baseBranch / access / linked 필드가 정책과 일치', () => {
+    const cfg = readJson('.changeset/config.json');
+    assert.equal(cfg.baseBranch, 'dev');
+    assert.equal(cfg.access, 'public');
+    assert.ok(Array.isArray(cfg.linked) && cfg.linked.length === 1);
+    const group = cfg.linked[0];
+    assert.ok(group.includes('@token-weather/cli'));
+    assert.ok(group.includes('@token-weather/provider-adapters'));
+    assert.ok(group.includes('@token-weather/schemas'));
+  });
+
+  it('.changeset/README.md (기여자 안내) 가 존재한다', () => {
+    assert.equal(repoFileExists('.changeset/README.md'), true);
+  });
+});
+
+describe('repo-policy/release — docs / CHANGELOG (PR #74)', () => {
+  it('docs/release-policy.md 가 핵심 섹션을 포함한다', () => {
+    const text = readText('docs/release-policy.md');
+    // semver 트리거 / SCHEMA_VERSION / CHANGELOG / release PR 흐름 4개 섹션이
+    // PR 리뷰에서 인용 가능하도록 유지되어야 함
+    assert.match(text, /semver/i);
+    assert.match(text, /SCHEMA_VERSION/);
+    assert.match(text, /CHANGELOG/);
+    assert.match(text, /release PR/i);
+  });
+
+  it('CHANGELOG.md 가 Keep a Changelog 포맷의 핵심 표식을 가진다', () => {
+    assert.equal(repoFileExists('CHANGELOG.md'), true);
+    const text = readText('CHANGELOG.md');
+    assert.match(text, /## \[Unreleased\]/);
+    assert.match(text, /## \[0\.1\.0\]/);
+    assert.match(text, /### Added/);
+    // 카테고리 안내가 사라지면 작성자가 어떤 섹션에 넣을지 모르게 됨
+    for (const cat of ['Changed', 'Fixed', 'Security']) {
+      assert.match(text, new RegExp(`### ${cat}`));
+    }
+  });
+});
+
+describe('repo-policy/release — release workflow (PR #74)', () => {
+  it('.github/workflows/release.yml 이 존재한다', () => {
+    assert.equal(repoFileExists('.github/workflows/release.yml'), true);
+  });
+
+  it('release.yml 이 changesets/action 을 사용한다', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /uses:\s*changesets\/action/);
+  });
+
+  it('release.yml 에 publish step 이 아직 없다 (의도적 — #76 범위)', () => {
+    const text = readText('.github/workflows/release.yml');
+    // 'publish: <command>' 형태의 yaml key가 changesets/action with: 블록에
+    // 들어오는 순간 실제 npm publish가 실행됨. 본 PR(#74)에서는 명시적 미포함.
+    assert.equal(/^\s*publish:\s*\S/m.test(text), false);
+  });
+});


### PR DESCRIPTION
closes #74

## 요약

publish(v0.1.0) 직전 상태에서 release 운영 인프라를 깐다. T1 시리즈의 두 번째 단계(#73 d.ts → **#74** → #53 install smoke).

- **Changesets** 도입(`@changesets/cli`) — PR 단위 release note 누적 + release PR 자동 생성
- **`docs/release-policy.md`** — semver 트리거 / SCHEMA_VERSION 규약 / CHANGELOG 카테고리 / release PR 흐름 6 sections
- **첫 `CHANGELOG.md`** — `[Unreleased]` placeholder + `[0.1.0] - 2026-04-27` entry로 그동안 머지된 25+개 PR을 Added/Changed/Fixed/Security/Internal로 정리
- **`.github/workflows/release.yml`** — dev push 시 누적된 changeset을 모아 release PR 자동 생성. publish step은 의도적으로 미포함 (→ #76)
- 회귀 가드 + cross-doc 링크 + `cli-json-output.md`의 `schemaVersion` 타입 표기 정정(`int` → `string semver`, 소스와 정합)

## 변경 내용

| commit | scope |
| --- | --- |
| `chore(deps)` | 루트 `@changesets/cli` devDep |
| `chore(release)` | `.changeset/config.json` (linked 3패키지, baseBranch=dev, access=public) + `.changeset/README.md` |
| `docs(release)` | `docs/release-policy.md` 6 sections |
| `docs(release)` | `CHANGELOG.md` 첫 작성 ([Unreleased] + [0.1.0]) |
| `ci(release)` | `.github/workflows/release.yml` (changesets/action, publish 없음) |
| `test(repo-policy)` | `repo-policy-release.test.js` 회귀 가드 9건 |
| `docs(contributing)` | CONTRIBUTING §8 Release / changeset 진입 섹션 (라이선스 단락은 §9로 한 칸 밂) |
| `docs` | codebase-guide 관련 문서 목록 + cli-json-output schemaVersion 타입 정정 |

## 변경 이유

publish 후 외부 사용자가 install/upgrade 결정을 하려면 (1) 어떤 변경이 breaking인지 명확한 기준, (2) version별 사용자-가시 변경 요약, (3) PR 작성자가 release type을 누적시킬 표준 절차가 필요하다. 본 PR이 머지되면 다음 PR부터 작성자가 \`npx changeset\` 으로 release note를 함께 commit하고, dev 머지 시 \`changesets/action\`이 누적된 changeset을 모아 release PR을 자동 생성한다.

## 영향 범위

- [x] \`repo\` (루트 package.json devDep, .changeset/, CHANGELOG.md, CONTRIBUTING.md)
- [x] \`docs\` (release-policy 신규, codebase-guide cross-link, cli-json-output 정정)
- [x] CI (.github/workflows/release.yml 신규)
- [x] \`packages/agent\` (회귀 가드 테스트, status-json.js JSDoc 1줄)
- [ ] 사용자 코드 변경 — 없음

## 테스트 / 확인

- 전체 722/722 pass (\`npm test\`)
- 신규 회귀 가드 9건 모두 pass (\`packages/agent/test/integration/repo-policy-release.test.js\`)
- 기존 \`repo-policy-{license,readme,publish,types}.test.js\` 회귀 영향 없음 (CONTRIBUTING 섹션 번호 밂에도 키워드 기반 검증이라 안전)

## 리뷰 포인트

1. **CHANGELOG \`[0.1.0]\` 회고 분류** — 25+개 PR을 카테고리화했는데 누락/오분류 spot check 환영. 보수적 원칙(사용자-가시만, 모호하면 Internal로) 따름.
2. **publish step 의도적 부재** — release.yml에 \`publish:\` 키 없음. 본 PR은 release PR 생성까지만, 실제 publish 자동화는 #76. 회귀 가드도 publish step 부재를 명시적으로 검증.
3. **schemaVersion 타입 정정** — \`int | null\` → \`string semver | null\`. 소스(\`SCHEMA_VERSION = '0.1.0'\`)는 처음부터 string이었고 doc만 잘못된 상태. 외부 consumer가 \`schemaVersion === 1\` integer 비교를 하고 있었다면 깨질 수 있으나 actual 출력은 항상 string이었음 (테스트 fixture가 정수를 쓴 건 passthrough 동작 검증용).
4. **SCHEMA_VERSION 운영 결정** — release-policy §3에 string semver / 패키지 version과 독립 / v1.0.0 이전엔 자유롭게 변경 가능 명시.

## 참고 사항

- 본 PR이 dev에 머지되어도 \`changesets/action\`은 첫 실행에서 누적된 changeset이 없어 release PR을 만들지 않음. 이후 PR에서 \`npx changeset\` 으로 changeset이 추가되면 그때 release PR이 자동 생성된다.
- branch protection이 dev에 걸려 있다면 changesets bot의 push가 막힐 수 있다 — 운영 이슈는 첫 release PR 생성 시점에 관찰.
- \`CHANGELOG.md\`의 \`[0.1.0]\` 날짜 \`2026-04-27\`은 잠정. 실제 publish 시점에 갱신 가능.