### PR TITLE
[docs] README CONTRIBUTING §9 정정 + CI badge main 정렬 (#103 review follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![npm version](https://img.shields.io/npm/v/%40token-weather%2Fcli.svg)](https://www.npmjs.com/package/@token-weather/cli)
-[![CI](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml)
+[![CI](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/LLagoon3/token-weather/actions/workflows/ci.yml)
 [![Node](https://img.shields.io/node/v/%40token-weather%2Fcli.svg)](https://nodejs.org/)
 
 > **Local CLI dashboard for AI service usage and OAuth credentials.**
@@ -105,7 +105,7 @@ OAuth token 같은 자격증명을 다루는 도구이므로, 보안 이슈는 �
 
 ## 라이선스
 
-[Apache License 2.0](./LICENSE). PR을 제출하시면 본인의 기여가 동일 라이선스로 제공됨에 동의한 것으로 간주됩니다 (자세한 내용은 [CONTRIBUTING.md §8](./CONTRIBUTING.md)).
+[Apache License 2.0](./LICENSE). PR을 제출하시면 본인의 기여가 동일 라이선스로 제공됨에 동의한 것으로 간주됩니다 (자세한 내용은 [CONTRIBUTING.md §9](./CONTRIBUTING.md)).
 
 ## Contributing
 


### PR DESCRIPTION
## 요약

PR #103 (dev → main) 리뷰 follow-up 의 2/3 처리. 1번 (사용자 데이터 경로 migration note) 은 사용자 결정으로 reject — 기존 사용자 0명 가정 정책 유지 (#91 / #97 동일 결정).

## 변경

- **README CI badge**: \`branch=dev\` → \`branch=main\`. main 정합 PR 머지 후 default branch 가 main 이므로 외부 사용자 첫 진입점 기준 정합.
- **CONTRIBUTING §8 → §9 정정**: PR #89 (#74 changeset) 머지 시 'Release / changeset' 섹션이 §8 로 들어가면서 license 단락이 §9 로 밀렸는데 README 의 인용은 §8 그대로 잔재. 외부 기여자가 README 따라가면 release 절차 페이지로 떨어지는 문제.

## 영향 범위

- [x] root \`README.md\` (외부 사용자 노출)
- [ ] 코드 / publish 메타 / CHANGELOG — 변경 없음

## 검증

- \`npm test\` 756/756 pass
- \`npm run lint\` / \`format:check\` 통과

## 머지 후

- 본 PR 이 dev 에 머지되면 PR #103 에 자동 반영 → main 머지 진행 가능.