### PR TITLE
[fix] release.yml: Node 24 로 업그레이드 + npm self-upgrade step 제거

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Node 24 — 번들 npm 이 11+ 라 npm Trusted Publishing(OIDC) 요구사항을
+      # 자기 업그레이드 없이 충족한다. node 22 번들 npm 위에서 npm 자기 업그레이드
+      # step 자체가 native module 캐시 충돌(promise-retry 누락)로 깨졌던 회귀
+      # (release run 25079605613)를 회피.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           scope: '@token-weather'
 
-      # npm Trusted Publishing(OIDC) 은 npm CLI 11+ 를 요구한다.
-      # actions/setup-node@v4 (node 22) 의 번들 npm 은 10.9.7 라 OIDC publish
-      # 인증이 PUT 404 로 거부됨 (이전 v0.2.0 release run 25059699115). 본
-      # repo 의 packageManager (root package.json) 와도 일관되게 11.x 사용.
-      - run: npm install -g npm@latest
-      - run: npm --version
+      - run: node --version && npm --version
 
       - run: npm install --no-package-lock
 

--- a/packages/agent/test/integration/repo-policy-release.test.js
+++ b/packages/agent/test/integration/repo-policy-release.test.js
@@ -118,11 +118,21 @@ describe('repo-policy/release — release workflow (PR #74)', () => {
     assert.match(text, /bash\s+\.\/scripts\/install-smoke\.sh/);
   });
 
-  // npm Trusted Publishing(OIDC) 은 npm CLI 11+ 를 요구한다. setup-node@v4
-  // 번들 npm (10.9.7) 으로는 publish 가 PUT 404 로 거부된다.
-  it('release.yml 이 npm 11+ 로 업그레이드한다 (Trusted Publishing OIDC 요구사항)', () => {
+  // npm Trusted Publishing(OIDC) 은 npm CLI 11+ 를 요구한다. Node 24 의
+  // 번들 npm 이 11+ 라 self-upgrade 없이 요구사항 충족 — 'npm install -g
+  // npm@latest' 자체가 node 22 번들 npm 위에서 깨졌던 회귀(release run
+  // 25079605613, MODULE_NOT_FOUND promise-retry) 회피.
+  it('release.yml 이 Node 24 를 사용한다 (Trusted Publishing OIDC + npm 11+ 번들)', () => {
     const text = readText('.github/workflows/release.yml');
-    assert.match(text, /npm install -g npm@/);
+    assert.match(text, /node-version:\s*24/);
+  });
+
+  it('release.yml 에 npm self-upgrade step 이 없다 (회귀 차단)', () => {
+    const text = readText('.github/workflows/release.yml');
+    // global npm 자기 업그레이드 패턴은 release.yml 에 다시 들어오면 안 됨.
+    // (코멘트의 historical reference 도 false-positive 가 안 되도록 코멘트
+    // 처음에 'global npm 자기 업그레이드' 한국어 표현 사용.)
+    assert.equal(/^\s*-?\s*run:\s*npm install -g npm@/m.test(text), false);
   });
 
   // npm provenance (OIDC) — Trusted Publisher 등록 완료 후 재활성화.


### PR DESCRIPTION
## 요약

PR #100 으로 추가한 \`npm install -g npm@latest\` step 자체가 깨짐. 원인은 setup-node@v4 (node 22) 의 번들 npm 10.9.7 위에서 npm 11 자기 업그레이드 시 native module 캐시 충돌 (\`MODULE_NOT_FOUND: promise-retry\`, [release run 25079605613](https://github.com/LLagoon3/token-weather/actions/runs/25079605613)).

수정 — Node 24 로 올리고 자기 업그레이드 제거:
- Node 24 의 번들 npm 이 이미 11+ → Trusted Publishing OIDC 요구사항 자동 충족
- \`npm install -g npm@latest\` 두 step 삭제, 진단용으로 \`node --version && npm --version\` 한 줄

## 변경 내용

| commit | scope |
| --- | --- |
| \`fix(release)\` | \`release.yml\` 의 \`node-version: 22\` → \`24\`, npm self-upgrade 두 step 삭제, 회귀 가드 뒤집기 (Node 24 검증 + npm self-upgrade 부재 검증) |

## 머지 후 자동 흐름

1. dev 머지 → release workflow trigger
2. setup-node@v4 (node 24, npm 11+) → install-smoke 통과
3. \`changesets/action\` publish 모드 (누적 changeset 0건 + dev 의 \`Version Packages\` commit + v0.2.0 미게시)
4. npm 11+ 가 OIDC publish 인증 정상 송신 → **v0.2.0 publish 성공 예상**

## 사용자 측 추가 검증 (병렬)

리뷰에서 지적된 한 가지: npm Trusted Publisher 등록 시 패키지명 오타 가능성.

| 잘못 입력 가능 | 정확한 패키지명 |
|---|---|
| \`@token-weather/provider\` ❌ | \`@token-weather/provider-adapters\` ✅ |

3 패키지(\`cli\`, \`provider-adapters\`, \`schemas\`) 각각의 Trusted Publisher 등록 페이지에서 정확한 패키지명/repo/workflow 검증 부탁드립니다:

- https://www.npmjs.com/package/@token-weather/cli/access
- https://www.npmjs.com/package/@token-weather/provider-adapters/access
- https://www.npmjs.com/package/@token-weather/schemas/access

만약 등록 정보 오류면 본 PR 머지 후에도 PUT 404 가 다시 발생합니다 — 그 경우 등록 수정 후 release workflow rerun.

## 검증

- \`npm test\` 통과 (회귀 가드 +1, 13 → 15)
- \`npm run lint\` / \`format:check\` 통과
- 머지 후 \`npm view @token-weather/cli@0.2.0 dist.attestations\` 로 OIDC + provenance 검증

## 후속 (이 PR 범위 밖)

- ci.yml 도 일관성 위해 Node 24 로 올릴지 검토 (test/install-smoke job)