### PR TITLE
[ci] release publish step + provenance 활성화 (#76 + #77 통합)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
 # dev 브랜치 push 시 누적된 .changeset/*.md 를 모아 release PR(version bump +
-# CHANGELOG entry)을 자동 생성/갱신한다. 본 워크플로는 release PR 작성까지만
-# 책임진다 — 실제 npm publish 자동화는 #76에서 'publish' step 추가 예정.
+# CHANGELOG entry)을 자동 생성/갱신한다. 그 release PR이 머지되면 install
+# smoke 통과 후 changesets/action 이 npm publish 를 자동 실행한다.
 #
 # 정책 / 카테고리 / SCHEMA_VERSION 기준은 docs/release-policy.md.
 
@@ -28,12 +28,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - run: npm install --no-package-lock
+
+      # publish 직전 안전벨트 — #75 에서 도입한 install smoke 스크립트 재사용.
+      # release PR 머지 직후 changesets/action 이 publish 를 호출하기 전에
+      # 한 번 더 npm pack → tmp install → bin smoke + d.ts/import 검증.
+      # smoke fail 시 set -e 로 publish 차단.
+      - run: bash ./scripts/install-smoke.sh
 
       - uses: changesets/action@v1
         with:
           version: npx changeset version
-          # publish step은 #76(릴리스 자동화)에서 추가
+          publish: npx changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write   # npm provenance (OIDC) — supply chain attestation
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,3 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # changesets 가 호출하는 npm publish 가 --provenance 플래그를 자동
+          # 적용하도록 한다 (npm 9.5+ 가 인식). id-token: write OIDC 권한과
+          # 함께 첫 publish 부터 supply chain attestation 보장.
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -121,3 +121,4 @@ CHANGELOG는 두 layer로 운영한다 — Changesets 기본 동작에 맞춰서
 - 2026-04-27 (#74): 초안 작성. v0.1.0 publish 직전 상태에서 정책 명문화.
 - 2026-04-28 (#74 review follow-up): root CHANGELOG는 수동 큐레이트, per-package CHANGELOG는 Changesets 자동 생성으로 layer 구분 명문화.
 - 2026-04-28 (#76): publish step 활성화 — `release.yml`에 `npx changeset publish` + `NPM_TOKEN` 연결 + install smoke (#75) 안전벨트 재호출. release PR 머지 시 자동 npm publish.
+- 2026-04-28 (#76 + #77 통합): npm publish provenance 활성화 — `release.yml` job 에 `id-token: write` 권한 + changesets/action env 에 `NPM_CONFIG_PROVENANCE: 'true'` 추가. 첫 publish 부터 supply chain attestation 적용. (#77 별도 이슈는 본 PR 로 흡수 close.)

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -113,10 +113,11 @@ CHANGELOG는 두 layer로 운영한다 — Changesets 기본 동작에 맞춰서
 1. PR 작성자가 `npx changeset` 실행 → `.changeset/<name>.md` 생성 + commit.
 2. PR이 dev로 머지되면 `changesets/action`이 누적된 changeset을 모아 release PR(`packages/*/package.json` version bump + `packages/*/CHANGELOG.md` 갱신)을 자동 생성/갱신.
 3. release PR을 검토하면서 root [CHANGELOG.md](../CHANGELOG.md)의 `[Unreleased]` 섹션을 per-package 변경 요약 기준으로 **수동** 갱신 후 머지.
-4. 실제 npm publish는 `#76`(릴리스 자동화)에서 추가될 publish step이 처리. 본 PR(#74)은 release PR 생성까지.
-5. v1.0.0 이상에서는 dev → main 머지가 release tag와 연결.
+4. release PR 머지 시 `release.yml`이 `bash ./scripts/install-smoke.sh` 안전벨트(#75)를 한 번 더 실행하고, `changesets/action`의 publish step이 `npx changeset publish`로 npm registry에 자동 출판한다. 3 publishable 패키지(`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas`)가 동일 version으로 출판된다(linked).
+5. publish 결과는 `changesets/action`이 GitHub Release 자동 생성 — release note는 per-package CHANGELOG 기반. v1.0.0 이상에서는 dev → main 머지가 release tag와 연결.
 
 ## 6. 변경 이력
 
 - 2026-04-27 (#74): 초안 작성. v0.1.0 publish 직전 상태에서 정책 명문화.
 - 2026-04-28 (#74 review follow-up): root CHANGELOG는 수동 큐레이트, per-package CHANGELOG는 Changesets 자동 생성으로 layer 구분 명문화.
+- 2026-04-28 (#76): publish step 활성화 — `release.yml`에 `npx changeset publish` + `NPM_TOKEN` 연결 + install smoke (#75) 안전벨트 재호출. release PR 머지 시 자동 npm publish.

--- a/packages/agent/test/integration/repo-policy-release.test.js
+++ b/packages/agent/test/integration/repo-policy-release.test.js
@@ -95,10 +95,23 @@ describe('repo-policy/release — release workflow (PR #74)', () => {
     assert.match(text, /uses:\s*changesets\/action/);
   });
 
-  it('release.yml 에 publish step 이 아직 없다 (의도적 — #76 범위)', () => {
+  // #76에서 publish step 활성화. 'publish: <command>' yaml key 가 changesets/
+  // action with: 블록에 들어오면 release PR 머지 시 실제 npm publish 실행.
+  it('release.yml 에 publish step 이 활성화되어 있다 (#76)', () => {
     const text = readText('.github/workflows/release.yml');
-    // 'publish: <command>' 형태의 yaml key가 changesets/action with: 블록에
-    // 들어오는 순간 실제 npm publish가 실행됨. 본 PR(#74)에서는 명시적 미포함.
-    assert.equal(/^\s*publish:\s*\S/m.test(text), false);
+    assert.match(text, /^\s*publish:\s+npx\s+changeset\s+publish/m);
+  });
+
+  it('release.yml 이 NPM_TOKEN 을 changesets/action env 로 주입한다 (#76)', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /NPM_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/);
+  });
+
+  // publish 직전 안전벨트로 install smoke 스크립트 재호출 (#75 산출물).
+  // 도메인 분리: ci.yml install-smoke job 검증은 repo-policy-install-smoke.test.js,
+  // 본 단언은 release.yml 의 publish-time 호출만 가드한다.
+  it('release.yml 이 publish 직전 install smoke 를 호출한다 (#76)', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /bash\s+\.\/scripts\/install-smoke\.sh/);
   });
 });

--- a/packages/agent/test/integration/repo-policy-release.test.js
+++ b/packages/agent/test/integration/repo-policy-release.test.js
@@ -114,4 +114,17 @@ describe('repo-policy/release — release workflow (PR #74)', () => {
     const text = readText('.github/workflows/release.yml');
     assert.match(text, /bash\s+\.\/scripts\/install-smoke\.sh/);
   });
+
+  // npm publish provenance (OIDC) — #77 을 #76 에 흡수.
+  // id-token: write 권한 + NPM_CONFIG_PROVENANCE: 'true' 가 함께 있어야
+  // changesets 가 호출하는 npm publish 에 supply chain attestation 적용.
+  it('release.yml job 이 id-token: write 권한을 갖는다 (#77 provenance)', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /^\s*id-token:\s*write/m);
+  });
+
+  it('release.yml 이 NPM_CONFIG_PROVENANCE 를 활성화한다 (#77 provenance)', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /NPM_CONFIG_PROVENANCE:\s*['"]?true['"]?/);
+  });
 });


### PR DESCRIPTION
closes #76
closes #77

## 요약

`#74`에서 만든 `release.yml`은 `version` step만 활성화돼 release PR 생성/갱신까지만 했다. 본 PR이 **publish step + npm provenance를 함께 wire**해 release 자동화를 완성한다. T2 시리즈의 마지막 운영 단계 (#75 install smoke → **#76 publish + #77 provenance 통합**).

> **중요 — 머지 직후 동작**: `changesets/action@v1`의 표준 동작은 base branch push 시 누적 changeset 0건이면 `publish` step을 즉시 실행한다. 따라서 본 PR이 dev에 머지되는 순간 release workflow가 돌면서 **첫 v0.1.0 publish가 자동 발생**한다. provenance가 같은 PR에 wire되어 있어 첫 출판부터 supply chain attestation이 적용된다.

사용자 측 선결 액션 모두 완료된 상태:
- npm `@token-weather` organization 등록 ✓
- `NPM_TOKEN` GitHub Actions secret 등록 ✓
- repo rename 메타 정렬 (#91) ✓

## 변경 내용

| commit | scope |
| --- | --- |
| `ci(release)` | `release.yml` 4가지 변경: `registry-url` / install-smoke pre-publish / `publish: npx changeset publish` / `NPM_TOKEN` env |
| `test(repo-policy)` | `repo-policy-release.test.js` 가드 뒤집기 + 신규 (publish step + NPM_TOKEN + install smoke 호출) |
| `docs(release)` | `release-policy.md` §5 step 4-5 흐름 갱신 + §6 이력 |
| `ci(release)` | **provenance 흡수** — `id-token: write` 권한 + `NPM_CONFIG_PROVENANCE: 'true'` env + 회귀 가드 2건 + §6 이력 |

## 동작 흐름 (활성화 후)

1. PR 작성자가 `npx changeset` 으로 release note 누적 + commit
2. PR이 dev로 머지되면 `changesets/action`이 release PR(version bump + per-package CHANGELOG) 자동 생성/갱신
3. release PR 검토 + 루트 CHANGELOG `[Unreleased]` 수동 큐레이트 후 머지
4. **release PR 머지 시 install smoke (#75) 안전벨트 → `npx changeset publish` → 3 패키지가 동일 version으로 npm registry에 provenance 적용된 채로 출판** (linked)
5. `changesets/action`이 GitHub Release 자동 생성 (release note는 per-package CHANGELOG 기반)

## **본 PR 머지 직후 흐름** (첫 publish)

1. 본 PR이 dev로 머지
2. release workflow 자동 trigger
3. install smoke 실행 → 통과
4. `changesets/action`이 누적 changeset 0건 detect → publish 모드로 동작
5. `npx changeset publish` 실행 → npm registry query → `@token-weather/{cli,provider-adapters,schemas}@0.1.0` 미게시 확인 → **첫 v0.1.0 publish 발생**
6. `NPM_CONFIG_PROVENANCE='true'` + `id-token: write` 권한이 함께 있어 **provenance 적용**된 채로 출판
7. `changesets/action`이 GitHub Release 자동 생성

## 회귀 가드

`repo-policy-release.test.js` (9 → 13 tests):
- ✅ `publish: npx changeset publish` 라인 존재 (#74의 '부재' 가드 뒤집기)
- ✅ `NPM_TOKEN` env 주입
- ✅ `bash ./scripts/install-smoke.sh` step 존재
- ✅ `id-token: write` 권한 존재 (#77 흡수)
- ✅ `NPM_CONFIG_PROVENANCE: 'true'` env 존재 (#77 흡수)

## 영향 범위

- [x] `.github/workflows/release.yml`
- [x] `packages/agent/test/integration/repo-policy-release.test.js`
- [x] `docs/release-policy.md`
- [ ] 사용자 코드 / CLI 동작 변경 — 없음 (changeset 미추가, CI/release 인프라)

## 테스트 / 확인

- `npm test` **734/734 pass**
- 본 PR 머지 직후 첫 publish 발생 후 검증 명령:
  ```
  npm view @token-weather/cli version            # 0.1.0
  npm view @token-weather/cli repository         # LLagoon3/token-weather
  npm view @token-weather/cli license            # Apache-2.0
  npm view @token-weather/cli dist.attestations  # provenance 검증
  npm install -g @token-weather/cli && token-weather --help
  ```

## 리뷰 포인트

1. **머지 직후 첫 publish 발생** — 의도. `changesets/action`의 표준 동작 그대로 받아들이고 provenance를 함께 wire해서 첫 publish부터 attestation 적용.
2. **#77 흡수 결정** — provenance 별도 PR로 분리하면 #76 머지 시점에 첫 publish가 attestation 없이 나가는 문제. 본 PR에 흡수가 가장 깔끔.
3. **`NPM_CONFIG_PROVENANCE` 환경변수 우회** — changesets CLI는 `--provenance` 플래그를 직접 받지 않으므로 npm config 환경변수가 표준 우회. npm 9.5+가 자동 인식.
4. **changeset 미추가** — CI/release 인프라 변경 (release-policy.md §1 chore 정책).

## 후속 (이 PR 범위 밖)

- **첫 publish 후 외부 검증**: 임의 환경에서 `npm install -g @token-weather/cli` + `--help` 한 줄 검증. epic #79 완료 정의 충족.
- **branch protection 운영**: dev / main에 changesets bot push 권한 부여 또는 PAT 사용 결정.
- **NPM_TOKEN 권한 범위 검증**: publish 권한만 가진 자동화 토큰인지 확인 권장 (read-only access 분리).