### PR TITLE
[ci] npm pack install smoke 자동화 (#75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,23 @@ jobs:
       - run: npm run build:types
 
       - run: npm test
+
+  install-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm install --no-package-lock
+
+      - run: bash ./scripts/install-smoke.sh
+
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-smoke-packs
+          path: packs/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env.*
 dist
 build
+packs
 coverage
 .next
 .turbo

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -10,6 +10,7 @@
 - `docs/provider-notes.md` — provider별 observed 값과 endpoint
 - `docs/typescript-consumers.md` — `.d.ts` 동봉 정책 + JSDoc 보강 시 따를 규약
 - `docs/release-policy.md` — semver / SCHEMA_VERSION / CHANGELOG 운영 규약 (사용자-가시 변경 PR 필독)
+- `scripts/install-smoke.sh` — publish 직전 npm install 깨짐(cross-package import / files 누락 / d.ts 부재 등)을 자동 검증하는 스크립트. PR마다 CI에서 호출.
 
 ---
 

--- a/docs/typescript-consumers.md
+++ b/docs/typescript-consumers.md
@@ -47,6 +47,8 @@ const result = validateUsageSnapshot(payload);
 
 ## Manual sanity check 절차 (메인테이너)
 
+> **자동 검증**: 아래 단계 1-2(pack + 임시 install)는 [`scripts/install-smoke.sh`](../scripts/install-smoke.sh)가 PR마다 CI에서 자동 수행한다 (#75 도입). 본 절차는 단계 3-5(`tsc --noEmit` + IDE 자동완성)까지의 **타입 추론 품질**을 사람이 확인하고 싶을 때 사용한다.
+
 publish 직전 외부 TypeScript 프로젝트에서 import / 추론이 동작하는지 수동 검증:
 
 ```bash
@@ -110,4 +112,4 @@ code .
 - 본 d.ts emission은 **JSDoc 커버리지에 의존**합니다. 미보강 export는 정확한 타입을 받지 못합니다 (any로 노출).
 - **타입 계약 범위는 package root entry만**: `package.json::types`가 가리키는 `./dist/types/index.d.ts`만 stable. subpath import (`@token-weather/.../src/...`)는 동작하지만 본 PR scope 외이고, 후속에서 `exports` 필드와 `typesVersions`로 공식 지원 여부 결정 (현재 main 사용 중이라 도입은 별도 PR로).
 - TypeScript 자체 컨버전은 본 정책 범위가 아닙니다.
-- 자동 sanity check (CI에 외부 TS project 컴파일 step) 도입은 후속 이슈에서 검토 (T2 #75 install smoke와 함께 묶일 수 있음).
+- 자동 install/import 검증: `scripts/install-smoke.sh` (#75)가 PR마다 CI에서 pack + tmp install + bin smoke + d.ts 산출물 존재까지 수행. `tsc --noEmit` 단계는 본 manual 절차에 남아있다 — 자동화는 별도 후속 이슈에서 검토.

--- a/packages/agent/test/integration/repo-policy-install-smoke.test.js
+++ b/packages/agent/test/integration/repo-policy-install-smoke.test.js
@@ -52,6 +52,11 @@ describe('repo-policy/install-smoke — script (PR #75)', () => {
     assert.match(text, /token-weather.*--help|--help.*token-weather|"\$BIN" --help/);
     // d.ts 검증 단계
     assert.match(text, /dist\/types\/index\.d\.ts/);
+    // ESM root import 해상도 검증 단계 (PR #90 review follow-up)
+    assert.match(text, /import-check\.mjs/);
+    assert.match(text, /from '@token-weather\/cli'/);
+    assert.match(text, /from '@token-weather\/schemas'/);
+    assert.match(text, /from '@token-weather\/provider-adapters'/);
   });
 });
 

--- a/packages/agent/test/integration/repo-policy-install-smoke.test.js
+++ b/packages/agent/test/integration/repo-policy-install-smoke.test.js
@@ -1,0 +1,75 @@
+/**
+ * Repo-level install-smoke 정책 회귀 가드.
+ *
+ * publish 직전 npm install 깨짐을 자동 검증하는 scripts/install-smoke.sh
+ * 와 .github/workflows/ci.yml의 install-smoke job 메타데이터가 우발적으로
+ * 깨지는 회귀를 막는 파일시스템 단위 검증.
+ *
+ * 도메인이 다른 repo-policy-{license, publish, readme, types, release}.test.js
+ * 와 분리해 install smoke 측면만 검증.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function readText(relPath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+}
+
+function repoFileExists(relPath) {
+  return fs.existsSync(path.join(REPO_ROOT, relPath));
+}
+
+const SCRIPT_REL = 'scripts/install-smoke.sh';
+const WORKFLOW_REL = '.github/workflows/ci.yml';
+
+describe('repo-policy/install-smoke — script (PR #75)', () => {
+  it(`${SCRIPT_REL} 가 존재한다`, () => {
+    assert.equal(repoFileExists(SCRIPT_REL), true);
+  });
+
+  it(`${SCRIPT_REL} 가 executable 비트를 가진다 (chmod +x)`, () => {
+    const stat = fs.statSync(path.join(REPO_ROOT, SCRIPT_REL));
+    // owner / group / other 중 한 곳이라도 execute 비트가 있으면 PASS.
+    // Linux/macOS에서 chmod +x는 보통 0o755 → mode & 0o111 != 0.
+    assert.ok((stat.mode & 0o111) !== 0, `mode=${stat.mode.toString(8)} (no exec bit)`);
+  });
+
+  it(`${SCRIPT_REL} 핵심 단계가 모두 포함되어 있다`, () => {
+    const text = readText(SCRIPT_REL);
+    // 단계 누락 회귀를 잡기 위한 grep — 표현은 다소 덮을 수 있도록 키워드 단위.
+    assert.match(text, /set -euo pipefail/);
+    assert.match(text, /npm run build:types/);
+    assert.match(text, /npm pack --workspaces/);
+    assert.match(text, /mktemp -d/);
+    assert.match(text, /npm install --no-package-lock/);
+    // bin smoke 호출 — 위치 무관, --help 가 등장해야 함
+    assert.match(text, /token-weather.*--help|--help.*token-weather|"\$BIN" --help/);
+    // d.ts 검증 단계
+    assert.match(text, /dist\/types\/index\.d\.ts/);
+  });
+});
+
+describe('repo-policy/install-smoke — CI workflow (PR #75)', () => {
+  it(`${WORKFLOW_REL} 에 install-smoke job 이 존재한다`, () => {
+    const text = readText(WORKFLOW_REL);
+    assert.match(text, /^\s*install-smoke:\s*$/m);
+  });
+
+  it(`${WORKFLOW_REL} install-smoke job 이 scripts/install-smoke.sh 를 호출한다`, () => {
+    const text = readText(WORKFLOW_REL);
+    assert.match(text, /bash\s+\.\/scripts\/install-smoke\.sh/);
+  });
+
+  it(`${WORKFLOW_REL} 가 실패 시 packs/ artifact 를 업로드한다`, () => {
+    const text = readText(WORKFLOW_REL);
+    // failure 시 actions/upload-artifact 사용 + path: packs/
+    assert.match(text, /actions\/upload-artifact/);
+    assert.match(text, /path:\s*packs\/?/);
+  });
+});

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# install-smoke.sh — npm pack 결과물의 install 가능성 자동 검증.
+#
+# Workspace 안에서는 잘 동작해도 실제 npm install 환경에선 깨질 수 있는
+# 항목(cross-package 상대 import, files 누락, dist/types 부재, bin shebang
+# 권한 등)을 publish 직전에 잡기 위한 스크립트.
+#
+# 흐름:
+#   1) build:types 로 d.ts emit
+#   2) npm pack --workspaces 로 3 publishable 패키지 tarball 생성
+#   3) 임시 디렉토리에서 3 tarball을 동시 install
+#      (서로 ^0.1.0 의존이라 단독 install 시 registry로 가서 fail)
+#   4) bin 핵심 명령(--help, auth login claude --help) 실행 → exit 0 확인
+#   5) 3 패키지의 dist/types/index.d.ts 가 install된 node_modules에 존재하는지 확인
+#
+# 안전장치:
+#   - HOME 을 mktemp 디렉토리로 override → 사용자 실 ~/.config/ai-usage-agent/auth.json
+#     절대 접근 안 함.
+#   - NO_COLOR=1 로 출력 deterministic.
+#   - status / usage / doctor 같은 network 의존 명령은 smoke 대상에서 제외.
+#
+# 사용:
+#   bash scripts/install-smoke.sh        # local 검증
+#   CI 에서는 .github/workflows/ci.yml install-smoke job이 동일 호출.
+#
+# 실패 시: CI는 packs/ 디렉토리를 actions/upload-artifact 로 업로드.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PACKS_DIR="$REPO_ROOT/packs"
+
+echo "▶ 1. build:types"
+npm run build:types --silent
+
+echo "▶ 2. npm pack --workspaces → $PACKS_DIR"
+rm -rf "$PACKS_DIR"
+mkdir -p "$PACKS_DIR"
+npm pack --workspaces --pack-destination "$PACKS_DIR" --silent > /dev/null
+
+TARBALL_COUNT=$(find "$PACKS_DIR" -maxdepth 1 -name '*.tgz' -type f | wc -l)
+if [ "$TARBALL_COUNT" -ne 3 ]; then
+  echo "❌ expected 3 tarballs in $PACKS_DIR, got $TARBALL_COUNT"
+  ls -la "$PACKS_DIR" || true
+  exit 1
+fi
+echo "  ✓ 3 tarballs packed"
+
+echo "▶ 3. tmp 디렉토리 install"
+TMP=$(mktemp -d -t tw-install-smoke-XXXXXX)
+TMP_HOME=$(mktemp -d -t tw-smoke-home-XXXXXX)
+trap 'rm -rf "$TMP" "$TMP_HOME"' EXIT
+
+cd "$TMP"
+cat > package.json <<'EOF'
+{
+  "name": "token-weather-install-smoke",
+  "private": true,
+  "version": "0.0.0"
+}
+EOF
+
+# 3 tarball을 한 번에 install — 서로 ^0.1.0 의존이라 npm이 fs path로 cross-resolve
+npm install --no-package-lock --no-audit --no-fund "$PACKS_DIR"/*.tgz > /dev/null
+echo "  ✓ install 완료"
+
+echo "▶ 4. bin smoke (--help / auth login claude --help)"
+BIN="$TMP/node_modules/.bin/token-weather"
+if [ ! -x "$BIN" ]; then
+  echo "❌ bin not executable: $BIN"
+  ls -la "$TMP/node_modules/.bin/" || true
+  exit 1
+fi
+
+HOME="$TMP_HOME" NO_COLOR=1 "$BIN" --help > /dev/null
+HOME="$TMP_HOME" NO_COLOR=1 "$BIN" auth login claude --help > /dev/null
+echo "  ✓ bin 실행 OK"
+
+echo "▶ 5. d.ts 산출물 검증"
+for pkg in @token-weather/cli @token-weather/provider-adapters @token-weather/schemas; do
+  dts="$TMP/node_modules/$pkg/dist/types/index.d.ts"
+  if [ ! -f "$dts" ]; then
+    echo "❌ d.ts 누락: $dts"
+    exit 1
+  fi
+done
+echo "  ✓ 3 패키지 d.ts 모두 존재"
+
+echo ""
+echo "✓ install smoke passed"

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -89,5 +89,36 @@ for pkg in @token-weather/cli @token-weather/provider-adapters @token-weather/sc
 done
 echo "  ✓ 3 패키지 d.ts 모두 존재"
 
+echo "▶ 6. ESM root import 해상도 검증"
+# tmp 프로젝트의 root에서 3 패키지를 직접 import — 실제 publish/install 환경의
+# resolution 흐름과 동일. 단순 import 가능성과 알려진 named export 한 개의
+# shape 까지만 검증하고 함수는 호출하지 않는다 (side effect 회피).
+cat > "$TMP/import-check.mjs" <<'MJS'
+import { SCHEMA_VERSION, validateUsageSnapshot } from '@token-weather/schemas';
+import * as adapters from '@token-weather/provider-adapters';
+import * as cli from '@token-weather/cli';
+
+const failures = [];
+if (typeof SCHEMA_VERSION !== 'string') {
+  failures.push(`SCHEMA_VERSION expected string, got ${typeof SCHEMA_VERSION}`);
+}
+if (typeof validateUsageSnapshot !== 'function') {
+  failures.push(`validateUsageSnapshot expected function, got ${typeof validateUsageSnapshot}`);
+}
+if (typeof adapters !== 'object' || adapters === null || Object.keys(adapters).length === 0) {
+  failures.push('@token-weather/provider-adapters resolved but exports look empty');
+}
+if (typeof cli !== 'object' || cli === null || Object.keys(cli).length === 0) {
+  failures.push('@token-weather/cli resolved but exports look empty');
+}
+if (failures.length > 0) {
+  for (const f of failures) console.error('❌', f);
+  process.exit(1);
+}
+MJS
+
+HOME="$TMP_HOME" NO_COLOR=1 node "$TMP/import-check.mjs"
+echo "  ✓ 3 패키지 ESM root import OK"
+
 echo ""
 echo "✓ install smoke passed"


### PR DESCRIPTION
closes #75

## 요약

publish 직전에 `npm install` 환경에서 깨질 수 있는 항목(cross-package 상대 import, `files` 누락, `dist/types` 부재, bin shebang 권한 등)을 자동으로 잡기 위한 install smoke를 CI에 추가. T2 시리즈의 첫 단계(**#75** → #76 publish 자동화 → #77 provenance).

- 새 스크립트 **`scripts/install-smoke.sh`** — `build:types` → `npm pack --workspaces` → mktemp dir에서 3 tarball 동시 install → bin `--help` smoke + d.ts 산출물 검증
- **`.github/workflows/ci.yml`**에 `install-smoke` job 추가 (test job과 **병렬**) — 실패 시 `packs/` artifact 업로드(7일 retention)
- **회귀 가드** `repo-policy-install-smoke.test.js` 6건 — 스크립트 존재/exec bit + 핵심 단계 + workflow 호출 + artifact upload 검증
- 문서 정렬 — typescript-consumers `manual sanity check`의 1-2단계가 자동화됐음 명시 + codebase-guide cross-link

## 변경 내용

| commit | scope |
| --- | --- |
| `chore(scripts)` | `scripts/install-smoke.sh` (chmod +x) + `.gitignore`에 `packs/` |
| `ci` | `ci.yml`에 install-smoke job (parallel to test) |
| `test(repo-policy)` | `repo-policy-install-smoke.test.js` 6건 회귀 가드 |
| `docs` | typescript-consumers manual procedure 정렬 + codebase-guide 한 줄 |

## 변경 이유

3 publishable 패키지(`@token-weather/cli` / `provider-adapters` / `schemas`)가 서로 `^0.1.0` 의존이라, registry에 publish 전에는 **세 tarball을 함께 install**하는 방식으로만 install 가능성을 검증할 수 있다. `docs/typescript-consumers.md`에 동일 절차가 manual로 명문화돼 있었지만, 사람이 매번 실행하긴 어렵다 — PR 단계에서 자동으로 잡혀야 #76 publish 자동화의 안전벨트가 된다.

## 영향 범위

- [x] `.github/workflows` (CI 새 job)
- [x] `scripts/` (install-smoke.sh)
- [x] `docs/` (typescript-consumers, codebase-guide)
- [x] `packages/agent` (회귀 가드 테스트만)
- [ ] 사용자 코드 / publish 메타 변경 — 없음 (changeset 미추가)

## 테스트 / 확인

- 로컬 `bash scripts/install-smoke.sh` → "✓ install smoke passed" 출력 + exit 0
- 전체 test 728/728 pass (회귀 가드 신규 6건 포함)
- CI에서 `test` job + 신규 `install-smoke` job 병렬 실행 확인 (PR push 후)

## 리뷰 포인트

1. **smoke 명령 선택** — `--help` (전역) + `auth login claude --help` 두 개만. status / usage / doctor 같은 network 의존 명령은 의도적 제외(실제 HTTP 요청 발생). "binary가 부팅하고 dispatcher가 동작한다" 수준의 검증.
2. **3 tarball 동시 install** — `npm install ./packs/*.tgz` 한 번에 셋을 주면 npm이 fs path로 cross-resolve. 단독 install은 미발행 상태에서 fail.
3. **HOME tmp override** — `~/.config/ai-usage-agent/auth.json` 절대 접근 안 함 (smoke.test.js와 동일 패턴).
4. **CI 통합 위치** — 별도 workflow 파일 대신 `ci.yml`에 새 job. #76에서 release-time 재실행 필요해지면 reusable workflow로 승격 가능. 현 시점에는 단일 workflow가 단순.
5. **changeset 미추가** — CI 인프라 변경 = 사용자-가시 변경 아님 (release-policy.md의 chore/CI 제외 정책).

## 참고 사항

- 의도적 회귀 시연: 임시로 `packages/agent/src/index.js`에 cross-workspace 상대 import를 추가해 install-smoke job이 fail하는지 사용자가 직접 검증 가능 (PR description에 캡처는 없음 — 필요 시 별도 PR로).
- branch protection settings에서 `install-smoke` status check를 required로 추가하면 PR merge gate가 됨 — **별도 user action**.
- 후속 #76(publish 자동화)에서 `release.yml`에 `bash scripts/install-smoke.sh` 한 줄로 동일 검증 재사용.