### PR TITLE
[refactor] codex refreshCodexToken 을 dedicated 파일로 분리 (provider-adapters symmetry)

### DIFF
--- a/.changeset/refresh-codex-token-extract.md
+++ b/.changeset/refresh-codex-token-extract.md
@@ -1,0 +1,7 @@
+---
+'@token-weather/cli': patch
+'@token-weather/provider-adapters': patch
+'@token-weather/schemas': patch
+---
+
+refactor(adapters): `refreshCodexToken` 을 dedicated `codex/refresh-codex-token.js` 로 분리. 기존엔 `codex/exchange-codex-authorization-code.js` 안에 inline 으로 있어 `claude/refresh-claude-token.js` 와 위치 비대칭이었음. public API 변화 없음 — 모든 소비자가 `@token-weather/provider-adapters/src/codex/index.js` 를 통해 import 하므로 호출 사이트 변경 0. 두 provider 가 `refresh-*-token.js` 의 동일한 파일 구조로 정렬되어 미래 provider 추가 시 패턴 따라가기 쉬워진다 (issue #105 의 일부).

--- a/packages/provider-adapters/README.md
+++ b/packages/provider-adapters/README.md
@@ -29,6 +29,7 @@ src/
     read-codex-auth-profiles.js
     fetch-codex-usage.js
     exchange-codex-authorization-code.js
+    refresh-codex-token.js
     index.js
   index.js
 ```

--- a/packages/provider-adapters/src/codex/exchange-codex-authorization-code.js
+++ b/packages/provider-adapters/src/codex/exchange-codex-authorization-code.js
@@ -1,11 +1,12 @@
 /**
- * Codex (OpenAI) OAuth token 교환 (authorization_code / refresh_token).
+ * Codex (OpenAI) OAuth authorization_code 교환.
  *
- * 공통 transport 로직은 `../shared/oauth-token-endpoint.js`에 있다.
+ * refresh_token 흐름은 `./refresh-codex-token.js` (v0.3.0 분리, Claude 의
+ * refresh-claude-token.js 와 대칭). 공통 transport 로직은
+ * `../shared/oauth-token-endpoint.js`.
  *
  * 미해결:
  *   - client_secret 필요 여부 (현재는 public client 가정)
- *   - refresh token rotation 정책
  */
 
 import { CODEX_AUTH } from './codex-auth-constants.js';
@@ -56,40 +57,6 @@ export async function exchangeCodexAuthorizationCode({
       ...(clientSecret ? { client_secret: clientSecret } : {}),
     },
     errorPrefix: 'Token exchange failed',
-    fetchImpl,
-  });
-}
-
-/**
- * Refresh an access token using a refresh token.
- *
- * @param {{
- *   refreshToken: string,
- *   clientId?: string,
- *   clientSecret?: string,
- *   tokenEndpoint?: string,
- *   fetchImpl?: typeof fetch,
- * }} params
- * @returns {Promise<TokenResponse>}
- */
-export async function refreshCodexToken({
-  refreshToken,
-  clientId = CODEX_AUTH.observedClientId,
-  clientSecret,
-  tokenEndpoint = CODEX_AUTH.tokenEndpoint,
-  fetchImpl,
-}) {
-  return postToTokenEndpoint({
-    endpoint: tokenEndpoint,
-    encoding: 'form',
-    body: {
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      client_id: clientId,
-      ...(clientSecret ? { client_secret: clientSecret } : {}),
-    },
-    errorPrefix: 'Token refresh failed',
-    fallbackRefreshToken: refreshToken,
     fetchImpl,
   });
 }

--- a/packages/provider-adapters/src/codex/index.js
+++ b/packages/provider-adapters/src/codex/index.js
@@ -3,3 +3,4 @@ export * from './fetch-codex-usage.js';
 export * from './codex-auth-constants.js';
 export * from './build-codex-authorization-url.js';
 export * from './exchange-codex-authorization-code.js';
+export * from './refresh-codex-token.js';

--- a/packages/provider-adapters/src/codex/refresh-codex-token.js
+++ b/packages/provider-adapters/src/codex/refresh-codex-token.js
@@ -1,0 +1,46 @@
+import { CODEX_AUTH } from './codex-auth-constants.js';
+import { postToTokenEndpoint } from '../shared/oauth-token-endpoint.js';
+
+/**
+ * Codex (OpenAI) OAuth refresh token 교환.
+ *
+ * Claude refreshClaudeToken과 동일한 shape — 단 Codex 는 form-encoded body
+ * 를 요구해 `encoding: 'form'` 을 사용한다 (Claude 는 'json'). 응답에
+ * `refresh_token` 이 오면 rotation, 아니면 입력 refreshToken 을 그대로 유지
+ * (`fallbackRefreshToken`).
+ *
+ * 본 함수는 v0.3.0 에서 `exchange-codex-authorization-code.js` 로부터 분리
+ * (issue #105 / refactor: provider-adapters symmetry). 두 provider 의
+ * `refresh-*-token.js` 단독 파일 구조로 정렬되어 미래 provider 추가 시
+ * 패턴을 따라가기 쉬워진다.
+ *
+ * @param {{
+ *   refreshToken: string,
+ *   clientId?: string,
+ *   clientSecret?: string,
+ *   tokenEndpoint?: string,
+ *   fetchImpl?: typeof fetch,
+ * }} params
+ * @returns {Promise<import('./exchange-codex-authorization-code.js').TokenResponse>}
+ */
+export async function refreshCodexToken({
+  refreshToken,
+  clientId = CODEX_AUTH.observedClientId,
+  clientSecret,
+  tokenEndpoint = CODEX_AUTH.tokenEndpoint,
+  fetchImpl,
+}) {
+  return postToTokenEndpoint({
+    endpoint: tokenEndpoint,
+    encoding: 'form',
+    body: {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: clientId,
+      ...(clientSecret ? { client_secret: clientSecret } : {}),
+    },
+    errorPrefix: 'Token refresh failed',
+    fallbackRefreshToken: refreshToken,
+    fetchImpl,
+  });
+}

--- a/packages/provider-adapters/test/codex/exchange-codex-authorization-code.test.js
+++ b/packages/provider-adapters/test/codex/exchange-codex-authorization-code.test.js
@@ -1,10 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import {
-  exchangeCodexAuthorizationCode,
-  refreshCodexToken,
-} from '../../src/codex/exchange-codex-authorization-code.js';
+import { exchangeCodexAuthorizationCode } from '../../src/codex/exchange-codex-authorization-code.js';
 import { CODEX_AUTH } from '../../src/codex/codex-auth-constants.js';
 
 function jsonResponse({ status = 200, body = {} } = {}) {
@@ -122,73 +119,5 @@ describe('exchangeCodexAuthorizationCode', () => {
   });
 });
 
-describe('refreshCodexToken', () => {
-  it('POSTs refresh_token grant with client_id', async () => {
-    let captured;
-    const fetchImpl = async (_u, init) => {
-      captured = init;
-      return jsonResponse({
-        body: {
-          access_token: 'at',
-          refresh_token: 'rt-new',
-          expires_in: 3600,
-          token_type: 'Bearer',
-        },
-      });
-    };
-    await refreshCodexToken({
-      refreshToken: 'rt-old',
-      fetchImpl,
-    });
-    const params = new URLSearchParams(captured.body);
-    assert.equal(params.get('grant_type'), 'refresh_token');
-    assert.equal(params.get('refresh_token'), 'rt-old');
-    assert.equal(params.get('client_id'), CODEX_AUTH.observedClientId);
-  });
-
-  it('keeps existing refreshToken when response omits one (no rotation)', async () => {
-    const fetchImpl = async () =>
-      jsonResponse({ body: { access_token: 'a', expires_in: 1, token_type: 'Bearer' } });
-    const result = await refreshCodexToken({
-      refreshToken: 'rt-kept',
-      fetchImpl,
-    });
-    assert.equal(result.refreshToken, 'rt-kept');
-  });
-
-  it('uses rotated refreshToken when server returns one', async () => {
-    const fetchImpl = async () =>
-      jsonResponse({
-        body: {
-          access_token: 'a',
-          refresh_token: 'rt-rotated',
-          expires_in: 1,
-          token_type: 'Bearer',
-        },
-      });
-    const result = await refreshCodexToken({
-      refreshToken: 'rt-old',
-      fetchImpl,
-    });
-    assert.equal(result.refreshToken, 'rt-rotated');
-  });
-
-  it('throws descriptive error on non-2xx', async () => {
-    const fetchImpl = async () => ({
-      status: 401,
-      statusText: 'Unauthorized',
-      ok: false,
-      async text() {
-        return 'expired';
-      },
-    });
-    await assert.rejects(
-      () =>
-        refreshCodexToken({
-          refreshToken: 'rt',
-          fetchImpl,
-        }),
-      /Token refresh failed: 401/,
-    );
-  });
-});
+// refreshCodexToken 테스트는 dedicated 파일로 이동:
+// → packages/provider-adapters/test/codex/refresh-codex-token.test.js

--- a/packages/provider-adapters/test/codex/refresh-codex-token.test.js
+++ b/packages/provider-adapters/test/codex/refresh-codex-token.test.js
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { refreshCodexToken } from '../../src/codex/refresh-codex-token.js';
+import { CODEX_AUTH } from '../../src/codex/codex-auth-constants.js';
+
+function jsonResponse({ status = 200, body = {} } = {}) {
+  const text = JSON.stringify(body);
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    ok: status >= 200 && status < 300,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
+describe('refreshCodexToken', () => {
+  it('POSTs refresh_token grant with client_id', async () => {
+    let captured;
+    const fetchImpl = async (_u, init) => {
+      captured = init;
+      return jsonResponse({
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt-new',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        },
+      });
+    };
+    await refreshCodexToken({
+      refreshToken: 'rt-old',
+      fetchImpl,
+    });
+    const params = new URLSearchParams(captured.body);
+    assert.equal(params.get('grant_type'), 'refresh_token');
+    assert.equal(params.get('refresh_token'), 'rt-old');
+    assert.equal(params.get('client_id'), CODEX_AUTH.observedClientId);
+  });
+
+  it('keeps existing refreshToken when response omits one (no rotation)', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({ body: { access_token: 'a', expires_in: 1, token_type: 'Bearer' } });
+    const result = await refreshCodexToken({
+      refreshToken: 'rt-kept',
+      fetchImpl,
+    });
+    assert.equal(result.refreshToken, 'rt-kept');
+  });
+
+  it('uses rotated refreshToken when server returns one', async () => {
+    const fetchImpl = async () =>
+      jsonResponse({
+        body: {
+          access_token: 'a',
+          refresh_token: 'rt-rotated',
+          expires_in: 1,
+          token_type: 'Bearer',
+        },
+      });
+    const result = await refreshCodexToken({
+      refreshToken: 'rt-old',
+      fetchImpl,
+    });
+    assert.equal(result.refreshToken, 'rt-rotated');
+  });
+
+  it('throws descriptive error on non-2xx', async () => {
+    const fetchImpl = async () => ({
+      status: 401,
+      statusText: 'Unauthorized',
+      ok: false,
+      async text() {
+        return 'expired';
+      },
+    });
+    await assert.rejects(
+      () =>
+        refreshCodexToken({
+          refreshToken: 'rt',
+          fetchImpl,
+        }),
+      /Token refresh failed: 401/,
+    );
+  });
+});


### PR DESCRIPTION
## 요약

`packages/provider-adapters` 의 refresh-token 위치 비대칭 해소. claude 는 `refresh-claude-token.js` 단독 파일, codex 는 `exchange-codex-authorization-code.js` 안에 inline 이었음. 같은 일을 하는 함수가 위치만 다른 상태였는데 본 PR 에서 codex 도 dedicated 파일로 정렬.

## 변경 내용

- 신규 `packages/provider-adapters/src/codex/refresh-codex-token.js` — `refreshCodexToken` 함수 이동
- `codex/exchange-codex-authorization-code.js` — `refreshCodexToken` 함수 + 관련 JSDoc 제거 (exchange 만 유지)
- `codex/index.js` — `./refresh-codex-token.js` 의 export 추가
- 신규 `packages/provider-adapters/test/codex/refresh-codex-token.test.js` — 4 회귀 가드 (POST 형식 / no-rotation / rotation / 401 에러), 기존 exchange test 에서 verbatim 이동
- `test/codex/exchange-codex-authorization-code.test.js` — refresh describe 블록 제거 + import 정리
- `packages/provider-adapters/README.md` — codex 파일 트리에 `refresh-codex-token.js` 추가
- changeset (patch) — 사용자 가시 변화 없음

## 변경 이유

issue #105 의 provider-adapters 측면. 두 provider 가 동일한 4-파일 구조 (`build-*-authorization-url.js` / `exchange-*-authorization-code.js` / `refresh-*-token.js` / `fetch-*-usage.js`) 로 정렬되어 미래 provider 추가 시 패턴 따라가기 쉬워진다. 깊은 분석 결과 (`refactor/provider-adapters-unify` 의 plan 문서 참고), 두 provider 의 진짜 비대칭은 이 한 곳뿐이고 나머지 차이는 essential (Anthropic OAuth quirk + API 응답 shape 차이). 본 PR 은 그 한 곳만 정리한 작은 PR.

## 영향 범위

- [ ] `packages/agent` — 직접 변경 없음 (소비자는 모두 codex/index.js 의 re-export 통해 import → 호출 사이트 변화 0)
- [ ] `packages/schemas`
- [x] `packages/provider-adapters` — 1 신규 + 1 기존 분리 + index 1줄
- [ ] `repo`
- [x] `docs` — provider-adapters/README.md 의 파일 트리 한 줄

## 테스트 / 확인

- [x] `npm test` 전체 통과 (refresh 4건은 위치만 이동, 무회귀)
- [x] `npm run lint` 통과
- [x] `npm run format:check` 통과
- [x] `npm run build:types` 정상 (d.ts emit OK)
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음

## 리뷰 포인트

- `refresh-codex-token.js` 의 JSDoc — 분리 사유와 claude 와의 대칭성 명시가 미래 reader 에게 충분한지
- `codex/index.js` export 순서 — 기존 라인들 뒤에 `refresh-codex-token` 추가, 알파벳 정렬 아닌 의미적 순서 (build → exchange → refresh) 그대로
- 본 PR 은 의도적으로 작게 유지 — Phase 2 (fetch-usage scaffold 추출) / Phase 3 (validation 정렬) 은 별도 PR 로 분리

## 참고 사항

- 본 PR 은 issue #105 (login-runner refactor) 의 provider-adapters 측면 일부. login-runner 본체 (saveLiveExchangeAccount 80+ LOC 분해) 는 별도 작업.
- 깊은 분석 결과 codex/claude 의 다른 차이들 (encoding, 헤더, usage window 구조, timestamp 등) 은 essential (provider API 가 진짜 다름) 이라 통합 안 함.
- 별도 issue #110 — claude stats-cache.json 의존 제거 — 도 진행 예정 (다른 도메인이라 별도 branch).
- 관련 plan 문서: `/home/lagoon3/.claude/plans/provider-adapters-refactor.md`
- 관련 issue: #105