### PR TITLE
[chore] status --json — Claude 영역 backward-compat alias 3 종 제거 (issue #119)

### DIFF
--- a/.changeset/claude-backward-compat-alias-removal.md
+++ b/.changeset/claude-backward-compat-alias-removal.md
@@ -15,7 +15,7 @@ chore(agent)!: `status --json` 의 claude provider 영역에서 backward-compat 
 
 **Migration**:
 
-- `.providers[].snapshot.networkUsage` 참조 → `.providers[].snapshot.networkUsages[0]` (단일 계정) 또는 array 순회.
+- `.providers[].snapshot.networkUsage` 참조 → `.providers[].snapshot.networkUsages[0].snapshot` (단일 계정) 또는 array 순회. **주의** — 이전 `networkUsage` 는 usage snapshot 객체 그대로였지만, 신규 `networkUsages[]` 의 각 원소는 `{ accountKey, account, snapshot }` wrapper. 실제 `usageWindows` / `status` 등 데이터는 `.snapshot` 안에 있어 `.snapshot` 단계 추가 필요. 자세한 예시는 `docs/cli-json-output.md` §"제거된 backward-compat alias (v0.4.0)".
 - `.providers[].snapshot.importedAccount` 참조 → `.providers[].snapshot.selectedAccount` 동일 의미.
 - `.providers[].snapshot.parsed` 참조 → `.providers[].snapshot.found` 동일 의미.
 

--- a/.changeset/claude-backward-compat-alias-removal.md
+++ b/.changeset/claude-backward-compat-alias-removal.md
@@ -1,0 +1,22 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+---
+
+chore(agent)!: `status --json` 의 claude provider 영역에서 backward-compat alias 3 종 제거 (issue #119). `SCHEMA_VERSION` `'0.3.0'` → `'0.4.0'`. v0.x convention 상 breaking 도 minor + `!` prefix (release-policy §1 / §3).
+
+**Breaking changes**:
+
+- `.providers[].snapshot.networkUsage` (단일 객체) 제거 — `.providers[].snapshot.networkUsages[]` (배열) 만 유지.
+- `.providers[].snapshot.importedAccount` 제거 — `.providers[].snapshot.selectedAccount` 만 유지 (동일 값이었음).
+- `.providers[].snapshot.parsed` 제거 — `.providers[].snapshot.found` 만 유지 (항상 같은 값이었음).
+- `formatClaudeSection` (status-formatters / doctor-helpers) 의 legacy `networkUsage` (단일) fallback 코드 경로 제거 — 항상 `networkUsages[]` 배열만 처리.
+
+**Migration**:
+
+- `.providers[].snapshot.networkUsage` 참조 → `.providers[].snapshot.networkUsages[0]` (단일 계정) 또는 array 순회.
+- `.providers[].snapshot.importedAccount` 참조 → `.providers[].snapshot.selectedAccount` 동일 의미.
+- `.providers[].snapshot.parsed` 참조 → `.providers[].snapshot.found` 동일 의미.
+
+`status --json` 외 평문 출력 / public API surface / runtime deps 무변경. 회귀 가드 — alias 키 부재 단언 신규 추가 (status-json.test.js / claude-provider.test.js / status-service.test.js).

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -85,13 +85,33 @@ token-weather status --json --account work@example.com --provider claude
 
 v0.4.0 (issue #119) 에서 claude provider snapshot 의 alias 3 종이 제거됐다. 외부 consumer 가 alias 키를 파싱하고 있었다면 정식 키로 마이그레이션 필요.
 
-| 제거된 alias                                     | 정식 키                                        | 비고                                                                           |
-| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
-| `.providers[].snapshot.networkUsage` (단일 객체) | `.providers[].snapshot.networkUsages[]` (배열) | 단일 계정 케이스는 `networkUsages[0]`. multi-account 도 `[]` 순회로 일관 처리. |
-| `.providers[].snapshot.importedAccount`          | `.providers[].snapshot.selectedAccount`        | 동일 값이었음.                                                                 |
-| `.providers[].snapshot.parsed`                   | `.providers[].snapshot.found`                  | 항상 `found` 와 동일 값이었음.                                                 |
+| 제거된 alias                                     | 정식 키                                        | 비고                                                                              |
+| ------------------------------------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `.providers[].snapshot.networkUsage` (단일 객체) | `.providers[].snapshot.networkUsages[]` (배열) | **원소 wrapper 주의** — 아래 참고. 단일 계정은 `[0]`, multi-account 는 `[]` 순회. |
+| `.providers[].snapshot.importedAccount`          | `.providers[].snapshot.selectedAccount`        | 동일 값이었음.                                                                    |
+| `.providers[].snapshot.parsed`                   | `.providers[].snapshot.found`                  | 항상 `found` 와 동일 값이었음.                                                    |
 
 이전 버전 (v0.3.x 이하) 에서는 두 키가 함께 출력되어 backward-compat 가 유지됐으나, v0.4.0 부터는 정식 키만 노출.
+
+### `networkUsages[]` 원소 구조 (중요)
+
+이전 `networkUsage` 는 usage snapshot **객체 그대로** 였지만, 신규 `networkUsages[]` 의 각 원소는 `{ accountKey, account, snapshot }` **wrapper**다. 실제 `usageWindows` / `status` 등 데이터는 `.snapshot` 안에 있다.
+
+```js
+// before (v0.3.x — 제거됨)
+const ok = data.providers.find((p) => p.id === 'claude').snapshot.networkUsage.status.ok;
+const windows = data.providers.find((p) => p.id === 'claude').snapshot.networkUsage.usageWindows;
+
+// after (v0.4.0+)
+const claude = data.providers.find((p) => p.id === 'claude').snapshot;
+const ok = claude.networkUsages[0].snapshot.status.ok; // ← .snapshot 단계 추가
+const windows = claude.networkUsages[0].snapshot.usageWindows;
+
+// 다 계정 순회 패턴
+for (const entry of claude.networkUsages) {
+  console.log(entry.accountKey, entry.snapshot.status.ok); // ← entry.snapshot
+}
+```
 
 ## 보안 원칙
 

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -23,7 +23,7 @@ token-weather status --json --account work@example.com --provider claude
 {
   "command": "status",
   "generatedAt": "2026-04-25T08:30:00.000Z",
-  "schemaVersion": "0.3.0",
+  "schemaVersion": "0.4.0",
   "configPath": "/home/user/.config/token-weather/config.json",
   "accountFilter": null,
   "providerFilter": null,
@@ -38,7 +38,7 @@ token-weather status --json --account work@example.com --provider claude
 | ---------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `command`        | `"status"` \| `"usage"` | 호출된 커맨드 이름.                                                                                                                                                          |
 | `generatedAt`    | ISO-8601 string         | snapshot 직렬화 시각(client-side).                                                                                                                                           |
-| `schemaVersion`  | string semver \| null   | `packages/schemas/src/index.js::SCHEMA_VERSION`(현재 `'0.3.0'`)을 그대로 통과. 패키지 `version`과는 독립이며 bump 트리거는 [docs/release-policy.md §3](./release-policy.md). |
+| `schemaVersion`  | string semver \| null   | `packages/schemas/src/index.js::SCHEMA_VERSION`(현재 `'0.4.0'`)을 그대로 통과. 패키지 `version`과는 독립이며 bump 트리거는 [docs/release-policy.md §3](./release-policy.md). |
 | `configPath`     | string \| null          | resolved config 파일 경로.                                                                                                                                                   |
 | `accountFilter`  | string \| null          | `--account <id>` 입력 (case-insensitive 매치는 별도).                                                                                                                        |
 | `providerFilter` | string \| null          | `--provider <id>` 입력. lowercase 정규화된 값.                                                                                                                               |
@@ -80,6 +80,18 @@ token-weather status --json --account work@example.com --provider claude
 - 신규 키 추가는 **non-breaking** (소비자는 unknown 필드 무시 권장).
 - 키 제거 / 의미 변경 / shape 재구성은 **breaking** — `schemaVersion` 증가가 필요.
 - `providers[].id` 식별자는 `PROVIDER_REGISTRY`와 동기화되며, 추가/삭제는 schema bump 사유.
+
+## 제거된 backward-compat alias (v0.4.0)
+
+v0.4.0 (issue #119) 에서 claude provider snapshot 의 alias 3 종이 제거됐다. 외부 consumer 가 alias 키를 파싱하고 있었다면 정식 키로 마이그레이션 필요.
+
+| 제거된 alias                                     | 정식 키                                        | 비고                                                                           |
+| ------------------------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| `.providers[].snapshot.networkUsage` (단일 객체) | `.providers[].snapshot.networkUsages[]` (배열) | 단일 계정 케이스는 `networkUsages[0]`. multi-account 도 `[]` 순회로 일관 처리. |
+| `.providers[].snapshot.importedAccount`          | `.providers[].snapshot.selectedAccount`        | 동일 값이었음.                                                                 |
+| `.providers[].snapshot.parsed`                   | `.providers[].snapshot.found`                  | 항상 `found` 와 동일 값이었음.                                                 |
+
+이전 버전 (v0.3.x 이하) 에서는 두 키가 함께 출력되어 backward-compat 가 유지됐으나, v0.4.0 부터는 정식 키만 노출.
 
 ## 보안 원칙
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -80,7 +80,7 @@ contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시�
 
 ## 3. SCHEMA_VERSION 규약
 
-`packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.3.0'` (string semver).
+`packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.4.0'` (string semver).
 
 - 본 패키지의 `version`과는 **독립**. 패키지가 0.5.0이어도 SCHEMA_VERSION은 0.1.0일 수 있음.
 - bump 트리거: §1의 **major** 항목 중 `status --json` shape 또는 `packages/schemas` JSON Schema의 breaking 변경이 발생할 때.
@@ -131,3 +131,4 @@ CHANGELOG는 두 layer로 운영한다 — Changesets 기본 동작에 맞춰서
 - 2026-04-29 (FF sync 도입): release.yml 에 publish 직후 `git push origin HEAD:main` FF push step 추가 + `changesets/action` 에 `id: changesets` 부여 (gate 용). trigger / baseBranch 는 `dev` 그대로 유지하고, main 만 자동 동기 mirror 로 복귀. PR #33 이후 정체된 main 이 npm latest 와 정합되는 외부 stable pointer 로 복귀, `docs/*-merge-followup` 같은 수동 정합 PR 패턴 영구 제거. 검토 단계에서 trigger 를 `[main]` 으로 옮기는 GitFlow lite 모델도 후보로 평가했으나 — `changesets/action` 의 trunk 가정과 충돌해 매 release 마다 `dev → main` 승격 PR 의 manual friction 이 발생, 1 인 maintainer + 빈번 release 인 본 repo 운영 패턴엔 부적합으로 판단해 폐기. CONTRIBUTING.md §1 / §6 / §8 + 본 §5 step 6 / §6 + repo-policy-release 회귀 가드 2건 (FF sync step / changesets step id) 동반.
 - 2026-05-06 (#110 — SCHEMA_VERSION 0.1.0 → 0.2.0): claude `~/.claude/stats-cache.json` 의존 제거 PR 의 일부로 `status --json` 에서 `claude.usage` 키가 제거됨 (release-policy §1 의 major 트리거 — 키 제거). v0.x convention 상 package version 은 minor bump 지만 **`status --json` 의 `schemaVersion` 자체는 별도 계약**이라 같이 bump (`docs/cli-json-output.md` §변경 정책 일관). 회귀 가드 신설 — `packages/schemas/test/schema-version.test.js` 가 SCHEMA_VERSION 값을 lock 해서 미래 우발적 bump 차단. PR #112 review 가 본 누락을 짚어 같은 PR 안에서 정정.
 - 2026-05-07 (#113 — SCHEMA_VERSION 0.2.0 → 0.3.0): codex 폴백을 OpenClaw `auth-profiles.json` 에서 Codex CLI `~/.codex/auth.json` 으로 전환 (claude 와 architectural symmetry). `status --json` shape 변경: `authSource` enum 의 `'openclaw-import'` 값 제거 + `'codex-cli-import'` 추가 (release-policy §1 의 키/의미 변경 = major 트리거); `codex.authProfilesPath` 필드 → `codex.credentialsPath` 로 정렬 (claude 측의 `claude.credentialsPath` 와 동일 표면). 외부 consumer 의 `authSource` 분기 + `authProfilesPath` 참조 둘 다 갱신 필요. v0.x convention 상 package version 은 minor + `!` prefix.
+- 2026-05-12 (#119 — SCHEMA_VERSION 0.3.0 → 0.4.0): `status --json` 의 claude provider 영역에서 backward-compat alias 3 종 제거 (release-policy §1 의 키 제거 = major 트리거): `networkUsage` (단일, → `networkUsages[]` 만 유지) / `importedAccount` (→ `selectedAccount` 만) / `parsed` (→ `found` 만). 외부 consumer 마이그레이션: alias 키 파싱 분기를 정식 키로 갱신. `docs/cli-json-output.md` 에 Migration 표 동봉. v0.x convention 상 package version 은 minor + `!` prefix. JSON 출력 외 평문 / public API surface 무영향.

--- a/packages/agent/src/cli/doctor-helpers.js
+++ b/packages/agent/src/cli/doctor-helpers.js
@@ -19,7 +19,6 @@ export function formatClaudeSection(snapshot) {
   lines.push('Claude credential 상태:');
   lines.push(`  credentialsPath: ${snapshot.credentialsPath}`);
   lines.push(`  found:           ${snapshot.found}`);
-  lines.push(`  parsed:          ${snapshot.parsed}`);
   lines.push(`  authSource:      ${snapshot.authSource}`);
   lines.push(`  accountKey:      ${snapshot.selectedAccount?.accountKey ?? '(없음)'}`);
   lines.push(`  authType:        ${snapshot.selectedAccount?.authType ?? '(알 수 없음)'}`);
@@ -27,17 +26,7 @@ export function formatClaudeSection(snapshot) {
   lines.push('');
   lines.push('Claude live usage (api.anthropic.com/api/oauth/usage):');
 
-  // multi-account: networkUsages 배열 우선. 없으면 legacy networkUsage 단일값으로 흡수.
-  const usages = Array.isArray(snapshot.networkUsages)
-    ? snapshot.networkUsages
-    : snapshot.networkUsage
-      ? [
-          {
-            accountKey: snapshot.selectedAccount?.accountKey ?? null,
-            snapshot: snapshot.networkUsage,
-          },
-        ]
-      : [];
+  const usages = Array.isArray(snapshot.networkUsages) ? snapshot.networkUsages : [];
 
   if (usages.length === 0) {
     lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');

--- a/packages/agent/src/cli/status-formatters.js
+++ b/packages/agent/src/cli/status-formatters.js
@@ -214,11 +214,7 @@ export function formatCodexSection(codex, ctx = {}) {
 export function formatClaudeSection(claude, ctx = {}) {
   const lines = [providerHeader('Claude usage'), ''];
 
-  const usages = Array.isArray(claude.networkUsages)
-    ? claude.networkUsages
-    : claude.networkUsage
-      ? [{ accountKey: claude.selectedAccount?.accountKey ?? null, snapshot: claude.networkUsage }]
-      : [];
+  const usages = Array.isArray(claude.networkUsages) ? claude.networkUsages : [];
   lines.push(
     ...formatClaudeNetworkUsages(usages, {
       filteredOut: claude.filteredOut,

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -42,7 +42,7 @@ export async function getClaudeSnapshot(
   );
 
   if (!config.providers?.claude?.enabled) {
-    return { ...base, networkUsages: [], networkUsage: null };
+    return { ...base, networkUsages: [] };
   }
 
   // Source 선택은 unfiltered 기준으로 먼저 결정.
@@ -72,7 +72,6 @@ export async function getClaudeSnapshot(
     return {
       ...base,
       networkUsages: [],
-      networkUsage: null,
       accountFilter: options.accountFilter ?? null,
       filteredOut: Boolean(options.accountFilter),
     };
@@ -101,12 +100,6 @@ export async function getClaudeSnapshot(
   return {
     ...base,
     networkUsages: settled,
-    // backward-compat alias: selectedAccount에 해당하는 항목을 우선 노출,
-    // 없으면 첫 항목.
-    networkUsage:
-      settled.find((s) => s.accountKey === base.selectedAccount?.accountKey)?.snapshot ??
-      settled[0]?.snapshot ??
-      null,
     accountFilter: options.accountFilter ?? null,
     filteredOut: false,
   };
@@ -124,7 +117,10 @@ export { filterProfilesByAccount } from './account-filter.js';
  * Exported for testing.
  *
  * v0.3.0 (issue #110): `~/.claude/stats-cache.json` 의존 제거 — `usage` 필드
- * 부재. window 사용률은 `networkUsage` (network endpoint 결과) 에서만 노출.
+ * 부재. window 사용률은 `networkUsages[]` (network endpoint 결과) 에서만 노출.
+ *
+ * v0.4.0 (issue #119): backward-compat alias 제거 — `parsed` (== `found`) /
+ * `importedAccount` (== `selectedAccount`) 삭제. `--json` shape 정리.
  */
 export function buildClaudeSnapshot(
   credentialsPath,
@@ -143,9 +139,7 @@ export function buildClaudeSnapshot(
     authSource,
     credentialsPath,
     found,
-    parsed: found,
     selectedAccount,
-    importedAccount: selectedAccount, // backward-compat alias — prefer selectedAccount
   };
 }
 

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -20,7 +20,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
@@ -28,38 +27,42 @@ describe('formatClaudeSection', () => {
     assert.ok(lines.some((l) => l.includes(FAKE_PATH)));
   });
 
-  it('shows found=true and parsed=true when credentials exist', () => {
+  it('shows found=true and authSource when credentials exist (issue #119: parsed alias 제거)', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('found') && l.includes('true')));
-    assert.ok(lines.some((l) => l.includes('parsed') && l.includes('true')));
     assert.ok(lines.some((l) => l.includes('authSource') && l.includes('claude-cli-import')));
+    // parsed alias 출력 부재 회귀 가드
+    assert.equal(
+      lines.some((l) => l.includes('parsed')),
+      false,
+    );
   });
 
-  it('shows found=false and parsed=false when credentials are absent', () => {
+  it('shows found=false when credentials are absent', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: false,
-      parsed: false,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('found') && l.includes('false')));
-    assert.ok(lines.some((l) => l.includes('parsed') && l.includes('false')));
+    assert.equal(
+      lines.some((l) => l.includes('parsed')),
+      false,
+    );
   });
 
   it('returns an array with at least 4 lines', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: false,
-      parsed: false,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
@@ -71,7 +74,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: { accountKey: 'claude-cli-import', authType: 'oauth' },
     };
@@ -83,7 +85,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: false,
-      parsed: false,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
@@ -95,7 +96,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: false,
-      parsed: false,
       authSource: 'claude-cli-import',
       selectedAccount: null,
     };
@@ -107,7 +107,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: { accountKey: 'claude-cli-import', authType: 'oauth' },
     };
@@ -119,7 +118,6 @@ describe('formatClaudeSection', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: { accountKey: 'claude-cli-import' },
     };
@@ -132,20 +130,24 @@ describe('formatClaudeSection', () => {
   // `shows not-found message when usage source is not-found` 는 stats-cache 의존
   // 제거에 따라 같이 삭제.)
 
-  it('shows live usage OK with usageWindows when networkUsage succeeded', () => {
+  it('shows live usage OK with usageWindows for a successful entry (issue #119: networkUsages[] only)', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: null,
-      networkUsage: {
-        status: { ok: true, httpStatus: 200 },
-        usageWindows: [
-          { kind: 'five_hour', usedPercent: 25, resetAt: '2026-04-14T14:00:00.000Z' },
-          { kind: 'seven_day', usedPercent: 80, resetAt: null },
-        ],
-      },
+      networkUsages: [
+        {
+          accountKey: 'claude-cli-import',
+          snapshot: {
+            status: { ok: true, httpStatus: 200 },
+            usageWindows: [
+              { kind: 'five_hour', usedPercent: 25, resetAt: '2026-04-14T14:00:00.000Z' },
+              { kind: 'seven_day', usedPercent: 80, resetAt: null },
+            ],
+          },
+        },
+      ],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('Claude live usage')));
@@ -154,22 +156,26 @@ describe('formatClaudeSection', () => {
     assert.ok(lines.some((l) => l.includes('seven_day') && l.includes('80%')));
   });
 
-  it('shows live usage failure bucket and message when networkUsage failed', () => {
+  it('shows live usage failure bucket and message for a failed entry', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: true,
-      parsed: true,
       authSource: 'claude-cli-import',
       selectedAccount: null,
-      networkUsage: {
-        status: {
-          ok: false,
-          httpStatus: 403,
-          bucket: 'auth_scope',
-          message: 'missing scope requirement user:profile',
+      networkUsages: [
+        {
+          accountKey: 'claude-cli-import',
+          snapshot: {
+            status: {
+              ok: false,
+              httpStatus: 403,
+              bucket: 'auth_scope',
+              message: 'missing scope requirement user:profile',
+            },
+            usageWindows: [],
+          },
         },
-        usageWindows: [],
-      },
+      ],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(
@@ -178,14 +184,13 @@ describe('formatClaudeSection', () => {
     assert.ok(lines.some((l) => l.includes('user:profile')));
   });
 
-  it('shows "호출 안 함" when networkUsage is null', () => {
+  it('shows "호출 안 함" when networkUsages is empty', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
       found: false,
-      parsed: false,
       authSource: 'not-found',
       selectedAccount: null,
-      networkUsage: null,
+      networkUsages: [],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('호출 안 함')));
@@ -350,15 +355,9 @@ describe('formatClaudeSection — multi-account networkUsages', () => {
     assert.ok(lines.some((l) => l.includes('OK (200)')));
   });
 
-  it('falls back to legacy networkUsage when networkUsages missing', () => {
-    const lines = formatClaudeSection({
-      ...basicSnapshot,
-      networkUsage: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
-    });
-    assert.ok(lines.some((l) => l.includes('OK (200)')));
-  });
+  // issue #119: legacy `networkUsage` (단일) fallback 은 제거됨 — `networkUsages[]` 만 지원.
 
-  it('shows "호출 안 함" when neither networkUsages nor networkUsage', () => {
+  it('shows "호출 안 함" when networkUsages is empty', () => {
     const lines = formatClaudeSection({ ...basicSnapshot, networkUsages: [] });
     assert.ok(lines.some((l) => l.includes('호출 안 함')));
   });

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -224,7 +224,7 @@ describe('formatStatusOutput', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsage: null,
+        networkUsages: [],
       },
     });
     // 'Command: status' / 'Local agent status summary' 모두 제거됨
@@ -310,17 +310,7 @@ describe('formatClaudeSection — networkUsages array support', () => {
     assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a:2')));
   });
 
-  it('falls back to legacy networkUsage when networkUsages absent', () => {
-    const lines = formatClaudeSection({
-      authSource: 'claude-cli-import',
-      detected: true,
-      selectedAccount: null,
-      networkUsage: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
-    });
-    assert.ok(lines.some((l) => l.includes('OK (200)')));
-    // 단일 블록이므로 '- Account:' 헤더 없어야 함
-    assert.ok(!lines.some((l) => l.startsWith('  - Account:')));
-  });
+  // issue #119: legacy `networkUsage` (단일) fallback 은 제거됨 — `networkUsages[]` 만 지원.
 });
 
 describe('parseStatusOptions', () => {

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -292,6 +292,35 @@ describe('formatStatusJson — providers array', () => {
   });
 });
 
+describe('formatStatusJson — claude backward-compat alias 부재 (issue #119)', () => {
+  // v0.4.0 (issue #119): claude provider snapshot 에서 backward-compat alias
+  // 3 종 제거 — `networkUsage` (단일, → `networkUsages[]` 만) /
+  // `importedAccount` (→ `selectedAccount` 만) / `parsed` (→ `found` 만).
+  // 외부 consumer 가 alias 키를 파싱했다면 Migration 필요.
+
+  it('does NOT emit `networkUsage` (single) alias when claude snapshot is built', () => {
+    const json = formatStatusJson({
+      schemaVersion: '0.4.0',
+      configPath: '/x',
+      providers: { codex: {}, claude: { enabled: true } },
+      sync: {},
+      codex: {},
+      claude: {
+        detected: true,
+        found: true,
+        authSource: 'claude-cli-import',
+        selectedAccount: { accountKey: 'a' },
+        networkUsages: [],
+      },
+    });
+    const parsed = JSON.parse(json);
+    const claude = parsed.providers.find((p) => p.id === 'claude').snapshot;
+    assert.equal('networkUsage' in claude, false);
+    assert.equal('importedAccount' in claude, false);
+    assert.equal('parsed' in claude, false);
+  });
+});
+
 describe('formatStatusJson — redaction (security)', () => {
   it('strips tokens from claude.selectedAccount.tokens', () => {
     const json = formatStatusJson({

--- a/packages/agent/test/services/claude-provider.test.js
+++ b/packages/agent/test/services/claude-provider.test.js
@@ -116,10 +116,13 @@ describe('resolveClaudeProfileFromSnapshot (via claude-provider)', () => {
 });
 
 describe('getClaudeSnapshot — disabled config contract', () => {
-  it('returns networkUsage=null and networkUsages=[] when claude provider is disabled', async () => {
+  it('returns networkUsages=[] when claude provider is disabled (issue #119: networkUsage alias 제거됨)', async () => {
     const snap = await getClaudeSnapshot({ providers: { claude: { enabled: false } } });
-    assert.equal(snap.networkUsage, null);
     assert.deepEqual(snap.networkUsages, []);
+    // backward-compat alias 부재 회귀 가드
+    assert.equal('networkUsage' in snap, false);
+    assert.equal('importedAccount' in snap, false);
+    assert.equal('parsed' in snap, false);
     assert.ok(typeof snap.authSource === 'string');
   });
 });

--- a/packages/agent/test/services/provider-registry.test.js
+++ b/packages/agent/test/services/provider-registry.test.js
@@ -41,8 +41,9 @@ describe('runProviderSnapshots', () => {
       providers: { codex: { enabled: false }, claude: { enabled: false } },
     });
     assert.equal(out.codex.enabled, false);
-    // Claude snapshot always returns a base+networkUsage(null when disabled/no profile) — just assert shape
-    assert.equal(out.claude.networkUsage, null);
+    // Claude snapshot always returns base + networkUsages=[] when disabled (issue #119:
+    // networkUsage 단일 alias 제거됨).
+    assert.deepEqual(out.claude.networkUsages, []);
   });
 
   it('CLI accountFilter and config.defaults.profiles do not throw when both supplied', async () => {

--- a/packages/agent/test/services/status-service.test.js
+++ b/packages/agent/test/services/status-service.test.js
@@ -168,7 +168,8 @@ describe('buildClaudeSnapshot', () => {
     assert.equal(result.detected, true);
     assert.equal(result.authSource, 'claude-cli-import');
     assert.equal(result.found, true);
-    assert.equal(result.parsed, true);
+    // issue #119: `parsed` alias 제거 (== found 였음)
+    assert.equal('parsed' in result, false);
     assert.equal(result.credentialsPath, FAKE_PATH);
   });
 
@@ -176,8 +177,9 @@ describe('buildClaudeSnapshot', () => {
     const result = buildClaudeSnapshot(FAKE_PATH, () => null);
     assert.equal(result.detected, false);
     assert.equal(result.found, false);
-    assert.equal(result.parsed, false);
     assert.equal(result.authSource, 'not-found');
+    // issue #119: `parsed` alias 제거
+    assert.equal('parsed' in result, false);
   });
 
   it('always includes credentialsPath in the snapshot', () => {
@@ -201,7 +203,7 @@ describe('buildClaudeSnapshot', () => {
     assert.equal(result.selectedAccount.source, 'claude-cli-import');
   });
 
-  it('importedAccount is a backward-compat alias for selectedAccount', () => {
+  it('does NOT include importedAccount alias (issue #119 removed)', () => {
     const fakeCredentials = {
       accessToken: 'tok',
       refreshToken: 'ref',
@@ -211,17 +213,14 @@ describe('buildClaudeSnapshot', () => {
       rateLimitTier: null,
     };
     const result = buildClaudeSnapshot(FAKE_PATH, () => fakeCredentials);
-    assert.equal(result.importedAccount, result.selectedAccount);
+    assert.equal('importedAccount' in result, false);
   });
 
   it('sets selectedAccount to null when credentials are not found', () => {
     const result = buildClaudeSnapshot(FAKE_PATH, () => null);
     assert.equal(result.selectedAccount, null);
-  });
-
-  it('importedAccount alias is also null when credentials are not found', () => {
-    const result = buildClaudeSnapshot(FAKE_PATH, () => null);
-    assert.equal(result.importedAccount, null);
+    // importedAccount alias 제거 회귀 가드
+    assert.equal('importedAccount' in result, false);
   });
 
   it('uses agent-store authSource when agentClaudeAccounts are provided', () => {
@@ -257,7 +256,8 @@ describe('buildClaudeSnapshot', () => {
     const result = buildClaudeSnapshot(FAKE_PATH, () => fakeCredentials, [fakeAgentAccount]);
     assert.equal(result.authSource, 'agent-store');
     assert.equal(result.selectedAccount?.accountKey, 'claude:alice');
-    assert.equal(result.importedAccount?.accountKey, 'claude:alice'); // alias check
+    // issue #119: importedAccount alias 제거 — selectedAccount 만 유지.
+    assert.equal('importedAccount' in result, false);
   });
 
   // issue #110 — `~/.claude/stats-cache.json` 의존이 v0.3.0 에서 제거됨.

--- a/packages/schemas/src/index.js
+++ b/packages/schemas/src/index.js
@@ -1,2 +1,2 @@
-export const SCHEMA_VERSION = '0.3.0';
+export const SCHEMA_VERSION = '0.4.0';
 export { validateUsageSnapshot, validateUsageEvent } from './validate.js';

--- a/packages/schemas/test/schema-version.test.js
+++ b/packages/schemas/test/schema-version.test.js
@@ -23,12 +23,15 @@ import { SCHEMA_VERSION } from '../src/index.js';
  *  - 0.3.0 (issue #113) — `status --json` 의 `authSource` enum value
  *    'openclaw-import' 제거 + 'codex-cli-import' 추가 +
  *    `codex.authProfilesPath` 필드를 `codex.credentialsPath` 로 변경
+ *  - 0.4.0 (issue #119) — `status --json` claude 영역의 backward-compat
+ *    alias 3 종 제거: `networkUsage` (단일, → `networkUsages[]` 만) /
+ *    `importedAccount` (→ `selectedAccount` 만) / `parsed` (→ `found` 만)
  */
 describe('SCHEMA_VERSION lock', () => {
   it('현재 값이 정책과 일치한다', () => {
     assert.equal(
       SCHEMA_VERSION,
-      '0.3.0',
+      '0.4.0',
       'SCHEMA_VERSION 변경 시 docs/release-policy.md §3 / docs/cli-json-output.md / 본 테스트를 같이 갱신',
     );
   });


### PR DESCRIPTION
Closes #119

## 요약

`status --json` 의 claude provider snapshot 에서 backward-compat alias 3 종을 제거. 정식 키 (`networkUsages[]` / `selectedAccount` / `found`) 와 동일 정보를 두 키로 노출하던 중복 정리. `SCHEMA_VERSION` 0.3.0 → 0.4.0.

3-phase JSON contract 정리 plan 의 **Phase 1**.

## 변경 내용

### 제거된 alias

| 정식 키 | 제거된 alias |
|---|---|
| `.providers[].snapshot.networkUsages[]` | `.providers[].snapshot.networkUsage` (단일) |
| `.providers[].snapshot.selectedAccount` | `.providers[].snapshot.importedAccount` |
| `.providers[].snapshot.found` | `.providers[].snapshot.parsed` (동일 값이었음) |

### 코드 변경

- **`packages/agent/src/services/claude-provider.js`**: `buildClaudeSnapshot` 의 `parsed` / `importedAccount` alias 삭제. `getClaudeSnapshot` 의 3 경로 (disabled / filteredOut / 정상) 에서 `networkUsage: null` / 단일값 노출 삭제.
- **`packages/agent/src/cli/status-formatters.js`**: `formatClaudeSection` 의 legacy `networkUsage` 단일 fallback 코드 경로 제거.
- **`packages/agent/src/cli/doctor-helpers.js`**: `formatClaudeSection` 의 `parsed:` 출력 라인 제거 + legacy networkUsage 단일 fallback 제거.

### SCHEMA / Lock

- **`packages/schemas/src/index.js`**: `SCHEMA_VERSION` `'0.3.0'` → `'0.4.0'`
- **`packages/schemas/test/schema-version.test.js`**: lock 값 + 변경 이력 주석 갱신

### 테스트 (회귀 가드 + 정합)

- `status-json.test.js` — 신규 describe: claude snapshot 의 alias 3 키 부재 단언
- `claude-provider.test.js` — disabled 케이스 alias 부재 가드
- `status-service.test.js` — buildClaudeSnapshot 의 `parsed` / `importedAccount` 부재 단언
- `provider-registry.test.js` — `networkUsage` null → `networkUsages` 배열 단언으로 교체
- `status-command.test.js` — legacy fallback 테스트 삭제 + fixture 갱신
- `doctor-command.test.js` — `networkUsage:{...}` 단일 → `networkUsages:[{...}]` 배열로 fixture 마이그레이션 + `parsed` 출력 부재 가드 추가 + 모든 fixture 의 `parsed` 필드 제거

### Docs

- `docs/cli-json-output.md` — top-level shape 예시 `0.4.0` 갱신 + 신규 §"제거된 backward-compat alias (v0.4.0)" + §"`networkUsages[]` 원소 구조 (중요)" 코드 예시 (PR review 반영)
- `docs/release-policy.md` — §3 현재 SCHEMA 값 갱신 + §6 변경 이력 entry (2026-05-12, #119)

### Changeset

`.changeset/claude-backward-compat-alias-removal.md` — 3 패키지 모두 minor + `!` (release-policy §1 의 키 제거 = major 트리거, v0.x convention 상 minor + `!`).

## Migration (외부 consumer)

**중요**: 이전 `networkUsage` 는 usage snapshot 객체 그대로였지만, 신규 `networkUsages[]` 의 각 원소는 `{ accountKey, account, snapshot }` wrapper 입니다. 실제 `usageWindows` / `status` 등 데이터는 `.snapshot` 안에 있어 `.snapshot` 단계 추가가 필요합니다.

```js
// before (v0.3.x — 제거됨)
const ok = data.providers
  .find((p) => p.id === 'claude').snapshot.networkUsage.status.ok;
const windows = ...snapshot.networkUsage.usageWindows;
const acct = ...snapshot.importedAccount;
const found = ...snapshot.parsed;

// after (v0.4.0+)
const claude = data.providers.find((p) => p.id === 'claude').snapshot;
const ok = claude.networkUsages[0].snapshot.status.ok;            // ← .snapshot 단계 추가
const windows = claude.networkUsages[0].snapshot.usageWindows;
const acct = claude.selectedAccount;                              // 동일 값
const found = claude.found;                                       // 동일 값

// 다 계정 순회 패턴
for (const entry of claude.networkUsages) {
  console.log(entry.accountKey, entry.snapshot.status.ok);        // ← entry.snapshot
}
```

자세한 예시: `docs/cli-json-output.md` §"`networkUsages[]` 원소 구조 (중요)".

## 영향 없음

- 평문 출력 (`status` / `usage`)
- Codex provider snapshot shape
- `packages/schemas/usage-snapshot.schema.json` (단일 snapshot shape)
- runtime deps
- public API surface 외 (CLI 내부)

## 트레이드오프

- 외부 스크립트가 alias 키를 파싱하던 경우 break. Migration 단계가 단순 1:1 매핑 + wrapper 한 단계 추가라 비용 낮음.
- `SCHEMA_VERSION` major 트리거지만 v0.x convention 상 minor + `!` (release-policy §3 인용).

## 테스트 / 확인

- [x] `npm test` 853 통과 (alias 부재 회귀 가드 신규 추가)
- [x] `npm run lint` 통과
- [x] `npm run format:check` 통과
- [x] `npm run build:types` 통과
- [x] `npm run cli:status -- --json | jq '.schemaVersion'` → `"0.4.0"`
- [x] `npm run cli:status -- --json | jq '[.providers[] | select(.id=="claude") | .snapshot | keys]'` → `[["accountFilter","authSource","credentialsPath","detected","filteredOut","found","networkUsages","selectedAccount"]]` (alias 3 부재 확인)
- [x] 평문 `npm run cli:status` 출력 무영향 확인

## 참고 사항

- 본 PR 은 3-phase plan (`~/.claude/plans/dreamy-tinkering-reddy.md`) 의 Phase 1.
- 다음: Phase 2 (#120) — provider shape symmetry.
- 본 PR 머지 → release PR force-update → publish 시 v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)