### PR TITLE
[fix] release.yml: npm CLI 11+ 로 업그레이드 (Trusted Publishing OIDC 요구사항)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,13 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: '@token-weather'
 
+      # npm Trusted Publishing(OIDC) 은 npm CLI 11+ 를 요구한다.
+      # actions/setup-node@v4 (node 22) 의 번들 npm 은 10.9.7 라 OIDC publish
+      # 인증이 PUT 404 로 거부됨 (이전 v0.2.0 release run 25059699115). 본
+      # repo 의 packageManager (root package.json) 와도 일관되게 11.x 사용.
+      - run: npm install -g npm@latest
+      - run: npm --version
+
       - run: npm install --no-package-lock
 
       # publish 직전 안전벨트 — #75 에서 도입한 install smoke 스크립트 재사용.

--- a/packages/agent/test/integration/repo-policy-release.test.js
+++ b/packages/agent/test/integration/repo-policy-release.test.js
@@ -118,6 +118,13 @@ describe('repo-policy/release — release workflow (PR #74)', () => {
     assert.match(text, /bash\s+\.\/scripts\/install-smoke\.sh/);
   });
 
+  // npm Trusted Publishing(OIDC) 은 npm CLI 11+ 를 요구한다. setup-node@v4
+  // 번들 npm (10.9.7) 으로는 publish 가 PUT 404 로 거부된다.
+  it('release.yml 이 npm 11+ 로 업그레이드한다 (Trusted Publishing OIDC 요구사항)', () => {
+    const text = readText('.github/workflows/release.yml');
+    assert.match(text, /npm install -g npm@/);
+  });
+
   // npm provenance (OIDC) — Trusted Publisher 등록 완료 후 재활성화.
   // id-token: write 권한 + NPM_CONFIG_PROVENANCE: 'true' 가 함께 있어야
   // changesets 가 호출하는 npm publish 에 supply chain attestation 적용.


### PR DESCRIPTION
## 요약

PR #99 (Version Packages) 머지 후 release workflow 가 PUT 404 로 v0.2.0 publish 에 실패. 원인은 **`actions/setup-node@v4` 번들 npm 이 10.9.7** — npm Trusted Publishing OIDC 인증은 npm CLI 11+ 를 요구.

## 변경 내용

`.github/workflows/release.yml` — `actions/setup-node` 다음에 한 step 추가:

\`\`\`yaml
- run: npm install -g npm@latest
- run: npm --version
\`\`\`

회귀 가드 1건 추가 (`repo-policy-release.test.js`).

## 근거

이전 release run [#25059699115](https://github.com/LLagoon3/token-weather/actions/runs/25059699115) 로그:
- provenance attestation 은 sigstore 에 등록됨 (`logIndex=1397207915/917`) → OIDC token 발급은 정상
- 그러나 npm 측 PUT 404 → npm CLI 가 OIDC publish 인증 패킷을 정상 보내지 못함
- npm v0.1.0 publish 시 docker 로그에서도 `New major version of npm available! 10.9.7 -> 11.13.0` 안내 등장

본 repo 의 root `package.json::packageManager: 'npm@11.6.2'` 와도 일관.

## 머지 후 자동 흐름

1. dev 머지 → release workflow trigger
2. setup-node → **npm 11+ 업그레이드** → install-smoke
3. `changesets/action`이 누적 changeset 0건 detect → publish 모드 진입
4. dev 의 `Version Packages` commit 으로 인해 v0.2.0 이 미게시 상태 → publish 시도
5. **첫 OIDC + provenance 적용 v0.2.0 publish 성공** 예상

## 검증

- `npm test` 통과 (회귀 가드 +1)
- `npm run lint` / `format:check` 통과
- 머지 후 release run 모니터링: `npm view @token-weather/cli version` → `0.2.0` + `dist.attestations` 검증

## 후속 (이 PR 범위 밖)

- ci.yml 에도 같은 npm bump step 일관 적용 검토 (test / install-smoke job)
- 만약 npm 11+ 적용에도 PUT 404 면 → Trusted Publisher 등록 정보 (repo / workflow filename / environment) 사용자 측 재검증