### PR TITLE
[docs] CHANGELOG v0.3.0 entry 수동 큐레이트 (release PR #109 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@
 
 이 섹션은 publish 시점에 root에서 **수동으로 큐레이트**합니다 — 3 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 패키지별 상세 release note는 [Changesets](https://github.com/changesets/changesets)가 `packages/*/CHANGELOG.md`를 자동 생성하고, 본 문서는 publish PR에서 그 내용을 참고해 채웁니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 changeset을 함께 commit 해주세요.
 
+## [0.3.0] - 2026-05-11
+
+두 차례의 architectural symmetry 정비 release. claude / codex 의 fallback credential 흐름과 refresh helper 위치가 1:1 대칭으로 정렬되고, `status --json` 의 키 정합을 위한 `SCHEMA_VERSION` 두 단계 bump (`0.1.0` → `0.3.0`). 운영 측면에서는 `doctor --dedupe` 신규 진단 명령으로 누적 stale 레코드의 retroactive 정리 경로 확보.
+
+### Changed (Breaking)
+
+- **claude `~/.claude/stats-cache.json` 의존 제거** — `status --json` 의 `claude.usage` 필드 + per-session/per-message 누적 통계 출력 + public export (`readClaudeStatsCache`, `parseClaudeStatsCache`, `resolveClaudeUsageSource`, `resolveClaudeUsageSourcePath`) 모두 제거. 본 도구는 이제 network endpoint (`/api/oauth/usage`) 의 window 기반 사용률 (`five_hour` / `seven_day`) 만 노출 — Codex 의 server-side rate-limit 모델과 architectural symmetry ([#112]).
+- **codex 폴백을 OpenClaw `auth-profiles.json` 에서 Codex CLI `~/.codex/auth.json` (`codex-cli-import`) 으로 교체** — claude 의 `claude-cli-import` 와 1:1 대칭. OpenClaw 환경 의존이 끊기고 npm 일반 사용자에게도 의미 있는 폴백이 제공됨 ([#114]).
+- `status --json` 의 `authSource` enum: `'openclaw-import'` 제거 + `'codex-cli-import'` 추가 ([#114]).
+- `status --json` 의 `codex.authProfilesPath` 필드 → `codex.credentialsPath` (claude 와 동일 표면, `~/.codex/auth.json` 경로) ([#114]).
+- `@token-weather/provider-adapters` codex 영역의 public export 정비 — 제거: `readCodexAuthProfiles` / `getDefaultAuthProfilesPath`. 신규: `readCodexCliCredentials` / `resolveCodexCliCredentialsPath` / `parseCodexCliCredentials` / `mapCodexCredentials` / `buildImportedCodexAccount` / `resolveImportedCodexAccounts` / `selectCodexAccountsSource` / `resolveImportedCodexSnapshot` ([#114]).
+- `SCHEMA_VERSION` `'0.1.0'` → `'0.3.0'` (두 단계 bump: `0.1.0` → `0.2.0` ([#112]), `0.2.0` → `0.3.0` ([#114])). `auth-store-schema.js::CREDENTIAL_SOURCES` enum 정합 — `'openclaw-import'` 제거 + 누락이던 `'claude-cli-import'` / `'codex-cli-import'` 명시 ([#114]).
+
+**Migration**:
+
+- `status --json` 의 `.providers[].snapshot.usage` 또는 `.providers[].snapshot.usage.source === 'stats-cache-json'` 분기 → 필드 부재. window 정보는 `.providers[].snapshot.networkUsage.usageWindows` 에서 그대로 수신.
+- `.providers[].snapshot.authSource === 'openclaw-import'` 분기 → `'codex-cli-import'`.
+- `.providers[].snapshot.codex.authProfilesPath` 참조 → `.credentialsPath`.
+- OpenClaw 워크스페이스 사용자: 1회 `token-weather auth login codex` 실행 (또는 OpenClaw 측이 `~/.config/token-weather/auth.json` 에 직접 inject — OpenClaw repo 후속 작업 영역).
+- `@token-weather/provider-adapters` 의 `readCodexAuthProfiles` 직접 import 한 consumer → `readCodexCliCredentials` + `buildImportedCodexAccount` 패턴으로 갱신.
+
+### Added
+
+- **`doctor codex/claude --dedupe` / `--apply` / `--backfill-account-id`** — 같은 OAuth subject (sub 또는 email) 의 stale 레코드를 dry-run 으로 감지하고 `--apply` 로 정리. login 시점 자동 정리(PR #38) 이전에 누적된 legacy accountKey 또는 id_token 파싱이 부분 실패한 레코드를 retroactive 로 청소 ([#108]).
+
+### Fixed
+
+- codex-cli-import fallback profile normalize 누락 수정 — `--account codex-cli-import` 필터 매칭 + `buildUsageSnapshot` 의 `snapshotId` / `account.profileId` 가 `codex:undefined:` 형태로 오염되던 회귀 차단. claude 의 `resolveClaudeProfileFromSnapshot` 과 1:1 대칭으로 `resolveCodexProfileFromAccount` 신설 (PR #114 review follow-up).
+
+### Internal
+
+- `refreshCodexToken` 을 dedicated `codex/refresh-codex-token.js` 로 분리 — `claude/refresh-claude-token.js` 와 위치 대칭. public API 변화 없음 (모든 소비자가 `codex/index.js` 통해 import) ([#111]).
+- `docs/auth-cli.md` `doctor --dedupe` / `--apply` / `--backfill-account-id` 사용 예 + 안전 가이드 추가.
+- `docs/cli-json-output.md` / `docs/architecture.md` / `docs/codebase-guide.md` / `docs/provider-notes.md` — stats-cache 제거 + codex-cli-import 전환 반영.
+
+[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.3.0
+
+[#108]: https://github.com/LLagoon3/token-weather/pull/108
+[#111]: https://github.com/LLagoon3/token-weather/pull/111
+[#112]: https://github.com/LLagoon3/token-weather/pull/112
+[#114]: https://github.com/LLagoon3/token-weather/pull/114
+
 ## [0.2.0] - 2026-04-29
 
 `auth login` default 동작을 실제 OAuth 토큰 교환으로 뒤집고 Codex/Claude 일관성 정렬 + observed `client_id` 가드 제거. publish 인프라 측면에서 첫 OIDC + Trusted Publishing + SLSA provenance 적용 release.
@@ -33,7 +76,6 @@
 - release workflow Node 24 + 번들 npm 11+ — Trusted Publishing OIDC 요구사항 self-upgrade 없이 충족 ([#101]).
 - install smoke (#75) + Trusted Publishing 운영 검증 흐름 정착 (release 격리/복원/token 제거 PR 시리즈 ([#92], [#93], [#94], [#95])).
 
-[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.2.0
 
 [#91]: https://github.com/LLagoon3/token-weather/pull/91


### PR DESCRIPTION
## 요약

release-policy.md §4 의 root CHANGELOG 운영 정책 ('publish 시점에 root 에서 수동 큐레이트') 정합. release PR #109 머지 직전 prep — v0.2.0 시점엔 publish 후 follow-up 으로 들어갔던 entry 를 이번엔 사전 배치.

## 변경 내용

`CHANGELOG.md` — `[Unreleased]` 아래에 `[0.3.0] - 2026-05-11` entry 신설. 카테고리:

- **Changed (Breaking)** — 6 항목 (#112 stats-cache 제거 / #114 codex-cli-import 전환 / authSource enum / authProfilesPath → credentialsPath / public export 정비 / SCHEMA_VERSION 0.1.0 → 0.3.0 + CREDENTIAL_SOURCES enum 정합)
- **Migration** — 5 항목 (usage 키 분기 / authSource enum / field rename / OpenClaw 사용자 1회 auth login / readCodexAuthProfiles consumer 갱신)
- **Added** — #108 (`doctor --dedupe` / `--apply` / `--backfill-account-id`)
- **Fixed** — PR #114 review follow-up (codex-cli-import fallback 의 profile normalize 누락 수정, `resolveCodexProfileFromAccount` 신설)
- **Internal** — #111 (`refreshCodexToken` 을 dedicated 파일로 분리)

`[Unreleased]` compare link 도 `v0.3.0...HEAD` 로 갱신 (next release 기준 재정렬). PR 번호 reference link 4건 추가.

## 변경 이유

- release-policy §4: per-package CHANGELOG 는 Changesets 자동 생성, root 는 high-level 요약을 publish PR 머지 전에 **수동 큐레이트**.
- release-policy §5 step 3: '[Unreleased] 섹션을 per-package 변경 요약 기준으로 수동 갱신 후 머지'.
- v0.2.0 publish 직후 entry 누락 → `0a0bbe4` 로 follow-up 추가됐던 회귀를 이번엔 사전 차단.

## 영향 범위

- [x] `CHANGELOG.md` — `[0.3.0]` entry 추가 + Unreleased link 갱신
- [ ] 패키지 코드 / 테스트 / docs — 변경 없음
- [ ] schemaVersion / contract — 변경 없음

## 테스트 / 확인

- [x] `npm test` 811 통과
- [x] `npm run lint` 통과
- [x] `npm run format:check` 통과
- [x] `repo-policy-readme.test.js` 의 [0.2.0]/[0.1.0] heading 단언 충족 (history 유지)
- [x] PR 본문 / 디프에 token / 자격증명 누출 없음

## 참고 사항

- 본 PR 머지 후 release PR #109 가 자동 force-update 됨. 그 PR 머지 시 `release.yml` 이 publish + main FF sync 실행 → v0.3.0 release 완료.
- per-package CHANGELOG (`packages/*/CHANGELOG.md`) 는 release PR #109 의 `changesets/action` 이 자동 생성 — 본 PR 은 root 큐레이트만 담당.
- 관련 정책: [docs/release-policy.md §4](docs/release-policy.md), [§5](docs/release-policy.md)
- 과거 동일 패턴 commit: `0a0bbe4 docs(changelog): v0.2.0 entry 추가 — 수동 큐레이트 (release-policy §4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)