### PR TITLE
[feat] doctor codex/claude --dedupe — stale 레코드 정리 명령 (issue #37)

### DIFF
--- a/.changeset/doctor-dedupe-37.md
+++ b/.changeset/doctor-dedupe-37.md
@@ -1,0 +1,7 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+---
+
+feat(cli): `doctor codex/claude --dedupe` / `--apply` / `--backfill-account-id` 옵션 추가 — 같은 OAuth subject (sub 또는 email) 의 stale 레코드를 dry-run 으로 감지하고 `--apply` 로 정리. login 시점 자동 정리(PR #38) 이전에 누적된 legacy accountKey 또는 id_token 파싱이 부분 실패한 레코드를 retroactive 로 청소 (issue #37). 자세한 사용법은 [docs/auth-cli.md §doctor `--dedupe`](docs/auth-cli.md).

--- a/docs/auth-cli.md
+++ b/docs/auth-cli.md
@@ -95,6 +95,48 @@ token-weather doctor claude --refresh-live --account <id>  # 특정 계정 지�
 
 `doctor --refresh-live`는 수동 진단/검증용 경로다. `status` / `usage`의 자동 refresh와는 별도로 동작한다.
 
+### `--dedupe` (issue #37)
+
+같은 OAuth subject (sub 또는 email) 를 가진 stale 레코드를 store 에서 정리한다. login 시점 자동 정리(PR #38) 이전에 누적된 legacy accountKey, 또는 id_token 파싱이 부분적으로 실패했던 케이스를 retroactive 로 청소.
+
+```bash
+token-weather doctor codex  --dedupe                              # dry-run: 후보만 출력
+token-weather doctor codex  --dedupe --apply                      # 실제 제거 반영
+token-weather doctor codex  --dedupe --backfill-account-id        # backfill 후보까지 dry-run
+token-weather doctor codex  --dedupe --backfill-account-id --apply  # 실제 반영
+token-weather doctor claude --dedupe ...                          # 동일 옵션
+```
+
+동작:
+
+- `--dedupe` 단독: 중복 그룹 + 유지/제거 후보를 콘솔에 출력만 (auth.json 변경 없음)
+- `--dedupe --apply`: 그룹마다 primary 1개를 유지하고 나머지를 `removeProviderAccount` 로 제거
+- `--backfill-account-id`: `accountId` 가 빈 레코드 중 `raw.idToken` 의 `sub` 로 채울 수 있는 후보를 함께 처리
+
+primary 선택 우선순위 (낮을수록 keep):
+
+1. `accountId` 가 set 된 쪽
+2. `status === 'active'` (vs `disabled`)
+3. `source === 'agent-store'` (vs `claude-cli-import` / `manual` 등)
+4. `updatedAt` 가 가장 최근
+5. `accountKey` lexicographic (안정 정렬)
+
+필터:
+
+- `source === 'manual'` 또는 `raw.mock === true` 인 레코드는 그룹화 대상에서 제외
+- 합성 email (`live-*@codex.openai.com`) 은 email 기반 매칭에서 배제
+
+상호작용:
+
+- `--account` 와 `--dedupe` 를 동시 지정하면 `--account` 는 무시되고 모든 계정을 검사한다 (warning 출력)
+- `--dedupe` 와 `--refresh-live` 가 동시에 오면 `--dedupe` 가 우선되어 dedupe 만 실행
+
+안전 가이드:
+
+- 항상 dry-run 먼저 (`--dedupe` 단독) 실행해 후보를 검토 후 `--apply`
+- 한 번 제거된 레코드는 자동 복구 안 됨 — 필요하면 사전에 `~/.config/token-weather/auth.json` 백업
+- v1 은 `doctor codex` / `doctor claude` 별도 실행 — provider 통합 dedupe 는 미지원
+
 ## 포트 충돌 정책 (Codex)
 
 - 기본 포트: `1455`

--- a/packages/agent/src/auth/auth-store.js
+++ b/packages/agent/src/auth/auth-store.js
@@ -73,3 +73,37 @@ export function removeProviderAccount(store, providerId, accountKey) {
 
   return nextStore;
 }
+
+/**
+ * 특정 accountKey 의 레코드를 partial patch 로 갱신한다.
+ * 매칭되는 레코드가 없으면 원본 store 를 그대로 반환 (no-op).
+ *
+ * upsertProviderAccount 와 차이:
+ *   - upsert 는 "신규 또는 전체 갱신" — 없으면 push, 있으면 spread merge.
+ *   - update 는 "있을 때만 부분 갱신" — 없으면 noop, 있으면 spread merge.
+ *
+ * 주 용도: doctor --dedupe --backfill-account-id 가 accountId 만 채울 때.
+ *
+ * @param {object} store
+ * @param {string} providerId
+ * @param {string} accountKey
+ * @param {object} patch - 병합할 부분 필드들
+ * @returns {object} 새 store (원본 불변)
+ */
+export function updateProviderAccount(store, providerId, accountKey, patch) {
+  const nextStore = structuredClone(store);
+
+  const provider = nextStore.providers?.[providerId];
+  if (!provider || !provider.accounts) return nextStore;
+
+  const index = provider.accounts.findIndex((a) => a.accountKey === accountKey);
+  if (index < 0) return nextStore;
+
+  provider.accounts[index] = {
+    ...provider.accounts[index],
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
+
+  return nextStore;
+}

--- a/packages/agent/src/auth/find-duplicate-groups.js
+++ b/packages/agent/src/auth/find-duplicate-groups.js
@@ -1,0 +1,177 @@
+import { decodeJwtPayload } from './token-claims.js';
+
+/**
+ * 저장소(`store.providers[providerId].accounts`) 안에서 같은 OAuth subject
+ * (sub 또는 email)를 가진 중복 그룹을 찾는다. PR #38 의 `findLegacyDuplicates`
+ * 가 "새 계정 vs 기존" 비교라면, 본 함수는 "기존 계정 내부의 그룹화" 라
+ * 시그니처가 다르다. 정책(필터 / 우선순위)은 동일하게 맞춤.
+ *
+ * identity 판별:
+ *   1. account.accountId (JWT sub) — 존재하면 최우선
+ *   2. account.email — sub 가 없을 때 (단 합성 email `live-*@...` 은 제외)
+ *   3. account.raw.idToken 디코드 — 위 둘 다 비어있을 때 fallback
+ *
+ * 그룹화 기준: 동일 sub OR 동일 email (case-insensitive). transitively 연결된
+ * 계정들은 한 그룹으로 합친다 — 예: A(sub1) ↔ B(sub1, email-x) ↔ C(email-x).
+ *
+ * 필터: source==='manual' 또는 raw.mock===true 인 계정은 그룹화 대상에서 제외.
+ *       (수동 paste / 테스트 placeholder 라 자동 정리 대상이 아님)
+ *
+ * primary 선택 우선순위 (낮을수록 keep):
+ *   1. accountId 가 set 된 쪽
+ *   2. status !== 'disabled' 인 쪽
+ *   3. source === 'agent-store' 인 쪽 (claude-cli-import 등 보다 우선)
+ *   4. updatedAt 이 가장 최근 (descending)
+ *   5. accountKey lexicographic (안정 정렬)
+ *
+ * @param {object[]} accounts - store.providers[providerId].accounts 배열
+ * @returns {Array<{
+ *   reason: 'same-sub' | 'same-email',
+ *   identityKey: string,
+ *   primary: object,
+ *   duplicates: object[]
+ * }>}
+ */
+export function findDuplicateGroups(accounts) {
+  if (!Array.isArray(accounts) || accounts.length < 2) return [];
+
+  const eligible = accounts.filter((a) => a && !isManualOrMockAccount(a));
+  if (eligible.length < 2) return [];
+
+  // 단순 iterative grouping — 각 계정을 기존 그룹 중 하나라도 매칭되면 합친다.
+  // 계정 수가 작아 (<50) O(n²) 충분.
+  /** @type {Array<{ accounts: object[], reason: 'same-sub'|'same-email'|null }>} */
+  const groups = [];
+  for (const account of eligible) {
+    let placed = false;
+    for (const group of groups) {
+      let hitReason = null;
+      for (const member of group.accounts) {
+        const matched = sameIdentity(member, account);
+        if (matched) {
+          hitReason = matched;
+          break;
+        }
+      }
+      if (hitReason) {
+        group.accounts.push(account);
+        // sub 매칭이 등장하면 그룹 reason 을 same-sub 로 승격
+        if (group.reason !== 'same-sub' && hitReason === 'same-sub') {
+          group.reason = 'same-sub';
+        } else if (group.reason == null) {
+          group.reason = hitReason;
+        }
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      groups.push({ accounts: [account], reason: null });
+    }
+  }
+
+  return groups
+    .filter((g) => g.accounts.length >= 2)
+    .map((g) => {
+      const sorted = [...g.accounts].sort(comparePrimaryPriority);
+      const primary = sorted[0];
+      const duplicates = sorted.slice(1);
+      const reason = g.reason ?? 'same-email';
+      const identityKey =
+        reason === 'same-sub'
+          ? (primary.accountId ?? extractIdentity(primary).sub ?? '?')
+          : (primary.email ?? extractIdentity(primary).email ?? '?');
+      return { reason, identityKey, primary, duplicates };
+    });
+}
+
+/**
+ * 두 계정이 같은 identity 인지 판단. 둘 중 하나라도 sub 매칭이면 'same-sub',
+ * 아니면 email 매칭 시 'same-email', 그 외 null.
+ *
+ * @param {object} a
+ * @param {object} b
+ * @returns {'same-sub'|'same-email'|null}
+ */
+function sameIdentity(a, b) {
+  const ia = extractIdentity(a);
+  const ib = extractIdentity(b);
+  if (ia.sub && ib.sub && ia.sub === ib.sub) return 'same-sub';
+  if (ia.email && ib.email && ia.email.toLowerCase() === ib.email.toLowerCase()) {
+    return 'same-email';
+  }
+  return null;
+}
+
+/**
+ * 저장된 계정 레코드에서 effective identity 추출.
+ * 우선순위: accountId > raw.idToken.sub > null. email 도 동일 폴백.
+ * 합성 email (`live-*@...`) 은 매칭 대상에서 제외.
+ *
+ * @param {object} account
+ * @returns {{ sub: string|null, email: string|null }}
+ */
+function extractIdentity(account) {
+  const direct = {
+    sub: account.accountId ?? null,
+    email: account.email ?? null,
+  };
+  if (isSyntheticEmail(direct.email)) direct.email = null;
+  if (direct.sub || direct.email) {
+    // raw.idToken 으로 빈 쪽을 보강 (단 직접값이 있으면 그것 우선)
+    const claims = decodeJwtPayload(account.raw?.idToken);
+    if (!claims) return direct;
+    return {
+      sub: direct.sub ?? claims.sub ?? null,
+      email: direct.email ?? (isSyntheticEmail(claims.email) ? null : (claims.email ?? null)),
+    };
+  }
+
+  const claims = decodeJwtPayload(account.raw?.idToken);
+  if (!claims) return direct;
+  const claimEmail = isSyntheticEmail(claims.email) ? null : (claims.email ?? null);
+  return {
+    sub: claims.sub ?? null,
+    email: claimEmail,
+  };
+}
+
+function isManualOrMockAccount(account) {
+  if (!account) return false;
+  if (account.source === 'manual') return true;
+  if (account.raw?.mock === true) return true;
+  return false;
+}
+
+function isSyntheticEmail(email) {
+  if (typeof email !== 'string') return false;
+  return /^live-[^@]+@/i.test(email);
+}
+
+/**
+ * primary 선택 정렬 함수. 낮을수록 keep (= primary).
+ * 5단 우선순위: accountId 보유 → active → agent-store source → updatedAt 최신 → accountKey.
+ *
+ * @param {object} a
+ * @param {object} b
+ * @returns {number}
+ */
+function comparePrimaryPriority(a, b) {
+  const aHasId = a.accountId ? 0 : 1;
+  const bHasId = b.accountId ? 0 : 1;
+  if (aHasId !== bHasId) return aHasId - bHasId;
+
+  const aDisabled = a.status === 'disabled' ? 1 : 0;
+  const bDisabled = b.status === 'disabled' ? 1 : 0;
+  if (aDisabled !== bDisabled) return aDisabled - bDisabled;
+
+  const aSource = a.source === 'agent-store' ? 0 : 1;
+  const bSource = b.source === 'agent-store' ? 0 : 1;
+  if (aSource !== bSource) return aSource - bSource;
+
+  const aUpdated = typeof a.updatedAt === 'string' ? a.updatedAt : '';
+  const bUpdated = typeof b.updatedAt === 'string' ? b.updatedAt : '';
+  if (aUpdated !== bUpdated) return bUpdated.localeCompare(aUpdated);
+
+  return (a.accountKey ?? '').localeCompare(b.accountKey ?? '');
+}

--- a/packages/agent/src/auth/find-duplicate-groups.js
+++ b/packages/agent/src/auth/find-duplicate-groups.js
@@ -38,51 +38,73 @@ export function findDuplicateGroups(accounts) {
   const eligible = accounts.filter((a) => a && !isManualOrMockAccount(a));
   if (eligible.length < 2) return [];
 
-  // 단순 iterative grouping — 각 계정을 기존 그룹 중 하나라도 매칭되면 합친다.
+  // Iterative grouping with merge — 새 계정이 여러 기존 그룹에 매칭되면 그
+  // 그룹들을 하나로 병합한다. 매칭이 첫 그룹에서 break 되던 이전 구현은
+  // 입력 순서에 따라 bridge 케이스가 누락됐다 (PR #108 review):
+  //   A(sub1, email=a) → group [A]
+  //   C(sub2, email=b) → group [C]
+  //   B(sub1, email=b) → A 그룹에만 합류, C 그룹과 merge 누락 → C 가 단독
+  //   잔존 → 길이 1 필터로 사라짐.
+  // 새 account 가 매칭되는 모든 그룹을 수집한 뒤 인덱스 0 으로 합쳐 해결.
   // 계정 수가 작아 (<50) O(n²) 충분.
-  /** @type {Array<{ accounts: object[], reason: 'same-sub'|'same-email'|null }>} */
+  /** @type {Array<{ accounts: object[] }>} */
   const groups = [];
   for (const account of eligible) {
-    let placed = false;
-    for (const group of groups) {
-      let hitReason = null;
-      for (const member of group.accounts) {
-        const matched = sameIdentity(member, account);
-        if (matched) {
-          hitReason = matched;
+    const matchedIndices = [];
+    for (let i = 0; i < groups.length; i += 1) {
+      for (const member of groups[i].accounts) {
+        if (sameIdentity(member, account)) {
+          matchedIndices.push(i);
           break;
         }
       }
-      if (hitReason) {
-        group.accounts.push(account);
-        // sub 매칭이 등장하면 그룹 reason 을 same-sub 로 승격
-        if (group.reason !== 'same-sub' && hitReason === 'same-sub') {
-          group.reason = 'same-sub';
-        } else if (group.reason == null) {
-          group.reason = hitReason;
-        }
-        placed = true;
-        break;
-      }
     }
-    if (!placed) {
-      groups.push({ accounts: [account], reason: null });
+
+    if (matchedIndices.length === 0) {
+      groups.push({ accounts: [account] });
+      continue;
+    }
+
+    const target = groups[matchedIndices[0]];
+    target.accounts.push(account);
+    // 두 번째 이후 매칭 그룹들을 target 으로 흡수 후 제거 (descending index 로
+    // splice 안전).
+    for (let j = matchedIndices.length - 1; j >= 1; j -= 1) {
+      const merging = groups[matchedIndices[j]];
+      target.accounts.push(...merging.accounts);
+      groups.splice(matchedIndices[j], 1);
     }
   }
 
   return groups
     .filter((g) => g.accounts.length >= 2)
     .map((g) => {
+      const reason = determineGroupReason(g.accounts);
       const sorted = [...g.accounts].sort(comparePrimaryPriority);
       const primary = sorted[0];
       const duplicates = sorted.slice(1);
-      const reason = g.reason ?? 'same-email';
       const identityKey =
         reason === 'same-sub'
           ? (primary.accountId ?? extractIdentity(primary).sub ?? '?')
           : (primary.email ?? extractIdentity(primary).email ?? '?');
       return { reason, identityKey, primary, duplicates };
     });
+}
+
+/**
+ * 그룹 내부 어떤 페어라도 sub 매칭이면 'same-sub', 아니면 'same-email'.
+ * 그룹은 이미 동일 identity 라 보장됐으므로 두 결과 중 하나는 반드시 나옴.
+ *
+ * @param {object[]} accounts - 동일 그룹 안의 계정들 (length >= 2)
+ * @returns {'same-sub' | 'same-email'}
+ */
+function determineGroupReason(accounts) {
+  for (let i = 0; i < accounts.length; i += 1) {
+    for (let j = i + 1; j < accounts.length; j += 1) {
+      if (sameIdentity(accounts[i], accounts[j]) === 'same-sub') return 'same-sub';
+    }
+  }
+  return 'same-email';
 }
 
 /**

--- a/packages/agent/src/cli/doctor-command.js
+++ b/packages/agent/src/cli/doctor-command.js
@@ -18,12 +18,22 @@ import {
 import { updateCodexStoreAfterRefresh } from '../auth/codex-refresh-store.js';
 import { updateClaudeStoreAfterRefresh } from '../auth/claude-refresh-store.js';
 import { parseCliOptions } from './parse-options.js';
+import { runDedupeFlow } from './doctor-dedupe-flow.js';
 
 const DOCTOR_FLAGS = {
   '--refresh-live': { key: 'refreshLive', type: 'boolean' },
   '--account': { key: 'account', type: 'string' },
+  '--dedupe': { key: 'dedupe', type: 'boolean' },
+  '--apply': { key: 'apply', type: 'boolean' },
+  '--backfill-account-id': { key: 'backfillAccountId', type: 'boolean' },
 };
-const DOCTOR_DEFAULTS = { refreshLive: false, account: null };
+const DOCTOR_DEFAULTS = {
+  refreshLive: false,
+  account: null,
+  dedupe: false,
+  apply: false,
+  backfillAccountId: false,
+};
 
 function parseDoctorOptions(args) {
   return parseCliOptions(args, {
@@ -66,9 +76,13 @@ export function formatDoctorCodexHelp() {
     'Codex 계정 상태와 refresh 가능성을 점검합니다.',
     '',
     'Options:',
-    '  --refresh-live        실제 token endpoint에 refresh POST 시도',
-    '  --account <id>        특정 계정 지정 (email / accountKey / label)',
-    '  -h, --help            이 도움말 출력',
+    '  --refresh-live           실제 token endpoint에 refresh POST 시도',
+    '  --account <id>           특정 계정 지정 (email / accountKey / label)',
+    '  --dedupe                 같은 sub/email 의 중복 레코드를 dry-run 으로 감지',
+    '  --apply                  --dedupe 와 함께 사용 — 실제 제거 반영',
+    '  --backfill-account-id    --dedupe 와 함께 사용 — accountId 빈 레코드를',
+    '                           raw.idToken 의 sub 로 채움',
+    '  -h, --help               이 도움말 출력',
   ];
 }
 
@@ -82,9 +96,13 @@ export function formatDoctorClaudeHelp() {
     'Claude credential 상태와 live usage를 점검합니다.',
     '',
     'Options:',
-    '  --refresh-live        Claude OAuth refresh token으로 실제 재발급 시도',
-    '  --account <id>        특정 계정 지정 (email / accountKey / label)',
-    '  -h, --help            이 도움말 출력',
+    '  --refresh-live           Claude OAuth refresh token으로 실제 재발급 시도',
+    '  --account <id>           특정 계정 지정 (email / accountKey / label)',
+    '  --dedupe                 같은 sub/email 의 중복 레코드를 dry-run 으로 감지',
+    '  --apply                  --dedupe 와 함께 사용 — 실제 제거 반영',
+    '  --backfill-account-id    --dedupe 와 함께 사용 — accountId 빈 레코드를',
+    '                           raw.idToken 의 sub 로 채움',
+    '  -h, --help               이 도움말 출력',
   ];
 }
 
@@ -149,6 +167,12 @@ async function runDoctorClaude(args = []) {
     for (const line of formatDoctorClaudeHelp()) console.log(line);
     return;
   }
+
+  if (options.dedupe) {
+    await runDedupeFlow({ providerId: CLAUDE_AUTH.storeProvider, options });
+    return;
+  }
+
   const snapshot = await getClaudeSnapshot();
 
   console.log('token-weather doctor claude');
@@ -249,6 +273,11 @@ async function runDoctorCodex(args) {
   const options = parseDoctorCodexOptions(args);
   if (options.help) {
     for (const line of formatDoctorCodexHelp()) console.log(line);
+    return;
+  }
+
+  if (options.dedupe) {
+    await runDedupeFlow({ providerId: 'openai-codex', options });
     return;
   }
 

--- a/packages/agent/src/cli/doctor-dedupe-flow.js
+++ b/packages/agent/src/cli/doctor-dedupe-flow.js
@@ -1,0 +1,128 @@
+/**
+ * `doctor codex --dedupe` / `doctor claude --dedupe` 명령의 흐름 (issue #37).
+ *
+ * 동작:
+ *  - dry-run (default): 중복 그룹 + backfill 후보를 콘솔에 출력만, store 변경 없음
+ *  - apply (`--apply`): 변경 사항을 실제 store 에 반영 + saveAuthStore
+ *
+ * 옵션 조합:
+ *  - `--dedupe`             : 중복 그룹만 dry-run
+ *  - `--dedupe --apply`     : 중복 제거 실제 반영
+ *  - `--dedupe --backfill-account-id`         : backfill 후보까지 dry-run
+ *  - `--dedupe --backfill-account-id --apply` : 둘 다 실제 반영
+ *
+ * I/O 와 순수 로직을 분리:
+ *  - buildDedupePlan : 순수 함수 (accounts → plan)
+ *  - applyDedupePlan : 순수 함수 (store + plan → next store)
+ *  - runDedupeFlow   : I/O wrapper (load / console / save)
+ */
+import {
+  loadAuthStore,
+  saveAuthStore,
+  removeProviderAccount,
+  updateProviderAccount,
+} from '../auth/auth-store.js';
+import { findDuplicateGroups } from '../auth/find-duplicate-groups.js';
+import { decodeJwtPayload } from '../auth/token-claims.js';
+import {
+  formatDedupeProposal,
+  formatDedupeApplied,
+  formatDedupeNoChanges,
+} from './doctor-dedupe-formatters.js';
+
+/**
+ * @typedef {object} DedupePlan
+ * @property {ReturnType<typeof findDuplicateGroups>} groups
+ * @property {Array<{ accountKey: string, sub: string }>} backfillCandidates
+ */
+
+/**
+ * accountId 가 빈 레코드 중 raw.idToken 에 sub 가 있어 backfill 가능한 후보를 추린다.
+ *
+ * @param {object[]} accounts
+ * @returns {Array<{ accountKey: string, sub: string }>}
+ */
+export function findBackfillCandidates(accounts) {
+  if (!Array.isArray(accounts)) return [];
+  const out = [];
+  for (const account of accounts) {
+    if (!account || account.accountId) continue;
+    if (!account.raw?.idToken) continue;
+    const payload = decodeJwtPayload(account.raw.idToken);
+    if (!payload?.sub) continue;
+    out.push({ accountKey: account.accountKey, sub: payload.sub });
+  }
+  return out;
+}
+
+/**
+ * 순수 함수: accounts + options 로 dedupe plan 을 계산.
+ *
+ * @param {{ accounts: object[], options: { backfillAccountId?: boolean } }} params
+ * @returns {DedupePlan}
+ */
+export function buildDedupePlan({ accounts, options }) {
+  const groups = findDuplicateGroups(accounts);
+  const backfillCandidates = options.backfillAccountId ? findBackfillCandidates(accounts) : [];
+  return { groups, backfillCandidates };
+}
+
+/**
+ * 순수 함수: store + plan → next store. 변경 없으면 원본 그대로 반환.
+ *
+ * @param {object} store
+ * @param {string} providerId
+ * @param {DedupePlan} plan
+ * @returns {object}
+ */
+export function applyDedupePlan(store, providerId, plan) {
+  let next = store;
+  for (const group of plan.groups) {
+    for (const dup of group.duplicates) {
+      next = removeProviderAccount(next, providerId, dup.accountKey);
+    }
+  }
+  for (const candidate of plan.backfillCandidates) {
+    next = updateProviderAccount(next, providerId, candidate.accountKey, {
+      accountId: candidate.sub,
+    });
+  }
+  return next;
+}
+
+/**
+ * doctor --dedupe 흐름의 entry point. console 출력 + 옵션에 따라 saveAuthStore.
+ *
+ * @param {{
+ *   providerId: 'openai-codex' | 'claude',
+ *   options: { dedupe: boolean, apply: boolean, backfillAccountId: boolean, account?: string|null }
+ * }} params
+ */
+export async function runDedupeFlow({ providerId, options }) {
+  if (options.account) {
+    console.log('ℹ --account 옵션은 --dedupe 모드에서 무시됩니다 (모든 계정을 대상으로 검사).');
+    console.log('');
+  }
+
+  const store = await loadAuthStore();
+  const accounts = store.providers?.[providerId]?.accounts ?? [];
+  const plan = buildDedupePlan({ accounts, options });
+
+  for (const line of formatDedupeProposal({ providerId, accounts, plan, options })) {
+    console.log(line);
+  }
+
+  if (!options.apply) return;
+
+  if (plan.groups.length === 0 && plan.backfillCandidates.length === 0) {
+    for (const line of formatDedupeNoChanges()) console.log(line);
+    return;
+  }
+
+  const nextStore = applyDedupePlan(store, providerId, plan);
+  await saveAuthStore(nextStore);
+
+  for (const line of formatDedupeApplied(plan)) {
+    console.log(line);
+  }
+}

--- a/packages/agent/src/cli/doctor-dedupe-formatters.js
+++ b/packages/agent/src/cli/doctor-dedupe-formatters.js
@@ -1,0 +1,131 @@
+/**
+ * doctor --dedupe 의 출력 문자열 빌더. 모두 `string[]` 반환 (console.log 호출 X).
+ *
+ * 입력 plan 은 doctor-dedupe-flow.js 의 buildDedupePlan 결과.
+ */
+
+/**
+ * dry-run / pre-apply 모두에서 호출 — 발견 결과 공통 출력.
+ *
+ * @param {{
+ *   providerId: string,
+ *   accounts: object[],
+ *   plan: { groups: any[], backfillCandidates: any[] },
+ *   options: { apply?: boolean, backfillAccountId?: boolean }
+ * }} params
+ * @returns {string[]}
+ */
+export function formatDedupeProposal({ providerId, accounts, plan, options }) {
+  const lines = [];
+  const providerLabel = providerLabelFor(providerId);
+  lines.push(`${providerLabel} 계정 dedupe 검사`);
+  lines.push('-'.repeat(40));
+  lines.push(`저장된 ${providerLabel} 계정: ${accounts.length}`);
+  lines.push('');
+
+  if (plan.groups.length === 0) {
+    lines.push('중복 후보: 없음');
+  } else {
+    lines.push(`중복 후보 (${plan.groups.length} 그룹):`);
+    plan.groups.forEach((group, idx) => {
+      lines.push('');
+      lines.push(`[그룹 ${idx + 1}] ${describeReason(group.reason)}: ${group.identityKey}`);
+      lines.push(`  유지: ${group.primary.accountKey}${formatPrimaryHints(group.primary)}`);
+      for (const dup of group.duplicates) {
+        lines.push(`  제거 후보: ${dup.accountKey} (reason=${group.reason}${formatDupHints(dup)})`);
+      }
+    });
+  }
+
+  if (options.backfillAccountId) {
+    lines.push('');
+    if (plan.backfillCandidates.length === 0) {
+      lines.push('accountId backfill 후보: 없음');
+    } else {
+      lines.push(`accountId backfill 후보 (${plan.backfillCandidates.length}):`);
+      for (const c of plan.backfillCandidates) {
+        lines.push(`  ${c.accountKey} → accountId=${c.sub}`);
+      }
+    }
+  }
+
+  if (!options.apply) {
+    lines.push('');
+    if (plan.groups.length === 0 && (!options.backfillAccountId || plan.backfillCandidates.length === 0)) {
+      lines.push('변경 사항이 없습니다 (dry-run).');
+    } else {
+      lines.push('실제 반영을 원하면 --apply 옵션을 추가하세요:');
+      const applyExample = options.backfillAccountId
+        ? `  token-weather doctor ${shortProviderName(providerId)} --dedupe --backfill-account-id --apply`
+        : `  token-weather doctor ${shortProviderName(providerId)} --dedupe --apply`;
+      lines.push(applyExample);
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * --apply 후 실제 변경 결과 출력.
+ *
+ * @param {{ groups: any[], backfillCandidates: any[] }} plan
+ * @returns {string[]}
+ */
+export function formatDedupeApplied(plan) {
+  const lines = [''];
+  lines.push('정리 결과:');
+  let removedCount = 0;
+  for (const group of plan.groups) {
+    for (const dup of group.duplicates) {
+      lines.push(`  ✓ 제거: ${dup.accountKey} (${group.reason})`);
+      removedCount += 1;
+    }
+  }
+  for (const c of plan.backfillCandidates) {
+    lines.push(`  ✓ backfill: ${c.accountKey} → accountId=${c.sub}`);
+  }
+  lines.push('');
+  const summary = [];
+  if (removedCount > 0) summary.push(`${removedCount}건 제거`);
+  if (plan.backfillCandidates.length > 0) summary.push(`${plan.backfillCandidates.length}건 backfill`);
+  lines.push(`총 ${summary.join(' + ')}. auth.json 갱신 완료.`);
+  return lines;
+}
+
+/**
+ * --apply 했지만 변경 사항이 없을 때.
+ *
+ * @returns {string[]}
+ */
+export function formatDedupeNoChanges() {
+  return ['', '변경 사항이 없습니다.'];
+}
+
+function describeReason(reason) {
+  return reason === 'same-sub' ? 'sub 일치' : 'email 일치';
+}
+
+function formatPrimaryHints(primary) {
+  const hints = [];
+  if (primary.source) hints.push(`source=${primary.source}`);
+  if (primary.updatedAt) hints.push(`updatedAt=${primary.updatedAt}`);
+  if (primary.status === 'disabled') hints.push('status=disabled');
+  return hints.length > 0 ? ` (${hints.join(', ')})` : '';
+}
+
+function formatDupHints(dup) {
+  const hints = [];
+  if (dup.accountId === null || dup.accountId === undefined) hints.push('accountId=null');
+  if (dup.status === 'disabled') hints.push('status=disabled');
+  return hints.length > 0 ? `, ${hints.join(', ')}` : '';
+}
+
+function providerLabelFor(providerId) {
+  if (providerId === 'openai-codex') return 'codex';
+  if (providerId === 'claude') return 'claude';
+  return providerId;
+}
+
+function shortProviderName(providerId) {
+  return providerLabelFor(providerId);
+}

--- a/packages/agent/src/cli/doctor-dedupe-formatters.js
+++ b/packages/agent/src/cli/doctor-dedupe-formatters.js
@@ -51,7 +51,10 @@ export function formatDedupeProposal({ providerId, accounts, plan, options }) {
 
   if (!options.apply) {
     lines.push('');
-    if (plan.groups.length === 0 && (!options.backfillAccountId || plan.backfillCandidates.length === 0)) {
+    if (
+      plan.groups.length === 0 &&
+      (!options.backfillAccountId || plan.backfillCandidates.length === 0)
+    ) {
       lines.push('변경 사항이 없습니다 (dry-run).');
     } else {
       lines.push('실제 반영을 원하면 --apply 옵션을 추가하세요:');
@@ -87,7 +90,8 @@ export function formatDedupeApplied(plan) {
   lines.push('');
   const summary = [];
   if (removedCount > 0) summary.push(`${removedCount}건 제거`);
-  if (plan.backfillCandidates.length > 0) summary.push(`${plan.backfillCandidates.length}건 backfill`);
+  if (plan.backfillCandidates.length > 0)
+    summary.push(`${plan.backfillCandidates.length}건 backfill`);
   lines.push(`총 ${summary.join(' + ')}. auth.json 갱신 완료.`);
   return lines;
 }

--- a/packages/agent/test/auth/auth-store.test.js
+++ b/packages/agent/test/auth/auth-store.test.js
@@ -6,7 +6,11 @@ import {
   AUTH_STORE_VERSION,
   createAccount,
 } from '../../src/auth/auth-store-schema.js';
-import { upsertProviderAccount, removeProviderAccount } from '../../src/auth/auth-store.js';
+import {
+  upsertProviderAccount,
+  removeProviderAccount,
+  updateProviderAccount,
+} from '../../src/auth/auth-store.js';
 
 describe('createEmptyAuthStore', () => {
   it('returns a store with correct version and empty providers', () => {
@@ -114,6 +118,69 @@ describe('removeProviderAccount', () => {
 
     removeProviderAccount(withAccount, 'openai-codex', 'codex:x');
     assert.equal(withAccount.providers['openai-codex'].accounts.length, 1);
+  });
+});
+
+describe('updateProviderAccount', () => {
+  it('partial patch 로 기존 레코드를 갱신', () => {
+    const store = createEmptyAuthStore();
+    const account = createAccount({ accountKey: 'k', email: 'e@e.com', accountId: null });
+    const withAccount = upsertProviderAccount(store, 'openai-codex', account);
+
+    const next = updateProviderAccount(withAccount, 'openai-codex', 'k', {
+      accountId: 'sub-recovered',
+    });
+
+    const updated = next.providers['openai-codex'].accounts[0];
+    assert.equal(updated.accountKey, 'k');
+    assert.equal(updated.accountId, 'sub-recovered');
+    assert.equal(updated.email, 'e@e.com'); // 다른 필드는 보존
+  });
+
+  it('updatedAt 을 새 타임스탬프로 갱신', async () => {
+    const store = createEmptyAuthStore();
+    const account = createAccount({ accountKey: 'k', email: 'e@e.com' });
+    const withAccount = upsertProviderAccount(store, 'openai-codex', account);
+    const before = withAccount.providers['openai-codex'].accounts[0].updatedAt;
+
+    await new Promise((r) => setTimeout(r, 5));
+    const next = updateProviderAccount(withAccount, 'openai-codex', 'k', {
+      accountId: 'new-sub',
+    });
+    const after = next.providers['openai-codex'].accounts[0].updatedAt;
+
+    assert.notEqual(before, after);
+    assert.ok(after > before);
+  });
+
+  it('존재하지 않는 accountKey 는 noop', () => {
+    const store = createEmptyAuthStore();
+    const account = createAccount({ accountKey: 'k', email: 'e@e.com' });
+    const withAccount = upsertProviderAccount(store, 'openai-codex', account);
+
+    const next = updateProviderAccount(withAccount, 'openai-codex', 'gone', {
+      accountId: 'x',
+    });
+
+    assert.equal(next.providers['openai-codex'].accounts.length, 1);
+    assert.equal(next.providers['openai-codex'].accounts[0].accountId, null);
+  });
+
+  it('존재하지 않는 provider 는 noop', () => {
+    const store = createEmptyAuthStore();
+    const next = updateProviderAccount(store, 'nonexistent', 'k', { accountId: 'x' });
+    assert.deepStrictEqual(next.providers, {});
+  });
+
+  it('원본 store 를 변형하지 않음', () => {
+    const store = createEmptyAuthStore();
+    const account = createAccount({ accountKey: 'k', email: 'e@e.com', accountId: null });
+    const withAccount = upsertProviderAccount(store, 'openai-codex', account);
+
+    updateProviderAccount(withAccount, 'openai-codex', 'k', { accountId: 'patched' });
+
+    // 원본은 그대로
+    assert.equal(withAccount.providers['openai-codex'].accounts[0].accountId, null);
   });
 });
 

--- a/packages/agent/test/auth/find-duplicate-groups.test.js
+++ b/packages/agent/test/auth/find-duplicate-groups.test.js
@@ -219,6 +219,28 @@ describe('findDuplicateGroups — manual / mock 제외', () => {
 });
 
 describe('findDuplicateGroups — transitive grouping', () => {
+  // PR #108 review 가 발견한 bridge 케이스 회귀 가드.
+  // 입력 순서: A(sub1) → C(sub2) → B(sub1+emailMatch C) — B 가 두 그룹의
+  // bridge 가 되어 A/B/C 가 한 그룹으로 병합되어야 한다. 이전 break 구현은
+  // B 를 첫 매칭 그룹(A)에만 합류시키고 C 를 단독 잔존 → 길이 1 필터로
+  // 사라지게 만들어 일부 duplicate 가 감지 누락됐었음.
+  it('bridge 케이스: A↔B sub 매칭 + B↔C email 매칭, 입력 순서 A→C→B 여도 한 그룹', () => {
+    const accounts = [
+      { accountKey: 'A', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+      { accountKey: 'C', accountId: 'sub2', email: 'b@x.com', source: 'agent-store' },
+      { accountKey: 'B', accountId: 'sub1', email: 'b@x.com', source: 'agent-store' },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1, 'bridge 합쳐져 단일 그룹이어야 함');
+    const allKeys = [
+      groups[0].primary.accountKey,
+      ...groups[0].duplicates.map((d) => d.accountKey),
+    ].sort();
+    assert.deepEqual(allKeys, ['A', 'B', 'C']);
+    // sub 매칭 (A↔B) 이 존재하므로 reason 은 same-sub
+    assert.equal(groups[0].reason, 'same-sub');
+  });
+
   it('A↔B sub 매칭 + B↔C email 매칭 → 한 그룹으로 묶임 (sub 우선 reason)', () => {
     const accounts = [
       {

--- a/packages/agent/test/auth/find-duplicate-groups.test.js
+++ b/packages/agent/test/auth/find-duplicate-groups.test.js
@@ -259,7 +259,9 @@ describe('findDuplicateGroups — 다중 그룹', () => {
     ];
     const groups = findDuplicateGroups(accounts);
     assert.equal(groups.length, 2);
-    const allKeys = groups.flatMap((g) => [g.primary.accountKey, ...g.duplicates.map((d) => d.accountKey)]).sort();
+    const allKeys = groups
+      .flatMap((g) => [g.primary.accountKey, ...g.duplicates.map((d) => d.accountKey)])
+      .sort();
     assert.deepEqual(allKeys, ['g1-a', 'g1-b', 'g2-a', 'g2-b']);
     // lone 계정은 어느 그룹에도 속하지 않음
     assert.ok(!allKeys.includes('lone'));

--- a/packages/agent/test/auth/find-duplicate-groups.test.js
+++ b/packages/agent/test/auth/find-duplicate-groups.test.js
@@ -1,0 +1,267 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { findDuplicateGroups } from '../../src/auth/find-duplicate-groups.js';
+
+// base64url for { "sub": "google-oauth2|115", "email": "a@x.com" }
+const JWT_SUB_A =
+  'eyJhbGciOiJub25lIn0.eyJzdWIiOiJnb29nbGUtb2F1dGgyfDExNSIsImVtYWlsIjoiYUB4LmNvbSJ9.';
+
+describe('findDuplicateGroups — empty / single-account', () => {
+  it('returns [] for empty input', () => {
+    assert.deepEqual(findDuplicateGroups([]), []);
+  });
+
+  it('returns [] for non-array input', () => {
+    assert.deepEqual(findDuplicateGroups(null), []);
+    assert.deepEqual(findDuplicateGroups(undefined), []);
+  });
+
+  it('returns [] when only 1 account', () => {
+    assert.deepEqual(
+      findDuplicateGroups([{ accountKey: 'a', accountId: 'sub1', email: 'a@x.com' }]),
+      [],
+    );
+  });
+
+  it('returns [] when 2 distinct accounts', () => {
+    const accounts = [
+      { accountKey: 'a', accountId: 'sub1', email: 'a@x.com' },
+      { accountKey: 'b', accountId: 'sub2', email: 'b@x.com' },
+    ];
+    assert.deepEqual(findDuplicateGroups(accounts), []);
+  });
+});
+
+describe('findDuplicateGroups — sub matching', () => {
+  it('groups two accounts with same accountId (sub)', () => {
+    const accounts = [
+      {
+        accountKey: 'openai-codex:live-old@codex.openai.com',
+        accountId: null,
+        email: 'live-old@codex.openai.com',
+        raw: { idToken: JWT_SUB_A },
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'openai-codex:google-oauth2|115',
+        accountId: 'google-oauth2|115',
+        email: 'a@x.com',
+        source: 'agent-store',
+        updatedAt: '2026-04-29T00:00:00Z',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].reason, 'same-sub');
+    assert.equal(groups[0].identityKey, 'google-oauth2|115');
+    // primary = accountId 가 set 된 쪽
+    assert.equal(groups[0].primary.accountKey, 'openai-codex:google-oauth2|115');
+    assert.equal(groups[0].duplicates.length, 1);
+    assert.equal(groups[0].duplicates[0].accountKey, 'openai-codex:live-old@codex.openai.com');
+  });
+
+  it('decodes raw.idToken to recover sub when accountId is missing', () => {
+    const accounts = [
+      {
+        accountKey: 'a-legacy',
+        accountId: null,
+        email: 'live-abc@codex.openai.com',
+        raw: { idToken: JWT_SUB_A },
+      },
+      {
+        accountKey: 'a-current',
+        accountId: 'google-oauth2|115',
+        email: 'a@x.com',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].reason, 'same-sub');
+  });
+});
+
+describe('findDuplicateGroups — email matching', () => {
+  it('groups by email when sub is missing on both', () => {
+    const accounts = [
+      { accountKey: 'a', email: 'shared@x.com' },
+      { accountKey: 'b', email: 'SHARED@x.com' },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].reason, 'same-email');
+    assert.equal(groups[0].identityKey.toLowerCase(), 'shared@x.com');
+  });
+
+  it('does NOT match synthetic fallback emails (live-xxxx@...)', () => {
+    const accounts = [
+      { accountKey: 'a', email: 'live-aaaa@codex.openai.com' },
+      { accountKey: 'b', email: 'live-aaaa@codex.openai.com' },
+    ];
+    assert.deepEqual(findDuplicateGroups(accounts), []);
+  });
+});
+
+describe('findDuplicateGroups — primary 선택 우선순위', () => {
+  it('accountId 가 set 된 쪽이 primary', () => {
+    const accounts = [
+      { accountKey: 'no-id', accountId: null, email: 'a@x.com', source: 'agent-store' },
+      { accountKey: 'has-id', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups[0].primary.accountKey, 'has-id');
+  });
+
+  it('disabled 보다 active 가 primary', () => {
+    const accounts = [
+      {
+        accountKey: 'active',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        status: 'active',
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'disabled',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        status: 'disabled',
+        source: 'agent-store',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups[0].primary.accountKey, 'active');
+    assert.equal(groups[0].duplicates[0].accountKey, 'disabled');
+  });
+
+  it('agent-store source 가 다른 source 보다 primary', () => {
+    const accounts = [
+      {
+        accountKey: 'imported',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        source: 'claude-cli-import',
+      },
+      {
+        accountKey: 'agent',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        source: 'agent-store',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups[0].primary.accountKey, 'agent');
+  });
+
+  it('updatedAt 이 최신인 쪽이 primary', () => {
+    const accounts = [
+      {
+        accountKey: 'old',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        source: 'agent-store',
+        updatedAt: '2026-04-01T00:00:00Z',
+      },
+      {
+        accountKey: 'new',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        source: 'agent-store',
+        updatedAt: '2026-04-29T00:00:00Z',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups[0].primary.accountKey, 'new');
+  });
+});
+
+describe('findDuplicateGroups — manual / mock 제외', () => {
+  it('manual / mock 계정은 그룹화 대상에서 제외', () => {
+    const accounts = [
+      { accountKey: 'manual', accountId: 'sub1', email: 'a@x.com', source: 'manual' },
+      {
+        accountKey: 'mock',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        raw: { mock: true },
+        source: 'agent-store',
+      },
+      { accountKey: 'real', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+    ];
+    // manual / mock 둘 다 제외 → real 1개만 남아 그룹 없음
+    assert.deepEqual(findDuplicateGroups(accounts), []);
+  });
+
+  it('manual / mock 외 두 real 계정만 같은 identity 면 그룹화', () => {
+    const accounts = [
+      {
+        accountKey: 'mock',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        raw: { mock: true },
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'real-a',
+        accountId: 'sub1',
+        email: 'a@x.com',
+        source: 'agent-store',
+        updatedAt: '2026-04-29T00:00:00Z',
+      },
+      { accountKey: 'real-b-legacy', accountId: null, email: 'a@x.com', source: 'agent-store' },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].primary.accountKey, 'real-a');
+    assert.equal(groups[0].duplicates.length, 1);
+    assert.equal(groups[0].duplicates[0].accountKey, 'real-b-legacy');
+  });
+});
+
+describe('findDuplicateGroups — transitive grouping', () => {
+  it('A↔B sub 매칭 + B↔C email 매칭 → 한 그룹으로 묶임 (sub 우선 reason)', () => {
+    const accounts = [
+      {
+        accountKey: 'A',
+        accountId: 'sub1',
+        email: 'shared@x.com',
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'B',
+        accountId: 'sub1',
+        email: 'shared@x.com',
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'C',
+        accountId: null,
+        email: 'shared@x.com',
+        source: 'agent-store',
+      },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].reason, 'same-sub');
+    assert.equal(groups[0].accounts ?? groups[0].primary, groups[0].primary);
+    assert.equal(1 + groups[0].duplicates.length, 3);
+  });
+});
+
+describe('findDuplicateGroups — 다중 그룹', () => {
+  it('서로 다른 identity 의 두 그룹을 동시에 반환', () => {
+    const accounts = [
+      { accountKey: 'g1-a', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+      { accountKey: 'g1-b', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+      { accountKey: 'g2-a', accountId: 'sub2', email: 'b@x.com', source: 'agent-store' },
+      { accountKey: 'g2-b', accountId: 'sub2', email: 'b@x.com', source: 'agent-store' },
+      { accountKey: 'lone', accountId: 'sub3', email: 'c@x.com', source: 'agent-store' },
+    ];
+    const groups = findDuplicateGroups(accounts);
+    assert.equal(groups.length, 2);
+    const allKeys = groups.flatMap((g) => [g.primary.accountKey, ...g.duplicates.map((d) => d.accountKey)]).sort();
+    assert.deepEqual(allKeys, ['g1-a', 'g1-b', 'g2-a', 'g2-b']);
+    // lone 계정은 어느 그룹에도 속하지 않음
+    assert.ok(!allKeys.includes('lone'));
+  });
+});

--- a/packages/agent/test/cli/doctor-command-dedupe.test.js
+++ b/packages/agent/test/cli/doctor-command-dedupe.test.js
@@ -1,10 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import {
-  formatDoctorCodexHelp,
-  formatDoctorClaudeHelp,
-} from '../../src/cli/doctor-command.js';
+import { formatDoctorCodexHelp, formatDoctorClaudeHelp } from '../../src/cli/doctor-command.js';
 
 describe('doctor 옵션 spec — --dedupe 관련', () => {
   it('codex --help 텍스트에 --dedupe / --apply / --backfill-account-id 가 노출됨', () => {

--- a/packages/agent/test/cli/doctor-command-dedupe.test.js
+++ b/packages/agent/test/cli/doctor-command-dedupe.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatDoctorCodexHelp,
+  formatDoctorClaudeHelp,
+} from '../../src/cli/doctor-command.js';
+
+describe('doctor 옵션 spec — --dedupe 관련', () => {
+  it('codex --help 텍스트에 --dedupe / --apply / --backfill-account-id 가 노출됨', () => {
+    const text = formatDoctorCodexHelp().join('\n');
+    assert.match(text, /--dedupe/);
+    assert.match(text, /--apply/);
+    assert.match(text, /--backfill-account-id/);
+  });
+
+  it('claude --help 텍스트에도 --dedupe / --apply / --backfill-account-id 가 노출됨', () => {
+    const text = formatDoctorClaudeHelp().join('\n');
+    assert.match(text, /--dedupe/);
+    assert.match(text, /--apply/);
+    assert.match(text, /--backfill-account-id/);
+  });
+});

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -222,67 +222,70 @@ describe('formatClaudeSection', () => {
 });
 
 describe('parseDoctorClaudeOptions', () => {
+  // 모든 default 필드 — issue #37 에서 dedupe / apply / backfillAccountId 추가.
+  const DEFAULTS = {
+    refreshLive: false,
+    account: null,
+    dedupe: false,
+    apply: false,
+    backfillAccountId: false,
+    help: false,
+  };
+
   it('returns defaults', () => {
-    assert.deepEqual(parseDoctorClaudeOptions([]), {
-      refreshLive: false,
-      account: null,
-      help: false,
-    });
+    assert.deepEqual(parseDoctorClaudeOptions([]), DEFAULTS);
   });
 
   it('sets refreshLive=true when --refresh-live is present', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--refresh-live']), {
+      ...DEFAULTS,
       refreshLive: true,
-      account: null,
-      help: false,
     });
   });
 
   it('handles mixed / unknown args gracefully', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--foo', '--refresh-live', 'bar']), {
+      ...DEFAULTS,
       refreshLive: true,
-      account: null,
-      help: false,
     });
   });
 
   it('handles null/undefined args', () => {
-    assert.deepEqual(parseDoctorClaudeOptions(undefined), {
-      refreshLive: false,
-      account: null,
-      help: false,
-    });
-    assert.deepEqual(parseDoctorClaudeOptions(null), {
-      refreshLive: false,
-      account: null,
-      help: false,
-    });
+    assert.deepEqual(parseDoctorClaudeOptions(undefined), DEFAULTS);
+    assert.deepEqual(parseDoctorClaudeOptions(null), DEFAULTS);
   });
 
   it('parses --account <value>', () => {
     assert.deepEqual(parseDoctorClaudeOptions(['--refresh-live', '--account', 'work']), {
+      ...DEFAULTS,
       refreshLive: true,
       account: 'work',
-      help: false,
     });
   });
 
   it('ignores --account without value', () => {
-    assert.deepEqual(parseDoctorClaudeOptions(['--account']), {
-      refreshLive: false,
-      account: null,
-      help: false,
-    });
+    assert.deepEqual(parseDoctorClaudeOptions(['--account']), DEFAULTS);
   });
 
   it('treats --account "" as "no value" and lets subsequent flags parse (legacy contract)', () => {
     // 공통 helper 전환 후에도 빈 문자열은 default 유지하고 consume하지 않아
     // 이어지는 --refresh-live가 정상 파싱되어야 한다.
     assert.deepEqual(parseDoctorClaudeOptions(['--account', '', '--refresh-live']), {
+      ...DEFAULTS,
       refreshLive: true,
-      account: null,
-      help: false,
     });
+  });
+
+  it('parses --dedupe / --apply / --backfill-account-id (issue #37)', () => {
+    assert.deepEqual(
+      parseDoctorClaudeOptions(['--dedupe', '--apply', '--backfill-account-id']),
+      {
+        ...DEFAULTS,
+        dedupe: true,
+        apply: true,
+        backfillAccountId: true,
+      },
+    );
   });
 
   it('recognizes --help and -h', () => {

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -277,15 +277,12 @@ describe('parseDoctorClaudeOptions', () => {
   });
 
   it('parses --dedupe / --apply / --backfill-account-id (issue #37)', () => {
-    assert.deepEqual(
-      parseDoctorClaudeOptions(['--dedupe', '--apply', '--backfill-account-id']),
-      {
-        ...DEFAULTS,
-        dedupe: true,
-        apply: true,
-        backfillAccountId: true,
-      },
-    );
+    assert.deepEqual(parseDoctorClaudeOptions(['--dedupe', '--apply', '--backfill-account-id']), {
+      ...DEFAULTS,
+      dedupe: true,
+      apply: true,
+      backfillAccountId: true,
+    });
   });
 
   it('recognizes --help and -h', () => {

--- a/packages/agent/test/cli/doctor-dedupe-flow.test.js
+++ b/packages/agent/test/cli/doctor-dedupe-flow.test.js
@@ -20,9 +20,7 @@ describe('findBackfillCandidates', () => {
   });
 
   it('skips accounts with accountId set', () => {
-    const accounts = [
-      { accountKey: 'a', accountId: 'sub1', raw: { idToken: JWT_SUB_A } },
-    ];
+    const accounts = [{ accountKey: 'a', accountId: 'sub1', raw: { idToken: JWT_SUB_A } }];
     assert.deepEqual(findBackfillCandidates(accounts), []);
   });
 

--- a/packages/agent/test/cli/doctor-dedupe-flow.test.js
+++ b/packages/agent/test/cli/doctor-dedupe-flow.test.js
@@ -1,0 +1,228 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDedupePlan,
+  applyDedupePlan,
+  findBackfillCandidates,
+} from '../../src/cli/doctor-dedupe-flow.js';
+import { createEmptyAuthStore, createAccount } from '../../src/auth/auth-store-schema.js';
+import { upsertProviderAccount } from '../../src/auth/auth-store.js';
+
+// base64url for { "sub": "google-oauth2|115" }
+const JWT_SUB_A = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJnb29nbGUtb2F1dGgyfDExNSJ9.';
+
+describe('findBackfillCandidates', () => {
+  it('returns [] for empty / non-array input', () => {
+    assert.deepEqual(findBackfillCandidates([]), []);
+    assert.deepEqual(findBackfillCandidates(null), []);
+    assert.deepEqual(findBackfillCandidates(undefined), []);
+  });
+
+  it('skips accounts with accountId set', () => {
+    const accounts = [
+      { accountKey: 'a', accountId: 'sub1', raw: { idToken: JWT_SUB_A } },
+    ];
+    assert.deepEqual(findBackfillCandidates(accounts), []);
+  });
+
+  it('skips accounts without raw.idToken', () => {
+    const accounts = [{ accountKey: 'a', accountId: null }];
+    assert.deepEqual(findBackfillCandidates(accounts), []);
+  });
+
+  it('extracts sub from raw.idToken when accountId is missing', () => {
+    const accounts = [
+      { accountKey: 'a', accountId: null, raw: { idToken: JWT_SUB_A } },
+      { accountKey: 'b', accountId: 'sub-existing' }, // 무시됨
+    ];
+    const out = findBackfillCandidates(accounts);
+    assert.equal(out.length, 1);
+    assert.deepEqual(out[0], { accountKey: 'a', sub: 'google-oauth2|115' });
+  });
+
+  it('skips when idToken decode fails (no sub)', () => {
+    const noSub = 'eyJhbGciOiJub25lIn0.eyJlbWFpbCI6ImFAeC5jb20ifQ.'; // { email: a@x.com }
+    const accounts = [{ accountKey: 'a', accountId: null, raw: { idToken: noSub } }];
+    assert.deepEqual(findBackfillCandidates(accounts), []);
+  });
+});
+
+describe('buildDedupePlan', () => {
+  it('returns empty plan when no duplicates and backfill option off', () => {
+    const accounts = [
+      { accountKey: 'a', accountId: 'sub1', email: 'a@x.com', source: 'agent-store' },
+    ];
+    const plan = buildDedupePlan({ accounts, options: { backfillAccountId: false } });
+    assert.deepEqual(plan.groups, []);
+    assert.deepEqual(plan.backfillCandidates, []);
+  });
+
+  it('returns groups but skips backfill when option is off', () => {
+    const accounts = [
+      {
+        accountKey: 'a',
+        accountId: null,
+        email: 'a@x.com',
+        raw: { idToken: JWT_SUB_A },
+        source: 'agent-store',
+      },
+      {
+        accountKey: 'b',
+        accountId: 'google-oauth2|115',
+        email: 'a@x.com',
+        source: 'agent-store',
+      },
+    ];
+    const plan = buildDedupePlan({ accounts, options: { backfillAccountId: false } });
+    assert.equal(plan.groups.length, 1);
+    assert.deepEqual(plan.backfillCandidates, []);
+  });
+
+  it('includes backfill candidates when option is on', () => {
+    const accounts = [
+      {
+        accountKey: 'a',
+        accountId: null,
+        email: 'a@x.com',
+        raw: { idToken: JWT_SUB_A },
+        source: 'agent-store',
+      },
+    ];
+    const plan = buildDedupePlan({ accounts, options: { backfillAccountId: true } });
+    assert.deepEqual(plan.groups, []);
+    assert.equal(plan.backfillCandidates.length, 1);
+    assert.equal(plan.backfillCandidates[0].sub, 'google-oauth2|115');
+  });
+});
+
+describe('applyDedupePlan', () => {
+  it('removes duplicate accountKeys from store', () => {
+    let store = createEmptyAuthStore();
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'primary',
+        email: 'a@x.com',
+        accountId: 'sub1',
+      }),
+    );
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'duplicate',
+        email: 'a@x.com',
+        accountId: null,
+      }),
+    );
+
+    const plan = {
+      groups: [
+        {
+          reason: 'same-email',
+          identityKey: 'a@x.com',
+          primary: { accountKey: 'primary' },
+          duplicates: [{ accountKey: 'duplicate' }],
+        },
+      ],
+      backfillCandidates: [],
+    };
+
+    const next = applyDedupePlan(store, 'openai-codex', plan);
+    const accounts = next.providers['openai-codex'].accounts;
+    assert.equal(accounts.length, 1);
+    assert.equal(accounts[0].accountKey, 'primary');
+  });
+
+  it('applies backfill — fills accountId from sub', () => {
+    let store = createEmptyAuthStore();
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'legacy',
+        email: 'a@x.com',
+        accountId: null,
+        raw: { idToken: JWT_SUB_A },
+      }),
+    );
+
+    const plan = {
+      groups: [],
+      backfillCandidates: [{ accountKey: 'legacy', sub: 'google-oauth2|115' }],
+    };
+
+    const next = applyDedupePlan(store, 'openai-codex', plan);
+    const account = next.providers['openai-codex'].accounts[0];
+    assert.equal(account.accountId, 'google-oauth2|115');
+  });
+
+  it('removal + backfill 동시 적용', () => {
+    let store = createEmptyAuthStore();
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'primary',
+        accountId: 'sub1',
+        email: 'a@x.com',
+      }),
+    );
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'dup',
+        accountId: null,
+        email: 'a@x.com',
+      }),
+    );
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({
+        accountKey: 'legacy',
+        accountId: null,
+        email: 'b@x.com',
+        raw: { idToken: JWT_SUB_A },
+      }),
+    );
+
+    const plan = {
+      groups: [
+        {
+          reason: 'same-email',
+          identityKey: 'a@x.com',
+          primary: { accountKey: 'primary' },
+          duplicates: [{ accountKey: 'dup' }],
+        },
+      ],
+      backfillCandidates: [{ accountKey: 'legacy', sub: 'google-oauth2|115' }],
+    };
+
+    const next = applyDedupePlan(store, 'openai-codex', plan);
+    const accounts = next.providers['openai-codex'].accounts;
+    assert.equal(accounts.length, 2);
+    assert.ok(accounts.find((a) => a.accountKey === 'primary'));
+    const legacy = accounts.find((a) => a.accountKey === 'legacy');
+    assert.equal(legacy.accountId, 'google-oauth2|115');
+    // dup 은 제거됨
+    assert.ok(!accounts.find((a) => a.accountKey === 'dup'));
+  });
+
+  it('빈 plan 은 store 변경 없음', () => {
+    let store = createEmptyAuthStore();
+    store = upsertProviderAccount(
+      store,
+      'openai-codex',
+      createAccount({ accountKey: 'a', email: 'a@x.com' }),
+    );
+    const next = applyDedupePlan(store, 'openai-codex', {
+      groups: [],
+      backfillCandidates: [],
+    });
+    assert.equal(next.providers['openai-codex'].accounts.length, 1);
+  });
+});

--- a/packages/agent/test/cli/doctor-dedupe-formatters.test.js
+++ b/packages/agent/test/cli/doctor-dedupe-formatters.test.js
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatDedupeProposal,
+  formatDedupeApplied,
+  formatDedupeNoChanges,
+} from '../../src/cli/doctor-dedupe-formatters.js';
+
+describe('formatDedupeProposal — 중복 없음', () => {
+  it('"중복 후보: 없음" 출력 + dry-run 메시지', () => {
+    const lines = formatDedupeProposal({
+      providerId: 'openai-codex',
+      accounts: [{ accountKey: 'a' }],
+      plan: { groups: [], backfillCandidates: [] },
+      options: { apply: false, backfillAccountId: false },
+    });
+    const text = lines.join('\n');
+    assert.match(text, /codex 계정 dedupe 검사/);
+    assert.match(text, /저장된 codex 계정: 1/);
+    assert.match(text, /중복 후보: 없음/);
+    assert.match(text, /변경 사항이 없습니다 \(dry-run\)/);
+  });
+});
+
+describe('formatDedupeProposal — 중복 그룹 1건', () => {
+  it('그룹 + primary + duplicates 표시 + apply 안내', () => {
+    const lines = formatDedupeProposal({
+      providerId: 'openai-codex',
+      accounts: [{ accountKey: 'a' }, { accountKey: 'b' }],
+      plan: {
+        groups: [
+          {
+            reason: 'same-sub',
+            identityKey: 'google-oauth2|115',
+            primary: {
+              accountKey: 'a',
+              source: 'agent-store',
+              updatedAt: '2026-04-29T00:00:00Z',
+            },
+            duplicates: [{ accountKey: 'b', accountId: null }],
+          },
+        ],
+        backfillCandidates: [],
+      },
+      options: { apply: false, backfillAccountId: false },
+    });
+    const text = lines.join('\n');
+    assert.match(text, /중복 후보 \(1 그룹\)/);
+    assert.match(text, /\[그룹 1\] sub 일치: google-oauth2\|115/);
+    assert.match(text, /유지: a \(source=agent-store, updatedAt=2026-04-29/);
+    assert.match(text, /제거 후보: b \(reason=same-sub, accountId=null\)/);
+    assert.match(text, /token-weather doctor codex --dedupe --apply/);
+  });
+});
+
+describe('formatDedupeProposal — backfill 옵션', () => {
+  it('backfill 후보 출력 + apply 명령에 --backfill-account-id 포함', () => {
+    const lines = formatDedupeProposal({
+      providerId: 'openai-codex',
+      accounts: [{ accountKey: 'a' }],
+      plan: {
+        groups: [],
+        backfillCandidates: [{ accountKey: 'a', sub: 'google-oauth2|115' }],
+      },
+      options: { apply: false, backfillAccountId: true },
+    });
+    const text = lines.join('\n');
+    assert.match(text, /accountId backfill 후보 \(1\)/);
+    assert.match(text, /a → accountId=google-oauth2\|115/);
+    assert.match(text, /--dedupe --backfill-account-id --apply/);
+  });
+
+  it('backfill 옵션 켜져있고 후보 0건', () => {
+    const lines = formatDedupeProposal({
+      providerId: 'openai-codex',
+      accounts: [],
+      plan: { groups: [], backfillCandidates: [] },
+      options: { apply: false, backfillAccountId: true },
+    });
+    const text = lines.join('\n');
+    assert.match(text, /accountId backfill 후보: 없음/);
+  });
+});
+
+describe('formatDedupeApplied', () => {
+  it('제거 + backfill 모두 보고', () => {
+    const lines = formatDedupeApplied({
+      groups: [
+        {
+          reason: 'same-sub',
+          duplicates: [{ accountKey: 'dup1' }, { accountKey: 'dup2' }],
+        },
+      ],
+      backfillCandidates: [{ accountKey: 'a', sub: 'google-oauth2|115' }],
+    });
+    const text = lines.join('\n');
+    assert.match(text, /✓ 제거: dup1 \(same-sub\)/);
+    assert.match(text, /✓ 제거: dup2 \(same-sub\)/);
+    assert.match(text, /✓ backfill: a → accountId=google-oauth2\|115/);
+    assert.match(text, /총 2건 제거 \+ 1건 backfill/);
+  });
+
+  it('제거만 (backfill 없음)', () => {
+    const lines = formatDedupeApplied({
+      groups: [{ reason: 'same-sub', duplicates: [{ accountKey: 'dup1' }] }],
+      backfillCandidates: [],
+    });
+    const text = lines.join('\n');
+    assert.match(text, /총 1건 제거\./);
+    assert.doesNotMatch(text, /backfill/);
+  });
+});
+
+describe('formatDedupeNoChanges', () => {
+  it('변경 없음 메시지', () => {
+    const lines = formatDedupeNoChanges();
+    const text = lines.join('\n');
+    assert.match(text, /변경 사항이 없습니다/);
+  });
+});
+
+describe('formatDedupeProposal — claude provider', () => {
+  it('claude label 사용', () => {
+    const lines = formatDedupeProposal({
+      providerId: 'claude',
+      accounts: [],
+      plan: { groups: [], backfillCandidates: [] },
+      options: { apply: false, backfillAccountId: false },
+    });
+    const text = lines.join('\n');
+    assert.match(text, /claude 계정 dedupe 검사/);
+  });
+});


### PR DESCRIPTION
## 요약

issue #37 — 같은 OAuth subject (sub 또는 email) 를 가진 store 의 중복 레코드를 dry-run 으로 감지하고 `--apply` 로 정리하는 명령. login 시점 자동 정리(PR #38) 이전에 누적된 legacy accountKey 또는 id_token 파싱이 부분 실패한 레코드를 사용자가 명시적으로 청소할 수 있다.

## 변경 내용

- **신규 코어**: `findDuplicateGroups(accounts)` — store 내부 중복 그룹화 (PR #38 의 `findLegacyDuplicates` 와 시그니처 다름, 정책은 동일)
- **신규 helper**: `updateProviderAccount(store, providerId, accountKey, patch)` — backfill 용 partial patch
- **신규 CLI flow**: `doctor-dedupe-flow.js` (buildDedupePlan / applyDedupePlan / findBackfillCandidates / runDedupeFlow), `doctor-dedupe-formatters.js`
- **doctor-command.js**: `--dedupe` / `--apply` / `--backfill-account-id` 옵션 + dispatch + help 텍스트 갱신
- **docs/auth-cli.md**: `### --dedupe` 섹션 (사용 예 + primary 우선순위 + 안전 가이드)
- **changeset**: minor bump (3 패키지 linked)

## 변경 이유

issue #37 의 실 사례 — Codex 에 같은 google-oauth2 sub 인 두 계정이 공존 (`live-ac_OYnlw@codex.openai.com` legacy + `google-oauth2|...@gmail.com` 정상). PR #38 가 login 시점 자동 정리는 추가했지만, 이미 store 에 누적된 stale 레코드는 그대로. 명시적 정리 명령이 필요.

dry-run 기본 + `--apply` opt-in 으로 안전성 확보. `auth.json` schema 변경 없음.

## 운영 결정 (open question 일괄)

- `--account` + `--dedupe` → `--account` 무시 + warning (dedupe 는 모든 계정 검사)
- disabled 계정도 그룹화 대상 포함, primary 선택에서 active 우선
- interactive 확인 미도입 (`--apply` 자체가 명시적 의사 표현)
- v1 은 codex / claude 각각만 — `doctor --dedupe` (provider 미지정) 미지원
- 한글 출력 유지

## 영향 범위

- [x] `packages/agent` — auth helpers + cli flow / formatters
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [x] `repo` — changeset
- [x] `docs` — auth-cli.md

## 테스트 / 확인

- [x] `npm test` — 802 통과 (44 신규 회귀 가드 + 기존 758 무회귀)
- [x] `npm run lint` 통과
- [x] dry-run / apply / backfill 수동 검증은 머지 후 자연 검증 (사용자가 issue #37 의 실 store 에 적용)
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음

## 리뷰 포인트

- `findDuplicateGroups` 의 transitive grouping (A↔B sub + B↔C email → 한 그룹) — 의도된 동작인지 검토
- primary 선택 우선순위 5단 — 본 PR 의 hard-coded 가 본 repo 운영 패턴과 부합하는지
- `--account` 무시 정책 — 별도 사용자 의도 분기가 필요한지
- formatter 출력 메시지의 한글 표현 + 명령 예시 정확성

## 참고 사항

- 본 PR 머지 후 별도 수동 작업 없음 (changeset 자동 흡수 → release PR 자동 갱신)
- 폐기된 GitFlow lite 모델 후보 같은 거 없음 — 단일 직선 구현
- 관련 issue: #37
- 참고 PR: #38 (login 시점 자동 정리, 본 PR 의 정책 모태)