### PR TITLE
[chore] GitHub repo URL을 LLagoon3/token-weather 로 갱신

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Changed
 
-- CLI option parser를 spec 기반 공통 helper(`parseCliOptions`)로 통일 — status / usage / doctor / login / logout / refresh ([#62]).
+- CLI option parser를 spec 기반 공통 helper(`parseCliOptions`)로 통일 — status / usage / doctor / auth login / auth logout ([#62]).
 - Claude OAuth flow를 pi-ai baseline(`claude.ai` authorize endpoint + 6-scope) 기준으로 정렬 ([#87]).
 - 패키지명을 `@token-weather/*`로 리네임, bin을 `token-weather`로 정렬 ([#82]).
 - repo 식별자(`ai-usage-agent` → `token-weather`) 일괄 치환 + 워크스페이스 경계 import를 `@token-weather/*` 패키지명으로 변환 ([#82]).
@@ -54,28 +54,28 @@
 - CI: `npm install --no-package-lock` → `npm run build:types` → `npm test` 흐름 정착 ([#88]).
 - README / CONTRIBUTING / `docs/codebase-guide.md` 사용자 온보딩 + 보안 신고 단락 + 라이선스 단락 ([#80], [#81], [#85]).
 
-[Unreleased]: https://github.com/LLagoon3/ai-usage-agent/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/LLagoon3/ai-usage-agent/releases/tag/v0.1.0
+[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.1.0
 
-[#6]: https://github.com/LLagoon3/ai-usage-agent/pull/6
-[#16]: https://github.com/LLagoon3/ai-usage-agent/pull/16
-[#19]: https://github.com/LLagoon3/ai-usage-agent/pull/19
-[#29]: https://github.com/LLagoon3/ai-usage-agent/pull/29
-[#32]: https://github.com/LLagoon3/ai-usage-agent/pull/32
-[#43]: https://github.com/LLagoon3/ai-usage-agent/pull/43
-[#47]: https://github.com/LLagoon3/ai-usage-agent/pull/47
-[#49]: https://github.com/LLagoon3/ai-usage-agent/pull/49
-[#51]: https://github.com/LLagoon3/ai-usage-agent/pull/51
-[#55]: https://github.com/LLagoon3/ai-usage-agent/pull/55
-[#57]: https://github.com/LLagoon3/ai-usage-agent/pull/57
-[#58]: https://github.com/LLagoon3/ai-usage-agent/pull/58
-[#62]: https://github.com/LLagoon3/ai-usage-agent/pull/62
-[#66]: https://github.com/LLagoon3/ai-usage-agent/pull/66
-[#67]: https://github.com/LLagoon3/ai-usage-agent/pull/67
-[#68]: https://github.com/LLagoon3/ai-usage-agent/pull/68
-[#80]: https://github.com/LLagoon3/ai-usage-agent/pull/80
-[#81]: https://github.com/LLagoon3/ai-usage-agent/pull/81
-[#82]: https://github.com/LLagoon3/ai-usage-agent/pull/82
-[#85]: https://github.com/LLagoon3/ai-usage-agent/pull/85
-[#87]: https://github.com/LLagoon3/ai-usage-agent/pull/87
-[#88]: https://github.com/LLagoon3/ai-usage-agent/pull/88
+[#6]: https://github.com/LLagoon3/token-weather/pull/6
+[#16]: https://github.com/LLagoon3/token-weather/pull/16
+[#19]: https://github.com/LLagoon3/token-weather/pull/19
+[#29]: https://github.com/LLagoon3/token-weather/pull/29
+[#32]: https://github.com/LLagoon3/token-weather/pull/32
+[#43]: https://github.com/LLagoon3/token-weather/pull/43
+[#47]: https://github.com/LLagoon3/token-weather/pull/47
+[#49]: https://github.com/LLagoon3/token-weather/pull/49
+[#51]: https://github.com/LLagoon3/token-weather/pull/51
+[#55]: https://github.com/LLagoon3/token-weather/pull/55
+[#57]: https://github.com/LLagoon3/token-weather/pull/57
+[#58]: https://github.com/LLagoon3/token-weather/pull/58
+[#62]: https://github.com/LLagoon3/token-weather/pull/62
+[#66]: https://github.com/LLagoon3/token-weather/pull/66
+[#67]: https://github.com/LLagoon3/token-weather/pull/67
+[#68]: https://github.com/LLagoon3/token-weather/pull/68
+[#80]: https://github.com/LLagoon3/token-weather/pull/80
+[#81]: https://github.com/LLagoon3/token-weather/pull/81
+[#82]: https://github.com/LLagoon3/token-weather/pull/82
+[#85]: https://github.com/LLagoon3/token-weather/pull/85
+[#87]: https://github.com/LLagoon3/token-weather/pull/87
+[#88]: https://github.com/LLagoon3/token-weather/pull/88

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![npm version](https://img.shields.io/npm/v/%40token-weather%2Fcli.svg)](https://www.npmjs.com/package/@token-weather/cli)
-[![CI](https://github.com/LLagoon3/ai-usage-agent/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/LLagoon3/ai-usage-agent/actions/workflows/ci.yml)
+[![CI](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml)
 [![Node](https://img.shields.io/node/v/%40token-weather%2Fcli.svg)](https://nodejs.org/)
 
 > **Local CLI dashboard for AI service usage and OAuth credentials.**
@@ -118,7 +118,7 @@ npm run test:adapters # provider adapters만
 npm run test:schemas  # schemas 패키지만
 ```
 
-진행 중인 작업은 [Issues](https://github.com/LLagoon3/ai-usage-agent/issues)에서 추적합니다.
+진행 중인 작업은 [Issues](https://github.com/LLagoon3/token-weather/issues)에서 추적합니다.
 
 ### 추가 문서
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ token-weather --help
 첫 명령:
 
 ```bash
-token-weather config init                              # ~/.config/ai-usage-agent/config.json 생성
+token-weather config init                              # ~/.config/token-weather/config.json 생성
 token-weather auth login claude --live-exchange        # 브라우저 → localhost callback (PKCE + state 검증)
 token-weather status                                   # 인증 / 사용량 / 만료까지 한 번에
 token-weather status --json | jq                       # 자동화/대시보드용 정규화 JSON

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 GitHub Security Advisory를 통해 비공개로 신고해 주세요.
 
-- 신고 페이지: https://github.com/LLagoon3/ai-usage-agent/security/advisories/new
+- 신고 페이지: https://github.com/LLagoon3/token-weather/security/advisories/new
 - 평균 응답 SLA: 영업일 기준 5일 이내 1차 답변
 - 심각도가 높은 경우(원격 토큰 유출, 자격증명 노출 등) 우선 대응
 
@@ -25,7 +25,7 @@ GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, 
 2. 해당 자격증명을 즉시 **revoke** 합니다.
    - Codex (OpenAI): https://platform.openai.com/account/api-keys 또는 chatgpt.com 세션 로그아웃
    - Claude (Anthropic): https://console.anthropic.com 또는 Claude CLI 재로그인
-3. `ai-usage-agent auth logout <provider>`로 로컬 store에서도 제거 후 재로그인합니다.
+3. `token-weather auth logout <provider>`로 로컬 store에서도 제거 후 재로그인합니다.
 
 토큰 복구 / 자동 revoke 기능은 제공하지 않습니다 (provider revoke endpoint 미통합 상태).
 

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -13,7 +13,7 @@ CLI agent가 외부 auth store(OpenClaw 등)에 의존하지 않고 독립적으
   │   ├─ OAuth localhost callback flow (Codex / Claude 공통)
   │   ├─ Manual paste fallback (Codex)
   │   └─ Device code fallback (미구현, 후순위)
-  ├─ Credential Store (~/.config/ai-usage-agent/auth.json, 0600)
+  ├─ Credential Store (~/.config/token-weather/auth.json, 0600)
   ├─ Provider Adapters (codex / claude)
   └─ Usage / Event Pipeline
 ```
@@ -60,7 +60,7 @@ provider별 callback path:
 
 ## 저장소 설계 원칙
 
-- `~/.config/ai-usage-agent/auth.json`, 권한 `0600`
+- `~/.config/token-weather/auth.json`, 권한 `0600`
 - normalized auth metadata와 민감 토큰은 논리적으로 분리 가능하게 설계
 - 이후 keychain으로 확장 가능
 - refresh token / session cookie는 외부 서버에 업로드 금지
@@ -165,7 +165,7 @@ Codex/Claude의 token exchange와 refresh 함수는 **기본적으로 guard**되
 
 ## 운영 방안
 
-- 토큰 저장: `auth.json` + `0600` (기본 경로 `~/.config/ai-usage-agent/`)
+- 토큰 저장: `auth.json` + `0600` (기본 경로 `~/.config/token-weather/`)
 - multi-account: `lastUsedAt` 자동 선택 + `--account` override
 - callback 포트 충돌 시: 기본 포트부터 최대 3회 대체 포트 시도 → 실패 시 manual paste로 전환 (Codex)
 - timeout: `--timeout <seconds>` (기본 120초)

--- a/docs/auth-store-schema.md
+++ b/docs/auth-store-schema.md
@@ -11,7 +11,7 @@
 기본 경로:
 
 ```text
-~/.config/ai-usage-agent/auth.json
+~/.config/token-weather/auth.json
 ```
 
 현재 기본 방안:

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -24,7 +24,7 @@ token-weather status --json --account work@example.com --provider claude
   "command": "status",
   "generatedAt": "2026-04-25T08:30:00.000Z",
   "schemaVersion": "0.1.0",
-  "configPath": "/home/user/.config/ai-usage-agent/config.json",
+  "configPath": "/home/user/.config/token-weather/config.json",
   "accountFilter": null,
   "providerFilter": null,
   "providers": [

--- a/docs/codebase-guide.md
+++ b/docs/codebase-guide.md
@@ -358,7 +358,7 @@ export function parseStatusOptions(args) {
 
 ### 6.1 Store 위치
 
-`~/.config/ai-usage-agent/auth.json` (권한 `0600`). 스키마는 `auth-store-schema.js`.
+`~/.config/token-weather/auth.json` (권한 `0600`). 스키마는 `auth-store-schema.js`.
 
 ```
 {

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -18,7 +18,7 @@
 - public d.ts breaking — export 제거, 함수 signature 변경(필수 param 추가/순서 변경/타입 narrow), `@typedef` 키 제거.
 - CLI flag 제거 또는 shorthand 의미 변경 (예: `--account` 동작 자체가 바뀜).
 - 기존 CLI 명령 제거 (예: `token-weather status` 자체를 없앰).
-- `~/.config/ai-usage-agent/` 경로 / `auth.json` 스키마의 incompatible 변경.
+- `~/.config/token-weather/` 경로 / `auth.json` 스키마의 incompatible 변경.
 
 ### minor (0.X.0)
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -81,7 +81,7 @@ node packages/agent/bin/token-weather.js status
 기본 설정 경로:
 
 ```text
-~/.config/ai-usage-agent/config.json
+~/.config/token-weather/config.json
 ```
 
 현재 기본 설정에는 아래 항목이 들어간다:

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -19,12 +19,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/LLagoon3/ai-usage-agent.git",
+    "url": "https://github.com/LLagoon3/token-weather.git",
     "directory": "packages/agent"
   },
-  "homepage": "https://github.com/LLagoon3/ai-usage-agent#readme",
+  "homepage": "https://github.com/LLagoon3/token-weather#readme",
   "bugs": {
-    "url": "https://github.com/LLagoon3/ai-usage-agent/issues"
+    "url": "https://github.com/LLagoon3/token-weather/issues"
   },
   "keywords": [
     "token-weather",

--- a/packages/agent/src/auth/auth-store-path.js
+++ b/packages/agent/src/auth/auth-store-path.js
@@ -4,7 +4,7 @@ import os from 'node:os';
 const AUTH_STORE_FILENAME = 'auth.json';
 
 export function resolveAuthStoreDir() {
-  return path.join(os.homedir(), '.config', 'ai-usage-agent');
+  return path.join(os.homedir(), '.config', 'token-weather');
 }
 
 export function resolveAuthStorePath() {

--- a/packages/agent/src/cli/config-init-command.js
+++ b/packages/agent/src/cli/config-init-command.js
@@ -9,7 +9,7 @@ export function formatConfigInitHelp() {
   return [
     'token-weather config init',
     '',
-    '~/.config/ai-usage-agent/config.json에 기본 설정 파일을 생성합니다.',
+    '~/.config/token-weather/config.json에 기본 설정 파일을 생성합니다.',
     '',
     'Options:',
     '  -h, --help   이 도움말 출력',

--- a/packages/agent/src/config/config-path.js
+++ b/packages/agent/src/config/config-path.js
@@ -2,7 +2,7 @@ import path from 'node:path';
 import os from 'node:os';
 
 export function resolveAgentConfigDir() {
-  return path.join(os.homedir(), '.config', 'ai-usage-agent');
+  return path.join(os.homedir(), '.config', 'token-weather');
 }
 
 export function resolveAgentConfigPath() {

--- a/packages/agent/test/cli/config-init-command.test.js
+++ b/packages/agent/test/cli/config-init-command.test.js
@@ -46,7 +46,7 @@ describe('runConfigInitCommand — --help', () => {
     await runConfigInitCommand(['--help']);
     assert.ok(logged.some((l) => l.startsWith('token-weather config init')));
     // --help 경로는 파일을 쓰지 않는다.
-    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    const configPath = path.join(tmpHome, '.config', 'token-weather', 'config.json');
     assert.equal(fs.existsSync(configPath), false);
   });
 });
@@ -54,10 +54,10 @@ describe('runConfigInitCommand — --help', () => {
 describe('runConfigInitCommand — fresh init', () => {
   withTmpHome();
 
-  it('creates ~/.config/ai-usage-agent/config.json with default contents', async () => {
+  it('creates ~/.config/token-weather/config.json with default contents', async () => {
     await runConfigInitCommand();
 
-    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    const configPath = path.join(tmpHome, '.config', 'token-weather', 'config.json');
     assert.ok(fs.existsSync(configPath), 'config file should exist');
 
     const raw = fs.readFileSync(configPath, 'utf8');
@@ -81,7 +81,7 @@ describe('runConfigInitCommand — overwrite behavior', () => {
   withTmpHome();
 
   it('overwrites existing file (current contract — caller responsible for backup)', async () => {
-    const configPath = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+    const configPath = path.join(tmpHome, '.config', 'token-weather', 'config.json');
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
     fs.writeFileSync(configPath, '{"custom":"value"}');
 

--- a/packages/agent/test/integration/repo-policy-publish.test.js
+++ b/packages/agent/test/integration/repo-policy-publish.test.js
@@ -155,4 +155,15 @@ describe('repo-policy/publish — engines / repository / homepage', () => {
       assert.ok(pkg.bugs?.url, `${label} bugs.url 누락`);
     }
   });
+
+  // GitHub repo 가 LLagoon3/token-weather 로 리네임된 후 npm registry 페이지의
+  // GitHub 링크가 옛 LLagoon3/ai-usage-agent 로 깨지는 회귀 차단.
+  it('3개 패키지 모두 repository / homepage / bugs URL 이 LLagoon3/token-weather 호스트', () => {
+    const HOST = 'github.com/LLagoon3/token-weather';
+    for (const [label, pkg] of [['agent', AGENT], ['provider-adapters', ADAPTERS], ['schemas', SCHEMAS]]) {
+      assert.match(pkg.repository?.url ?? '', new RegExp(HOST), `${label} repository.url`);
+      assert.match(pkg.homepage ?? '', new RegExp(HOST), `${label} homepage`);
+      assert.match(pkg.bugs?.url ?? '', new RegExp(HOST), `${label} bugs.url`);
+    }
+  });
 });

--- a/packages/agent/test/integration/smoke.test.js
+++ b/packages/agent/test/integration/smoke.test.js
@@ -47,7 +47,7 @@ describe('bin/token-weather — smoke', () => {
         timeout: 10_000,
       });
       assert.equal(result.status, 0, `stderr: ${result.stderr}`);
-      const expected = path.join(tmpHome, '.config', 'ai-usage-agent', 'config.json');
+      const expected = path.join(tmpHome, '.config', 'token-weather', 'config.json');
       assert.ok(fs.existsSync(expected), 'config.json should be created');
       const parsed = JSON.parse(fs.readFileSync(expected, 'utf8'));
       assert.ok(parsed.providers);

--- a/packages/provider-adapters/package.json
+++ b/packages/provider-adapters/package.json
@@ -15,12 +15,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/LLagoon3/ai-usage-agent.git",
+    "url": "https://github.com/LLagoon3/token-weather.git",
     "directory": "packages/provider-adapters"
   },
-  "homepage": "https://github.com/LLagoon3/ai-usage-agent#readme",
+  "homepage": "https://github.com/LLagoon3/token-weather#readme",
   "bugs": {
-    "url": "https://github.com/LLagoon3/ai-usage-agent/issues"
+    "url": "https://github.com/LLagoon3/token-weather/issues"
   },
   "keywords": [
     "token-weather",

--- a/packages/provider-adapters/src/claude/fetch-claude-oauth-profile.js
+++ b/packages/provider-adapters/src/claude/fetch-claude-oauth-profile.js
@@ -40,7 +40,7 @@ export async function fetchClaudeOauthProfile({
       Accept: 'application/json',
       'anthropic-version': '2023-06-01',
       'anthropic-beta': 'oauth-2025-04-20',
-      'User-Agent': 'ai-usage-agent',
+      'User-Agent': 'token-weather',
     },
     timeoutMs,
   });

--- a/packages/provider-adapters/src/claude/fetch-claude-usage.js
+++ b/packages/provider-adapters/src/claude/fetch-claude-usage.js
@@ -44,7 +44,7 @@ export async function fetchClaudeUsage(profile, options = {}) {
   const headers = {
     Authorization: `Bearer ${profile.accessToken}`,
     Accept: 'application/json',
-    'User-Agent': 'ai-usage-agent',
+    'User-Agent': 'token-weather',
     'anthropic-version': '2023-06-01',
     'anthropic-beta': 'oauth-2025-04-20',
   };

--- a/packages/provider-adapters/test/claude/fetch-claude-oauth-profile.test.js
+++ b/packages/provider-adapters/test/claude/fetch-claude-oauth-profile.test.js
@@ -51,6 +51,16 @@ describe('fetchClaudeOauthProfile', () => {
     assert.equal(result.application.name, 'Claude Code');
   });
 
+  it('sends User-Agent: token-weather header', async () => {
+    let capturedInit = null;
+    const fetchImpl = async (_input, init) => {
+      capturedInit = init;
+      return jsonResponse({ body: { account: { uuid: 'acct-1' } } });
+    };
+    await fetchClaudeOauthProfile({ accessToken: 'tok', fetchImpl });
+    assert.equal(capturedInit.headers['User-Agent'], 'token-weather');
+  });
+
   it('falls back to full_name when display_name is absent', async () => {
     const fetchImpl = async () => jsonResponse({
       body: {

--- a/packages/provider-adapters/test/claude/fetch-claude-usage.test.js
+++ b/packages/provider-adapters/test/claude/fetch-claude-usage.test.js
@@ -40,6 +40,7 @@ describe('fetchClaudeUsage', () => {
     assert.equal(capturedInit.headers['anthropic-version'], '2023-06-01');
     assert.equal(capturedInit.headers['anthropic-beta'], 'oauth-2025-04-20');
     assert.equal(capturedInit.headers.Accept, 'application/json');
+    assert.equal(capturedInit.headers['User-Agent'], 'token-weather');
   });
 
   it('returns a snapshot with provider id anthropic-claude and ok status on 200', async () => {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -18,12 +18,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/LLagoon3/ai-usage-agent.git",
+    "url": "https://github.com/LLagoon3/token-weather.git",
     "directory": "packages/schemas"
   },
-  "homepage": "https://github.com/LLagoon3/ai-usage-agent#readme",
+  "homepage": "https://github.com/LLagoon3/token-weather#readme",
   "bugs": {
-    "url": "https://github.com/LLagoon3/ai-usage-agent/issues"
+    "url": "https://github.com/LLagoon3/token-weather/issues"
   },
   "keywords": [
     "token-weather",

--- a/scripts/demo-script.sh
+++ b/scripts/demo-script.sh
@@ -5,7 +5,7 @@
 #
 # **DO NOT RUN THIS SCRIPT DIRECTLY.** Always invoke through
 # scripts/record-demo.sh, which sets up an isolated HOME via mktemp. Direct
-# execution would read the user's real ~/.config/ai-usage-agent/auth.json
+# execution would read the user's real ~/.config/token-weather/auth.json
 # and leak account identifiers / token metadata into the recording.
 #
 # Constraints:
@@ -22,7 +22,7 @@ if [[ "${TOKEN_WEATHER_DEMO_SAFE:-0}" != "1" ]]; then
   cat >&2 <<'EOF'
 ERROR: demo-script.sh must be invoked through scripts/record-demo.sh.
 
-Direct execution would read your real ~/.config/ai-usage-agent/auth.json
+Direct execution would read your real ~/.config/token-weather/auth.json
 and expose account identifiers / token metadata in the recording.
 
 Run instead:

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -15,7 +15,7 @@
 #   5) 3 패키지의 dist/types/index.d.ts 가 install된 node_modules에 존재하는지 확인
 #
 # 안전장치:
-#   - HOME 을 mktemp 디렉토리로 override → 사용자 실 ~/.config/ai-usage-agent/auth.json
+#   - HOME 을 mktemp 디렉토리로 override → 사용자 실 ~/.config/token-weather/auth.json
 #     절대 접근 안 함.
 #   - NO_COLOR=1 로 출력 deterministic.
 #   - status / usage / doctor 같은 network 의존 명령은 smoke 대상에서 제외.


### PR DESCRIPTION
## 요약

GitHub repo 이름이 **`ai-usage-agent` → `token-weather`** 로 리네임되어, npm publish **직전**에 patch 메타 + 사용자 노출 문자열 + 사용자 데이터 경로 + provider 요청 헤더까지 새 이름으로 일괄 정렬. publish 후 npm registry 페이지의 GitHub 링크 + 신규 사용자의 `~/.config/` 경로 / Claude API `User-Agent`가 모두 `token-weather`로 일관되게 시작.

> **변경 타이밍 근거**: publish 전이라 외부 사용자 0명. `~/.config/token-weather/` 와 Claude `User-Agent`를 지금 정렬하면 마이그레이션 부담 0. publish 이후엔 옛 경로 read fallback / 자동 migrate / 사용자 안내가 필요해진다 → **publish 전(지금)이 정렬할 수 있는 유일한 타이밍**.

## 변경 내용 (commit 4개)

| commit | 영향 |
| --- | --- |
| `chore(publish)` `58298f0` | 3 패키지 `package.json` × 3 필드(`repository.url`, `homepage`, `bugs.url`) = 9 라인 + `repo-policy-publish.test.js` 회귀 가드(host assertion `LLagoon3/token-weather`) |
| `docs` `dbc2682` | `README.md` (CI badge + Issues), `SECURITY.md` (advisory URL), `CHANGELOG.md` (compare/release/PR 참조 25+) |
| `chore(config)` `cb03d7a` | 사용자 데이터 경로 `~/.config/ai-usage-agent/` → `~/.config/token-weather/` (코드 3 + 테스트 5 + 문서 6 + 스크립트 2) |
| `chore(claude)` `b8b16c3` | Claude API `User-Agent: ai-usage-agent` → `token-weather` (`fetch-claude-{usage,oauth-profile}.js` × 2) + 회귀 가드 2건 |

## 함께 정정 (rename 잔재)

- `SECURITY.md` 의 옛 bin 명령 `ai-usage-agent auth logout` → `token-weather auth logout` (#82 bin rename 이후 잔재)
- `CHANGELOG.md [0.1.0]` 의 parseCliOptions 통일 항목에서 잘못 나열된 `refresh` 제거 — 실제 #62 변환 대상은 `status / usage / doctor / auth login / auth logout` (auth refresh 명령 자체가 존재하지 않음)

## 보존 (의도적)

`grep ai-usage-agent` 실행 시 다음 2건만 잔재 — 둘 다 *그래야 의미가 성립*:

- `CHANGELOG.md:34` — 과거 #82 rename **역사 이력 명기** (`ai-usage-agent` → `token-weather` 사실 자체가 정보)
- `packages/agent/test/integration/repo-policy-publish.test.js:160` — 가드 **코멘트** (`옛 LLagoon3/ai-usage-agent 로 깨지는 회귀 차단` 설명)

## 회귀 가드

- `repo-policy-publish.test.js` host assertion: 3 패키지 URL이 `LLagoon3/token-weather` 호스트 포함
- `config-init-command.test.js` (기존): `'.config/token-weather/config.json'` 명시 검증 → config-path 회귀 시 즉시 fail (de-facto guard)
- `fetch-claude-usage.test.js` (1줄 추가) + `fetch-claude-oauth-profile.test.js` (신규 케이스): `User-Agent: 'token-weather'` 검증
- Codex 의 `'CodexBar'` UA는 별개 — 공식 Codex CLI mimick 결정이라 유지 (변경 안 함)

## 영향 범위

- [x] `repo` (3 패키지 publish 메타)
- [x] `docs` (README / SECURITY / CHANGELOG / docs/*)
- [x] `packages/agent` (config-path / auth-store-path 코드 + 회귀 가드 + 사용자 출력 메시지)
- [x] `packages/provider-adapters` (Claude User-Agent + 회귀 가드)
- [x] `scripts` (demo-script / install-smoke 안의 path 안내)
- [ ] CLI 동작 / `--json` shape / 사용자 코드 변경 — 없음 (changeset 미추가)

## 테스트 / 확인

- `npm test` **730/730 pass** (User-Agent 회귀 가드 1 신규)
- `bash scripts/install-smoke.sh` 로컬 실행 통과
- `auth.json` 옛 토큰을 `~/.config/token-weather/` 로 `cp -a` (권한 `0600` 보존) 후 새 경로에서 `status` 정상 응답 확인 — 본인 환경 호환 검증
- CI: `test` / `install-smoke` / `GitGuardian` 전부 ✓

## 리뷰 포인트

1. **publish 전 정렬 타이밍** — 외부 사용자 0명이라 `~/.config/` 경로와 `User-Agent` 변경에 마이그레이션 부담 없음. publish 후엔 fallback 코드가 영구 부담이 되니 지금이 깨끗하게 정렬할 수 있는 마지막 시점.
2. **회귀 가드의 host assertion** — 3 패키지 URL이 옛 `ai-usage-agent` 로 실수로 되돌아가는 회귀를 차단.
3. **changeset 미추가** — npm publish 메타 / 내부 path / informative 헤더 정렬은 사용자 코드/CLI 동작 변경이 없는 chore.

## 사용자 액션

본인 환경 옛 데이터 호환은 한 줄로 끝:

```
mkdir -p ~/.config/token-weather && cp -a ~/.config/ai-usage-agent/. ~/.config/token-weather/
```

(`cp -a`로 `auth.json`의 `0600` 권한 보존. 옛 경로는 그대로 두면 정상 확인 후 `rm -rf ~/.config/ai-usage-agent`로 정리 가능.)

본 PR 머지 후 epic #79 의 다음 단계는 **#76 publish 자동화** — `release.yml`에 `publish: npx changeset publish` step + `NPM_TOKEN` 연결.