### PR TITLE
[refactor] status --json — Codex / Claude provider shape 정합 (issue #120)

### DIFF
--- a/.changeset/provider-shape-symmetry.md
+++ b/.changeset/provider-shape-symmetry.md
@@ -1,0 +1,43 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+---
+
+refactor(agent)!: `status --json` provider entry shape 정합 — codex / claude 키셋 동일화 (issue #120). `SCHEMA_VERSION` `'0.4.0'` → `'0.5.0'`. v0.x convention 상 breaking 도 minor + `!` prefix.
+
+**Breaking changes** (release-policy §1 의 키 제거 + 의미 변경 = major 트리거):
+
+- codex `.providers[].snapshot.snapshots[]` 키 → `.usageSnapshots[]` 로 rename.
+- claude `.providers[].snapshot.networkUsages[]` 키 → `.usageSnapshots[]` 로 rename.
+- claude `usageSnapshots[]` 원소 shape 정합 — 이전 `{ accountKey, account, snapshot }` wrapper 제거, **UsageSnapshot 객체 직접** 배열로 (codex 와 동일). `.snapshot.usageWindows` → `.usageWindows` 한 단계 짧아짐.
+- claude `.providers[].snapshot.detected` / `.found` 제거 → 단일 `.enabled` boolean 으로 통합 (codex 와 동일 키).
+- claude `.providers[].snapshot.selectedAccount` 제거 — default account 개념이 multi-account + 박스 UI 도입 후 의미가 약해져 양 provider 모두 미노출. 필요시 `.usageSnapshots[]` 순회로 식별.
+- claude `.providers[].snapshot.credentialsPath` 정책 정합 — 이전엔 항상 path 노출이었으나 v0.5.0 부터 `cli-import` 인증 소스 시점에만 path, 그 외엔 `null` (codex 와 동일 정책).
+
+**Migration**:
+
+```js
+// before (v0.4.x)
+const codexEnabled = providers.find((p) => p.id === 'codex').snapshot.enabled;
+const codexSnaps = providers.find((p) => p.id === 'codex').snapshot.snapshots;
+const claudeEnabled = providers.find((p) => p.id === 'claude').snapshot.detected;
+const claudeFound = providers.find((p) => p.id === 'claude').snapshot.found;
+const claudeWindows = providers.find((p) => p.id === 'claude').snapshot.networkUsages[0].snapshot
+  .usageWindows;
+const claudeAccount = providers.find((p) => p.id === 'claude').snapshot.selectedAccount;
+
+// after (v0.5.0+) — codex / claude 동일 path
+const provider = (id) => providers.find((p) => p.id === id).snapshot;
+const codexEnabled = provider('codex').enabled;
+const codexSnaps = provider('codex').usageSnapshots;
+const claudeEnabled = provider('claude').enabled;
+const claudeWindows = provider('claude').usageSnapshots[0].usageWindows; // wrapper 제거됨
+const claudeAccount = provider('claude').usageSnapshots.find(/* ... */)?.account;
+```
+
+자세한 표 + 예시는 [`docs/cli-json-output.md`](docs/cli-json-output.md) §"Provider shape symmetry (v0.5.0)".
+
+**무영향**: 평문 출력 (`status` / `usage`) 사용자 가시 동일성 유지 — 내부 키 rename 만, 시각 표현 무변경. public API surface (workspace package 의 export) 무변경. runtime deps 무변경.
+
+회귀 가드 신설: `status-json.test.js` 에 codex / claude provider snapshot keyset 동일성 + legacy 키 부재 단언 (snapshots / networkUsages / networkUsage / detected / found / parsed / selectedAccount / importedAccount).

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -23,7 +23,7 @@ token-weather status --json --account work@example.com --provider claude
 {
   "command": "status",
   "generatedAt": "2026-04-25T08:30:00.000Z",
-  "schemaVersion": "0.4.0",
+  "schemaVersion": "0.5.0",
   "configPath": "/home/user/.config/token-weather/config.json",
   "accountFilter": null,
   "providerFilter": null,
@@ -38,7 +38,7 @@ token-weather status --json --account work@example.com --provider claude
 | ---------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `command`        | `"status"` \| `"usage"` | 호출된 커맨드 이름.                                                                                                                                                          |
 | `generatedAt`    | ISO-8601 string         | snapshot 직렬화 시각(client-side).                                                                                                                                           |
-| `schemaVersion`  | string semver \| null   | `packages/schemas/src/index.js::SCHEMA_VERSION`(현재 `'0.4.0'`)을 그대로 통과. 패키지 `version`과는 독립이며 bump 트리거는 [docs/release-policy.md §3](./release-policy.md). |
+| `schemaVersion`  | string semver \| null   | `packages/schemas/src/index.js::SCHEMA_VERSION`(현재 `'0.5.0'`)을 그대로 통과. 패키지 `version`과는 독립이며 bump 트리거는 [docs/release-policy.md §3](./release-policy.md). |
 | `configPath`     | string \| null          | resolved config 파일 경로.                                                                                                                                                   |
 | `accountFilter`  | string \| null          | `--account <id>` 입력 (case-insensitive 매치는 별도).                                                                                                                        |
 | `providerFilter` | string \| null          | `--provider <id>` 입력. lowercase 정규화된 값.                                                                                                                               |
@@ -51,6 +51,19 @@ token-weather status --json --account work@example.com --provider claude
 `providerFilter`가 지정되면 매칭되는 provider만 배열에 포함된다 (다른 provider는 snapshot 자체가 만들어지지 않으므로 누락). 미지정 시 등록 순서대로 모두 포함.
 
 `snapshot`은 각 provider builder(`getCodexSnapshot` / `getClaudeSnapshot`)가 반환하는 객체에서 **민감 키를 제거한 deep clone**이다.
+
+### Provider entry shape (v0.5.0, symmetric)
+
+v0.5.0 (issue #120) 부터 codex / claude provider snapshot 의 키셋이 **동일**하다. 외부 consumer 는 provider 분기 없이 단일 path 로 데이터를 조회할 수 있다.
+
+| 필드              | 타입                 | 설명                                                                                                                                 |
+| ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`         | boolean              | `config.providers.<id>.enabled` 통과. provider 가 호출 대상인지.                                                                     |
+| `authSource`      | string               | `'agent-store'` / `'codex-cli-import'` / `'claude-cli-import'` / `'not-found'` 중 하나.                                              |
+| `credentialsPath` | string \| null       | `cli-import` 인증 소스 시점에만 경로. 그 외엔 `null` (codex / claude 동일 정책).                                                     |
+| `usageSnapshots`  | Array<UsageSnapshot> | 계정별 usage snapshot 직접 배열. element shape 는 [usage-snapshot.schema.json](../packages/schemas/usage-snapshot.schema.json) 정합. |
+| `accountFilter`   | string \| null       | `--account` 입력 그대로 통과 (case-insensitive 매치는 별도).                                                                         |
+| `filteredOut`     | boolean              | filter 가 지정됐는데 매칭되는 계정이 없었는지.                                                                                       |
 
 ### 제거되는 민감 키 (redaction)
 
@@ -93,9 +106,48 @@ v0.4.0 (issue #119) 에서 claude provider snapshot 의 alias 3 종이 제거됐
 
 이전 버전 (v0.3.x 이하) 에서는 두 키가 함께 출력되어 backward-compat 가 유지됐으나, v0.4.0 부터는 정식 키만 노출.
 
-### `networkUsages[]` 원소 구조 (중요)
+## Provider shape symmetry (v0.5.0)
 
-이전 `networkUsage` 는 usage snapshot **객체 그대로** 였지만, 신규 `networkUsages[]` 의 각 원소는 `{ accountKey, account, snapshot }` **wrapper**다. 실제 `usageWindows` / `status` 등 데이터는 `.snapshot` 안에 있다.
+v0.5.0 (issue #120) 에서 codex / claude provider snapshot 의 키 이름이 통일되고 claude 의 wrapper 패턴이 제거됐다.
+
+| 영역               | v0.4.x 이하 (Codex)             | v0.4.x 이하 (Claude)                        | v0.5.0+ (양 provider 동일)                                    |
+| ------------------ | ------------------------------- | ------------------------------------------- | ------------------------------------------------------------- |
+| usage 배열 키      | `snapshots[]`                   | `networkUsages[]`                           | **`usageSnapshots[]`**                                        |
+| usage 배열 element | `UsageSnapshot` 직접            | `{ accountKey, account, snapshot }` wrapper | **`UsageSnapshot` 직접** (wrapper 제거)                       |
+| 활성 여부          | `enabled: bool`                 | `detected` / `found` (2 키)                 | **`enabled: bool`** (단일)                                    |
+| 기본 계정          | (없음)                          | `selectedAccount`                           | (없음, 양 provider 모두 제거)                                 |
+| credentialsPath    | `cli-import` 시점만 (null 아님) | 항상 (절대 null 아님)                       | **`cli-import` 시점만**, 그 외 `null` (양 provider 동일 정책) |
+
+### Migration (v0.4.x → v0.5.0)
+
+```js
+// before (v0.4.x)
+const codexEnabled = data.providers.find((p) => p.id === 'codex').snapshot.enabled;
+const codexSnaps = data.providers.find((p) => p.id === 'codex').snapshot.snapshots;
+const claudeEnabled = data.providers.find((p) => p.id === 'claude').snapshot.detected;
+const claudeFound = data.providers.find((p) => p.id === 'claude').snapshot.found;
+const claudeWindows = data.providers.find((p) => p.id === 'claude').snapshot.networkUsages[0]
+  .snapshot.usageWindows;
+const claudeAccount = data.providers.find((p) => p.id === 'claude').snapshot.selectedAccount;
+
+// after (v0.5.0+) — codex / claude 동일 path
+const provider = (id) => data.providers.find((p) => p.id === id).snapshot;
+const codexEnabled = provider('codex').enabled;
+const codexSnaps = provider('codex').usageSnapshots;
+const claudeEnabled = provider('claude').enabled;
+//   found / detected: 의미가 약간 다른데, "credential 이 어디서든 발견됐는지" 는 enabled 와 같음.
+//   순수 credential 파일 존재 확인은 credentialsPath 가 null 인지로 대체 가능.
+const claudeWindows = provider('claude').usageSnapshots[0].usageWindows;
+//   wrapper 제거 — `.snapshot` 단계 더 이상 없음.
+const claudeAccount = provider('claude').usageSnapshots.find(/* by criteria */)?.account;
+//   default account 개념 제거 — 필요시 usageSnapshots[] 순회로 식별.
+```
+
+### `networkUsages[]` 원소 구조 (v0.4.x 기준 — v0.5.0 에서 제거됨)
+
+> **v0.5.0 (issue #120) 갱신**: `networkUsages[]` 자체가 `usageSnapshots[]` 로 rename 되었고, wrapper `{ accountKey, account, snapshot }` 도 unwrap 되어 **UsageSnapshot 직접** 으로 들어간다. 즉 v0.5.0+ 에서는 아래의 wrapper 단계가 사라져 `.snapshot.usageWindows` → `.usageWindows` 로 한 단계 짧아짐. 위 §"Provider shape symmetry (v0.5.0)" 의 Migration 참고.
+
+이전 (v0.3.x) `networkUsage` (단일) 는 usage snapshot **객체 그대로** 였지만, v0.4.x 의 `networkUsages[]` 의 각 원소는 `{ accountKey, account, snapshot }` **wrapper**였다. 실제 `usageWindows` / `status` 등 데이터는 `.snapshot` 안에 있었음.
 
 ```js
 // before (v0.3.x — 제거됨)

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -80,7 +80,7 @@ contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시�
 
 ## 3. SCHEMA_VERSION 규약
 
-`packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.4.0'` (string semver).
+`packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.5.0'` (string semver).
 
 - 본 패키지의 `version`과는 **독립**. 패키지가 0.5.0이어도 SCHEMA_VERSION은 0.1.0일 수 있음.
 - bump 트리거: §1의 **major** 항목 중 `status --json` shape 또는 `packages/schemas` JSON Schema의 breaking 변경이 발생할 때.
@@ -132,3 +132,4 @@ CHANGELOG는 두 layer로 운영한다 — Changesets 기본 동작에 맞춰서
 - 2026-05-06 (#110 — SCHEMA_VERSION 0.1.0 → 0.2.0): claude `~/.claude/stats-cache.json` 의존 제거 PR 의 일부로 `status --json` 에서 `claude.usage` 키가 제거됨 (release-policy §1 의 major 트리거 — 키 제거). v0.x convention 상 package version 은 minor bump 지만 **`status --json` 의 `schemaVersion` 자체는 별도 계약**이라 같이 bump (`docs/cli-json-output.md` §변경 정책 일관). 회귀 가드 신설 — `packages/schemas/test/schema-version.test.js` 가 SCHEMA_VERSION 값을 lock 해서 미래 우발적 bump 차단. PR #112 review 가 본 누락을 짚어 같은 PR 안에서 정정.
 - 2026-05-07 (#113 — SCHEMA_VERSION 0.2.0 → 0.3.0): codex 폴백을 OpenClaw `auth-profiles.json` 에서 Codex CLI `~/.codex/auth.json` 으로 전환 (claude 와 architectural symmetry). `status --json` shape 변경: `authSource` enum 의 `'openclaw-import'` 값 제거 + `'codex-cli-import'` 추가 (release-policy §1 의 키/의미 변경 = major 트리거); `codex.authProfilesPath` 필드 → `codex.credentialsPath` 로 정렬 (claude 측의 `claude.credentialsPath` 와 동일 표면). 외부 consumer 의 `authSource` 분기 + `authProfilesPath` 참조 둘 다 갱신 필요. v0.x convention 상 package version 은 minor + `!` prefix.
 - 2026-05-12 (#119 — SCHEMA_VERSION 0.3.0 → 0.4.0): `status --json` 의 claude provider 영역에서 backward-compat alias 3 종 제거 (release-policy §1 의 키 제거 = major 트리거): `networkUsage` (단일, → `networkUsages[]` 만 유지) / `importedAccount` (→ `selectedAccount` 만) / `parsed` (→ `found` 만). 외부 consumer 마이그레이션: alias 키 파싱 분기를 정식 키로 갱신. `docs/cli-json-output.md` 에 Migration 표 동봉. v0.x convention 상 package version 은 minor + `!` prefix. JSON 출력 외 평문 / public API surface 무영향.
+- 2026-05-12 (#120 — SCHEMA_VERSION 0.4.0 → 0.5.0): `status --json` provider entry shape 정합 — codex / claude 키셋 동일화 (release-policy §1 의 키 제거 + 의미 변경 + 재구성 = major 트리거). 변경: (a) codex `snapshots[]` / claude `networkUsages[]` → 통일 `usageSnapshots[]`; (b) claude `networkUsages[]` 의 wrapper `{ accountKey, account, snapshot }` 제거 — UsageSnapshot 직접 배열로 (codex 와 동일); (c) claude `detected` / `found` → 단일 `enabled` boolean (codex 와 동일); (d) claude `selectedAccount` 제거 (default account 개념 multi-account 박스 UI 도입 후 의미 약화 — 양 provider 모두 미노출); (e) claude `credentialsPath` 항상-노출 정책 → `cli-import` 시점만 (codex 와 동일 정책 정렬). 외부 consumer 마이그레이션 비용 큼 — `docs/cli-json-output.md` §"Provider shape symmetry (v0.5.0)" 의 before/after 예시 참고. v0.x convention 상 package version 은 minor + `!` prefix.

--- a/packages/agent/src/cli/doctor-helpers.js
+++ b/packages/agent/src/cli/doctor-helpers.js
@@ -17,26 +17,25 @@ import { refreshCodexToken } from '@token-weather/provider-adapters/src/codex/in
 export function formatClaudeSection(snapshot) {
   const lines = [];
   lines.push('Claude credential 상태:');
-  lines.push(`  credentialsPath: ${snapshot.credentialsPath}`);
-  lines.push(`  found:           ${snapshot.found}`);
+  lines.push(`  credentialsPath: ${snapshot.credentialsPath ?? '(없음)'}`);
   lines.push(`  authSource:      ${snapshot.authSource}`);
-  lines.push(`  accountKey:      ${snapshot.selectedAccount?.accountKey ?? '(없음)'}`);
-  lines.push(`  authType:        ${snapshot.selectedAccount?.authType ?? '(알 수 없음)'}`);
+  lines.push(`  enabled:         ${snapshot.enabled}`);
 
   lines.push('');
   lines.push('Claude live usage (api.anthropic.com/api/oauth/usage):');
 
-  const usages = Array.isArray(snapshot.networkUsages) ? snapshot.networkUsages : [];
+  // v0.5.0 (issue #120): networkUsages wrapper 가 usageSnapshots 직접 배열로 정합 (codex 와 동일).
+  const usageSnapshots = Array.isArray(snapshot.usageSnapshots) ? snapshot.usageSnapshots : [];
 
-  if (usages.length === 0) {
+  if (usageSnapshots.length === 0) {
     lines.push('  호출 안 함 (Claude 비활성 또는 토큰 없음)');
     return lines;
   }
 
-  const multi = usages.length > 1;
-  for (const { accountKey, snapshot: network } of usages) {
-    if (multi) lines.push(`  - 계정: ${accountKey ?? '(unknown)'}`);
-    lines.push(...formatClaudeNetworkSnapshot(network, multi ? '    ' : '  '));
+  const multi = usageSnapshots.length > 1;
+  for (const usageSnap of usageSnapshots) {
+    if (multi) lines.push(`  - 계정: ${usageSnap.account?.profileId ?? '(unknown)'}`);
+    lines.push(...formatClaudeNetworkSnapshot(usageSnap, multi ? '    ' : '  '));
   }
 
   return lines;

--- a/packages/agent/src/cli/status-formatters.js
+++ b/packages/agent/src/cli/status-formatters.js
@@ -54,15 +54,18 @@ function providerHeader(name) {
 /**
  * 계정 헤더 라벨 — `provider | identifier` 형식.
  *
- * identifier 우선순위: email → accountId → accountKey. 셋 다 없으면 provider
- * 단독. issue #116 review 의 lean output 정합.
+ * identifier 우선순위: email → accountId → accountKey → profileId. 넷 다 없으면
+ * provider 단독. issue #116 review 의 lean output 정합. profileId 는 v0.5.0
+ * (issue #120) 에서 usageSnapshots[] 원소의 snapshot.account 가 wrapper 없이
+ * 직접 들어오면서 fallback 추가됨.
  *
  * @param {string} providerId — `'openai-codex'` / `'anthropic-claude'` 등
  * @param {object|null|undefined} account
  * @returns {string}
  */
 function accountLabel(providerId, account) {
-  const identifier = account?.email ?? account?.accountId ?? account?.accountKey ?? null;
+  const identifier =
+    account?.email ?? account?.accountId ?? account?.accountKey ?? account?.profileId ?? null;
   return identifier ? `${providerId} | ${identifier}` : providerId;
 }
 
@@ -174,7 +177,7 @@ export function formatCodexSection(codex, ctx = {}) {
     lines.push('');
   }
 
-  if (codex.snapshots.length === 0) {
+  if (codex.usageSnapshots.length === 0) {
     if (codex.filteredOut) {
       lines.push(`No Codex account matches account filter "${codex.accountFilter}".`);
     } else {
@@ -183,9 +186,9 @@ export function formatCodexSection(codex, ctx = {}) {
     return lines;
   }
 
-  const useBox = codex.snapshots.length > 1;
-  for (let i = 0; i < codex.snapshots.length; i++) {
-    const snapshot = codex.snapshots[i];
+  const useBox = codex.usageSnapshots.length > 1;
+  for (let i = 0; i < codex.usageSnapshots.length; i++) {
+    const snapshot = codex.usageSnapshots[i];
     if (i > 0) lines.push(''); // 박스 사이 1 줄 gap
 
     const label = accountLabel('openai-codex', snapshot.account);
@@ -214,9 +217,9 @@ export function formatCodexSection(codex, ctx = {}) {
 export function formatClaudeSection(claude, ctx = {}) {
   const lines = [providerHeader('Claude usage'), ''];
 
-  const usages = Array.isArray(claude.networkUsages) ? claude.networkUsages : [];
+  const usageSnapshots = Array.isArray(claude.usageSnapshots) ? claude.usageSnapshots : [];
   lines.push(
-    ...formatClaudeNetworkUsages(usages, {
+    ...formatClaudeNetworkUsages(usageSnapshots, {
       filteredOut: claude.filteredOut,
       accountFilter: claude.accountFilter,
       useColor: ctx.useColor,
@@ -226,10 +229,17 @@ export function formatClaudeSection(claude, ctx = {}) {
   return lines;
 }
 
-/** Claude live network usage 블록(들). */
-export function formatClaudeNetworkUsages(usages, context = {}) {
+/**
+ * Claude live network usage 블록(들).
+ *
+ * v0.5.0 (issue #120): 인자 `usageSnapshots` 는 UsageSnapshot 객체 배열 — 이전
+ * `{ accountKey, account, snapshot }` wrapper 가 unwrap 되어 codex 와 동일.
+ * 각 element 는 `buildUsageSnapshot` 결과 (status / usageWindows / provider /
+ * account 등).
+ */
+export function formatClaudeNetworkUsages(usageSnapshots, context = {}) {
   const lines = [];
-  if (!usages || usages.length === 0) {
+  if (!usageSnapshots || usageSnapshots.length === 0) {
     if (context.filteredOut) {
       lines.push(`No Claude account matches account filter "${context.accountFilter}".`);
     } else {
@@ -238,15 +248,13 @@ export function formatClaudeNetworkUsages(usages, context = {}) {
     return lines;
   }
 
-  const useBox = usages.length > 1;
-  for (let i = 0; i < usages.length; i++) {
-    const { accountKey, snapshot, account } = usages[i];
+  const useBox = usageSnapshots.length > 1;
+  for (let i = 0; i < usageSnapshots.length; i++) {
+    const snapshot = usageSnapshots[i];
     if (useBox) {
       if (i > 0) lines.push(''); // 박스 사이 1 줄 gap
-      const header = accountLabel('anthropic-claude', account ?? { accountKey });
+      const header = accountLabel('anthropic-claude', snapshot.account);
       const body = formatClaudeNetworkUsageBody(snapshot, true, context);
-      // body 는 '  ' (2 spaces) indent — wrapInBox 가 prefix '  ' 를
-      // `'│ '` (column 0) 로 변환.
       lines.push(...wrapInBox(header, body, '', '  '));
     } else {
       lines.push(...formatClaudeNetworkUsageBody(snapshot, false, context));

--- a/packages/agent/src/services/claude-provider.js
+++ b/packages/agent/src/services/claude-provider.js
@@ -34,24 +34,30 @@ export async function getClaudeSnapshot(
   config = { providers: { claude: { enabled: true } } },
   options = {},
 ) {
-  const agentClaudeAccounts = await loadAgentStoreClaudeAccounts();
-  const base = buildClaudeSnapshot(
-    resolveClaudeCredentialsPath(),
-    readClaudeCredentials,
-    agentClaudeAccounts,
-  );
+  const claudeConfigEnabled = config?.providers?.claude?.enabled ?? false;
+  const credentialsPath = resolveClaudeCredentialsPath();
 
-  if (!config.providers?.claude?.enabled) {
-    return { ...base, networkUsages: [] };
+  if (!claudeConfigEnabled) {
+    return {
+      enabled: false,
+      authSource: 'not-found',
+      credentialsPath: null,
+      usageSnapshots: [],
+      accountFilter: options.accountFilter ?? null,
+      filteredOut: false,
+    };
   }
 
-  // Source 선택은 unfiltered 기준으로 먼저 결정.
-  // accountFilter가 source precedence를 바꿔서는 안 된다.
+  const agentClaudeAccounts = await loadAgentStoreClaudeAccounts();
+  const base = buildClaudeSnapshot(credentialsPath, readClaudeCredentials, agentClaudeAccounts);
+
+  // Source 선택은 unfiltered 기준으로 먼저 결정 — accountFilter 가 source
+  // precedence 를 바꾸지 않게.
   const allAgentEntries = await resolveProviderAccountEntries({
     providerId: CLAUDE_AUTH.storeProvider,
     filterFn: filterClaudeRealAccounts,
     mapFn: claudeMapAccountToProfile,
-    accountFilter: null, // source 선택은 필터 없이
+    accountFilter: null,
     updateLastUsed: false,
   });
 
@@ -68,40 +74,32 @@ export async function getClaudeSnapshot(
     }
   }
 
-  if (entries.length === 0) {
-    return {
-      ...base,
-      networkUsages: [],
-      accountFilter: options.accountFilter ?? null,
-      filteredOut: Boolean(options.accountFilter),
-    };
-  }
-
-  // 각 계정에 대해 병렬로 usage 조회. 한 계정이 실패해도 다른 계정은 유지.
-  const settled = await Promise.all(
-    entries.map(async (entry) => {
-      try {
-        return await fetchUsageWithAutoRefresh(entry, {
-          fetchUsage: fetchClaudeUsage,
-          refreshToken: refreshClaudeToken,
-          updateStoreAfterRefresh: updateClaudeStoreAfterRefresh,
-          mapAccountToProfile: claudeMapAccountToProfile,
-        });
-      } catch (error) {
-        return {
-          accountKey: entry.profile.id,
-          account: entry.profile,
-          snapshot: createClaudeNetworkFailureSnapshot(entry.profile, error),
-        };
-      }
-    }),
-  );
+  const usageSnapshots =
+    entries.length === 0
+      ? []
+      : await Promise.all(
+          entries.map(async (entry) => {
+            try {
+              const result = await fetchUsageWithAutoRefresh(entry, {
+                fetchUsage: fetchClaudeUsage,
+                refreshToken: refreshClaudeToken,
+                updateStoreAfterRefresh: updateClaudeStoreAfterRefresh,
+                mapAccountToProfile: claudeMapAccountToProfile,
+              });
+              return result.snapshot;
+            } catch (error) {
+              return createClaudeNetworkFailureSnapshot(entry.profile, error);
+            }
+          }),
+        );
 
   return {
-    ...base,
-    networkUsages: settled,
+    enabled: true,
+    authSource: base.authSource,
+    credentialsPath: base.authSource === 'claude-cli-import' ? credentialsPath : null,
+    usageSnapshots,
     accountFilter: options.accountFilter ?? null,
-    filteredOut: false,
+    filteredOut: entries.length === 0 && Boolean(options.accountFilter),
   };
 }
 

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -31,17 +31,20 @@ export async function getCodexSnapshot(config, options = {}) {
   if (!config.providers?.codex?.enabled) {
     return {
       enabled: false,
+      authSource: 'not-found',
       credentialsPath: resolveCodexCliCredentialsPath(),
-      snapshots: [],
+      usageSnapshots: [],
+      accountFilter: options.accountFilter ?? null,
+      filteredOut: false,
     };
   }
 
   const { entries, authSource } = await resolveCodexProfiles(options.accountFilter);
-  const snapshots = [];
+  const usageSnapshots = [];
 
   for (const entry of entries) {
     try {
-      snapshots.push(
+      usageSnapshots.push(
         (
           await fetchUsageWithAutoRefresh(entry, {
             fetchUsage: fetchCodexUsage,
@@ -52,7 +55,7 @@ export async function getCodexSnapshot(config, options = {}) {
         ).snapshot,
       );
     } catch (error) {
-      snapshots.push(createCodexFailureSnapshot(entry.profile, error));
+      usageSnapshots.push(createCodexFailureSnapshot(entry.profile, error));
     }
   }
 
@@ -60,7 +63,7 @@ export async function getCodexSnapshot(config, options = {}) {
     enabled: true,
     authSource,
     credentialsPath: authSource === 'codex-cli-import' ? resolveCodexCliCredentialsPath() : null,
-    snapshots,
+    usageSnapshots,
     accountFilter: options.accountFilter ?? null,
     filteredOut: Boolean(options.accountFilter) && entries.length === 0,
   };

--- a/packages/agent/src/services/codex-provider.js
+++ b/packages/agent/src/services/codex-provider.js
@@ -32,7 +32,9 @@ export async function getCodexSnapshot(config, options = {}) {
     return {
       enabled: false,
       authSource: 'not-found',
-      credentialsPath: resolveCodexCliCredentialsPath(),
+      // claude 와 동일 정책 — credentialsPath 는 'codex-cli-import' 시점만 노출.
+      // disabled 또는 not-found 시 null (PR #123 review 정정).
+      credentialsPath: null,
       usageSnapshots: [],
       accountFilter: options.accountFilter ?? null,
       filteredOut: false,

--- a/packages/agent/test/cli/doctor-command.test.js
+++ b/packages/agent/test/cli/doctor-command.test.js
@@ -14,138 +14,73 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('formatClaudeSection', () => {
+  // v0.5.0 (issue #120): doctor 의 formatClaudeSection 도 새 contract 정합 —
+  // detected/found/selectedAccount alias 제거 + enabled / usageSnapshots 사용.
   const FAKE_PATH = '/home/user/.claude/.credentials.json';
 
   it('includes credentialsPath in output', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
-      found: true,
+      enabled: true,
       authSource: 'claude-cli-import',
-      selectedAccount: null,
+      usageSnapshots: [],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes(FAKE_PATH)));
   });
 
-  it('shows found=true and authSource when credentials exist (issue #119: parsed alias 제거)', () => {
+  it('shows authSource and enabled when credentials exist', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
-      found: true,
+      enabled: true,
       authSource: 'claude-cli-import',
-      selectedAccount: null,
+      usageSnapshots: [],
     };
     const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('found') && l.includes('true')));
     assert.ok(lines.some((l) => l.includes('authSource') && l.includes('claude-cli-import')));
-    // parsed alias 출력 부재 회귀 가드
+    assert.ok(lines.some((l) => l.includes('enabled') && l.includes('true')));
+    // 제거된 alias 출력 부재 회귀 가드 (Phase 1+2)
     assert.equal(
-      lines.some((l) => l.includes('parsed')),
+      lines.some((l) => l.includes('parsed') || l.includes('found:') || l.includes('accountKey')),
       false,
     );
   });
 
-  it('shows found=false when credentials are absent', () => {
+  it('shows enabled=false when claude disabled', () => {
     const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: false,
-      authSource: 'claude-cli-import',
-      selectedAccount: null,
+      credentialsPath: null,
+      enabled: false,
+      authSource: 'not-found',
+      usageSnapshots: [],
     };
     const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('found') && l.includes('false')));
-    assert.equal(
-      lines.some((l) => l.includes('parsed')),
-      false,
-    );
+    assert.ok(lines.some((l) => l.includes('enabled') && l.includes('false')));
   });
 
   it('returns an array with at least 4 lines', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
-      found: false,
+      enabled: true,
       authSource: 'claude-cli-import',
-      selectedAccount: null,
+      usageSnapshots: [],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.length >= 4);
   });
 
-  it('shows accountKey when selectedAccount is present', () => {
+  it('shows live usage OK with usageWindows for a successful entry', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
-      found: true,
+      enabled: true,
       authSource: 'claude-cli-import',
-      selectedAccount: { accountKey: 'claude-cli-import', authType: 'oauth' },
-    };
-    const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('accountKey') && l.includes('claude-cli-import')));
-  });
-
-  it('shows (없음) for accountKey when selectedAccount is null', () => {
-    const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: false,
-      authSource: 'claude-cli-import',
-      selectedAccount: null,
-    };
-    const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('accountKey') && l.includes('없음')));
-  });
-
-  it('shows (알 수 없음) for authType when selectedAccount is null', () => {
-    const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: false,
-      authSource: 'claude-cli-import',
-      selectedAccount: null,
-    };
-    const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('authType') && l.includes('알 수 없음')));
-  });
-
-  it('shows authType from selectedAccount when present', () => {
-    const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: true,
-      authSource: 'claude-cli-import',
-      selectedAccount: { accountKey: 'claude-cli-import', authType: 'oauth' },
-    };
-    const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('authType') && l.includes('oauth')));
-  });
-
-  it('shows fallback for authType when selectedAccount has no authType', () => {
-    const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: true,
-      authSource: 'claude-cli-import',
-      selectedAccount: { accountKey: 'claude-cli-import' },
-    };
-    const lines = formatClaudeSection(snapshot);
-    assert.ok(lines.some((l) => l.includes('authType') && l.includes('알 수 없음')));
-  });
-
-  // issue #110 — formatClaudeSection 의 stats-cache 출력 블록은 v0.3.0 에서 제거됨.
-  // (이전 두 테스트 `shows usage stats when usage source is stats-cache-json` 와
-  // `shows not-found message when usage source is not-found` 는 stats-cache 의존
-  // 제거에 따라 같이 삭제.)
-
-  it('shows live usage OK with usageWindows for a successful entry (issue #119: networkUsages[] only)', () => {
-    const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: true,
-      authSource: 'claude-cli-import',
-      selectedAccount: null,
-      networkUsages: [
+      usageSnapshots: [
         {
-          accountKey: 'claude-cli-import',
-          snapshot: {
-            status: { ok: true, httpStatus: 200 },
-            usageWindows: [
-              { kind: 'five_hour', usedPercent: 25, resetAt: '2026-04-14T14:00:00.000Z' },
-              { kind: 'seven_day', usedPercent: 80, resetAt: null },
-            ],
-          },
+          account: { profileId: 'claude-cli-import' },
+          status: { ok: true, httpStatus: 200 },
+          usageWindows: [
+            { kind: 'five_hour', usedPercent: 25, resetAt: '2026-04-14T14:00:00.000Z' },
+            { kind: 'seven_day', usedPercent: 80, resetAt: null },
+          ],
         },
       ],
     };
@@ -159,21 +94,18 @@ describe('formatClaudeSection', () => {
   it('shows live usage failure bucket and message for a failed entry', () => {
     const snapshot = {
       credentialsPath: FAKE_PATH,
-      found: true,
+      enabled: true,
       authSource: 'claude-cli-import',
-      selectedAccount: null,
-      networkUsages: [
+      usageSnapshots: [
         {
-          accountKey: 'claude-cli-import',
-          snapshot: {
-            status: {
-              ok: false,
-              httpStatus: 403,
-              bucket: 'auth_scope',
-              message: 'missing scope requirement user:profile',
-            },
-            usageWindows: [],
+          account: { profileId: 'claude-cli-import' },
+          status: {
+            ok: false,
+            httpStatus: 403,
+            bucket: 'auth_scope',
+            message: 'missing scope requirement user:profile',
           },
+          usageWindows: [],
         },
       ],
     };
@@ -184,13 +116,12 @@ describe('formatClaudeSection', () => {
     assert.ok(lines.some((l) => l.includes('user:profile')));
   });
 
-  it('shows "호출 안 함" when networkUsages is empty', () => {
+  it('shows "호출 안 함" when usageSnapshots is empty', () => {
     const snapshot = {
-      credentialsPath: FAKE_PATH,
-      found: false,
+      credentialsPath: null,
+      enabled: false,
       authSource: 'not-found',
-      selectedAccount: null,
-      networkUsages: [],
+      usageSnapshots: [],
     };
     const lines = formatClaudeSection(snapshot);
     assert.ok(lines.some((l) => l.includes('호출 안 함')));
@@ -304,33 +235,26 @@ describe('formatDoctorClaudeHelp', () => {
   });
 });
 
-describe('formatClaudeSection — multi-account networkUsages', () => {
+describe('formatClaudeSection — multi-account usageSnapshots', () => {
   const basicSnapshot = {
     credentialsPath: '/x/.credentials.json',
-    found: true,
-    parsed: true,
+    enabled: true,
     authSource: 'agent-store',
-    selectedAccount: { accountKey: 'a:1', authType: 'oauth' },
-    usage: { source: 'not-found' },
   };
 
-  it('renders per-account blocks when networkUsages has multiple entries', () => {
+  it('renders per-account blocks when usageSnapshots has multiple entries', () => {
     const lines = formatClaudeSection({
       ...basicSnapshot,
-      networkUsages: [
+      usageSnapshots: [
         {
-          accountKey: 'a:1',
-          snapshot: {
-            status: { ok: true, httpStatus: 200 },
-            usageWindows: [{ kind: 'five_hour', usedPercent: 5, resetAt: '2026-04-16' }],
-          },
+          account: { profileId: 'a:1' },
+          status: { ok: true, httpStatus: 200 },
+          usageWindows: [{ kind: 'five_hour', usedPercent: 5, resetAt: '2026-04-16' }],
         },
         {
-          accountKey: 'a:2',
-          snapshot: {
-            status: { ok: false, httpStatus: 401, bucket: 'auth', message: 'expired' },
-            usageWindows: [],
-          },
+          account: { profileId: 'a:2' },
+          status: { ok: false, httpStatus: 401, bucket: 'auth', message: 'expired' },
+          usageWindows: [],
         },
       ],
     });
@@ -344,10 +268,11 @@ describe('formatClaudeSection — multi-account networkUsages', () => {
   it('omits per-account header when single entry', () => {
     const lines = formatClaudeSection({
       ...basicSnapshot,
-      networkUsages: [
+      usageSnapshots: [
         {
-          accountKey: 'a:1',
-          snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+          account: { profileId: 'a:1' },
+          status: { ok: true, httpStatus: 200 },
+          usageWindows: [],
         },
       ],
     });
@@ -355,10 +280,8 @@ describe('formatClaudeSection — multi-account networkUsages', () => {
     assert.ok(lines.some((l) => l.includes('OK (200)')));
   });
 
-  // issue #119: legacy `networkUsage` (단일) fallback 은 제거됨 — `networkUsages[]` 만 지원.
-
-  it('shows "호출 안 함" when networkUsages is empty', () => {
-    const lines = formatClaudeSection({ ...basicSnapshot, networkUsages: [] });
+  it('shows "호출 안 함" when usageSnapshots is empty', () => {
+    const lines = formatClaudeSection({ ...basicSnapshot, usageSnapshots: [] });
     assert.ok(lines.some((l) => l.includes('호출 안 함')));
   });
 });

--- a/packages/agent/test/cli/status-command.test.js
+++ b/packages/agent/test/cli/status-command.test.js
@@ -82,7 +82,11 @@ describe('formatCodexSection', () => {
   });
 
   it('reports no profile message when enabled but snapshots empty', () => {
-    const lines = formatCodexSection({ enabled: true, authSource: 'agent-store', snapshots: [] });
+    const lines = formatCodexSection({
+      enabled: true,
+      authSource: 'agent-store',
+      usageSnapshots: [],
+    });
     assert.ok(lines.some((l) => l.includes('No Codex OAuth profile found')));
   });
 
@@ -91,7 +95,7 @@ describe('formatCodexSection', () => {
       enabled: true,
       authSource: 'codex-cli-import',
       credentialsPath: '/home/u/.codex/auth.json',
-      snapshots: [],
+      usageSnapshots: [],
     });
     assert.ok(lines.some((l) => l.includes('Codex CLI credential path: /home/u/.codex/auth.json')));
   });
@@ -100,7 +104,7 @@ describe('formatCodexSection', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [
+      usageSnapshots: [
         {
           source: 'provider_usage_endpoint',
           authType: 'oauth',
@@ -125,7 +129,7 @@ describe('formatCodexSection', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [
+      usageSnapshots: [
         {
           source: 'provider_usage_endpoint',
           authType: 'oauth',
@@ -152,7 +156,7 @@ describe('formatCodexSection', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [
+      usageSnapshots: [
         {
           source: 'x',
           authType: 'oauth',
@@ -224,7 +228,7 @@ describe('formatStatusOutput', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsages: [],
+        usageSnapshots: [],
       },
     });
     // 'Command: status' / 'Local agent status summary' 모두 제거됨
@@ -242,6 +246,9 @@ describe('formatStatusOutput', () => {
 });
 
 describe('formatClaudeNetworkUsages — multi-account', () => {
+  // v0.5.0 (issue #120): wrapper { accountKey, account, snapshot } 가 unwrap 되어
+  // 인자가 UsageSnapshot 배열 직접 (codex 와 동일). account 정보는 snapshot.account.
+
   it('renders single "Skipped" line when usages is empty', () => {
     const lines = formatClaudeNetworkUsages([]);
     assert.ok(lines.some((l) => l.includes('Skipped')));
@@ -250,11 +257,9 @@ describe('formatClaudeNetworkUsages — multi-account', () => {
   it('outputs a single block without account header when usages has one entry', () => {
     const lines = formatClaudeNetworkUsages([
       {
-        accountKey: 'a:1',
-        snapshot: {
-          status: { ok: true, httpStatus: 200 },
-          usageWindows: [{ kind: 'five_hour', usedPercent: 10, resetAt: '2026-04-16' }],
-        },
+        account: { profileId: 'a:1', email: 'a@x.com' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [{ kind: 'five_hour', usedPercent: 10, resetAt: '2026-04-16' }],
       },
     ]);
     // 단일 계정 블록은 'Account:' 헤더를 붙이지 않음
@@ -265,23 +270,20 @@ describe('formatClaudeNetworkUsages — multi-account', () => {
   it('outputs per-account header + body for multiple usages', () => {
     const lines = formatClaudeNetworkUsages([
       {
-        accountKey: 'a:1',
-        snapshot: {
-          status: { ok: true, httpStatus: 200 },
-          usageWindows: [{ kind: 'five_hour', usedPercent: 5 }],
-        },
+        account: { profileId: 'a:1', email: 'a@x.com' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [{ kind: 'five_hour', usedPercent: 5 }],
       },
       {
-        accountKey: 'a:2',
-        snapshot: {
-          status: { ok: false, httpStatus: 401, bucket: 'auth', message: 'expired' },
-          usageWindows: [],
-        },
+        account: { profileId: 'a:2', email: 'b@x.com' },
+        status: { ok: false, httpStatus: 401, bucket: 'auth', message: 'expired' },
+        usageWindows: [],
       },
     ]);
     // multi-account → rounded-corner box header (lean: `provider | identifier`)
-    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a:1')));
-    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a:2')));
+    // accountLabel 은 account.email 을 우선 사용.
+    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a@x.com')));
+    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | b@x.com')));
     assert.ok(lines.some((l) => l.includes('OK (200)')));
     assert.ok(lines.some((l) => l.includes('Status: FAILED')));
     assert.ok(!lines.some((l) => l.includes('bucket=')));
@@ -289,28 +291,28 @@ describe('formatClaudeNetworkUsages — multi-account', () => {
   });
 });
 
-describe('formatClaudeSection — networkUsages array support', () => {
-  it('uses networkUsages when provided (multi-account path)', () => {
+describe('formatClaudeSection — usageSnapshots array', () => {
+  it('iterates usageSnapshots directly (multi-account path)', () => {
     const lines = formatClaudeSection({
+      enabled: true,
       authSource: 'agent-store',
-      detected: true,
-      selectedAccount: { accountKey: 'a:1' },
-      networkUsages: [
+      credentialsPath: null,
+      usageSnapshots: [
         {
-          accountKey: 'a:1',
-          snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+          account: { profileId: 'a:1', email: 'a@x.com' },
+          status: { ok: true, httpStatus: 200 },
+          usageWindows: [],
         },
         {
-          accountKey: 'a:2',
-          snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+          account: { profileId: 'a:2', email: 'b@x.com' },
+          status: { ok: true, httpStatus: 200 },
+          usageWindows: [],
         },
       ],
     });
-    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a:1')));
-    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a:2')));
+    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | a@x.com')));
+    assert.ok(lines.some((l) => l.startsWith('╭─ anthropic-claude | b@x.com')));
   });
-
-  // issue #119: legacy `networkUsage` (단일) fallback 은 제거됨 — `networkUsages[]` 만 지원.
 });
 
 describe('parseStatusOptions', () => {
@@ -453,7 +455,7 @@ describe('formatStatusOutput — accountFilter line', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsages: [],
+        usageSnapshots: [],
       },
     });
     assert.ok(!lines.some((l) => l.includes('Account filter')));
@@ -470,7 +472,7 @@ describe('formatStatusOutput — accountFilter line', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsages: [],
+        usageSnapshots: [],
       },
     });
     // summary box 안에 들어가므로 `│ ` prefix 포함
@@ -489,7 +491,7 @@ describe('formatStatusOutput — providerFilter scope', () => {
     authSource: 'not-found',
     detected: false,
     selectedAccount: null,
-    networkUsages: [],
+    usageSnapshots: [],
   };
 
   it('renders only Codex usage section when providerFilter=codex (no claude key)', () => {
@@ -531,7 +533,7 @@ describe('formatCodexSection — accountFilter empty result', () => {
       authSource: 'agent-store',
       accountFilter: 'nope@x.com',
       filteredOut: true,
-      snapshots: [],
+      usageSnapshots: [],
     });
     assert.ok(
       lines.some((l) => l.includes('No Codex account matches account filter "nope@x.com"')),
@@ -542,7 +544,7 @@ describe('formatCodexSection — accountFilter empty result', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [],
+      usageSnapshots: [],
     });
     assert.ok(lines.some((l) => l.includes('No Codex OAuth profile found')));
   });
@@ -564,7 +566,7 @@ describe('multi-account box wrapping (issue #116 review)', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [
+      usageSnapshots: [
         {
           source: 'x',
           authType: 'oauth',
@@ -601,7 +603,7 @@ describe('multi-account box wrapping (issue #116 review)', () => {
     const lines = formatCodexSection({
       enabled: true,
       authSource: 'agent-store',
-      snapshots: [
+      usageSnapshots: [
         {
           source: 'x',
           authType: 'oauth',
@@ -620,14 +622,17 @@ describe('multi-account box wrapping (issue #116 review)', () => {
   });
 
   it('wraps Claude usages in an indented box when count > 1', () => {
+    // v0.5.0: usageSnapshots array (UsageSnapshot 직접, wrapper 제거)
     const lines = formatClaudeNetworkUsages([
       {
-        accountKey: 'a:1',
-        snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+        account: { profileId: 'a:1' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [],
       },
       {
-        accountKey: 'a:2',
-        snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+        account: { profileId: 'a:2' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [],
       },
     ]);
     // Claude multi-account 박스는 outer indent 0 ([live] 컨테이너 제거됨).
@@ -635,7 +640,7 @@ describe('multi-account box wrapping (issue #116 review)', () => {
     const bottoms = lines.filter((l) => l.startsWith('╰─'));
     assert.equal(tops.length, 2);
     assert.equal(bottoms.length, 2);
-    // 헤더 — `provider | identifier` 형식
+    // 헤더 — `provider | identifier` 형식 (accountLabel 이 profileId 를 fallback 으로 사용)
     assert.ok(tops[0].includes('anthropic-claude | a:1'));
     assert.ok(tops[1].includes('anthropic-claude | a:2'));
     // 본문은 `│ ` prefix (no outer indent)
@@ -645,8 +650,9 @@ describe('multi-account box wrapping (issue #116 review)', () => {
   it('does NOT box a single Claude usage', () => {
     const lines = formatClaudeNetworkUsages([
       {
-        accountKey: 'a:1',
-        snapshot: { status: { ok: true, httpStatus: 200 }, usageWindows: [] },
+        account: { profileId: 'a:1' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [],
       },
     ]);
     assert.equal(
@@ -665,7 +671,7 @@ describe('formatStatusOutput — useColor context (issue #116)', () => {
       codex: {
         enabled: true,
         authSource: 'agent-store',
-        snapshots: [
+        usageSnapshots: [
           {
             source: 'provider_usage_endpoint',
             authType: 'oauth',
@@ -680,7 +686,7 @@ describe('formatStatusOutput — useColor context (issue #116)', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsages: [],
+        usageSnapshots: [],
       },
     };
     const colored = formatStatusOutput(snapshot, { useColor: true });
@@ -697,7 +703,7 @@ describe('formatStatusOutput — useColor context (issue #116)', () => {
       codex: {
         enabled: true,
         authSource: 'agent-store',
-        snapshots: [
+        usageSnapshots: [
           {
             source: 'provider_usage_endpoint',
             authType: 'oauth',
@@ -712,7 +718,7 @@ describe('formatStatusOutput — useColor context (issue #116)', () => {
         authSource: 'not-found',
         detected: false,
         selectedAccount: null,
-        networkUsages: [],
+        usageSnapshots: [],
       },
     });
     assert.ok(!lines.some((l) => l.includes('\x1b[')));

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -235,14 +235,14 @@ describe('formatStatusJson — providers array', () => {
       configPath: '/x',
       providers: { codex: { enabled: true }, claude: { enabled: true } },
       sync: {},
-      codex: { enabled: true, snapshots: [] },
+      codex: { enabled: true, usageSnapshots: [] },
       claude: { detected: false },
     });
     const parsed = JSON.parse(json);
     assert.equal(parsed.providers.length, 2);
     assert.deepEqual(parsed.providers.map((p) => p.id).sort(), ['claude', 'codex']);
     const codexEntry = parsed.providers.find((p) => p.id === 'codex');
-    assert.deepEqual(codexEntry.snapshot, { enabled: true, snapshots: [] });
+    assert.deepEqual(codexEntry.snapshot, { enabled: true, usageSnapshots: [] });
   });
 
   it('only includes the matching provider when providerFilter is set', () => {
@@ -252,7 +252,7 @@ describe('formatStatusJson — providers array', () => {
       providers: { codex: { enabled: true }, claude: { enabled: true } },
       sync: {},
       providerFilter: 'codex',
-      codex: { enabled: true, snapshots: [] },
+      codex: { enabled: true, usageSnapshots: [] },
       // claude key absent — runProviderSnapshots already filtered
     });
     const parsed = JSON.parse(json);
@@ -289,6 +289,64 @@ describe('formatStatusJson — providers array', () => {
     );
     assert.equal(parsed.accountFilter, null);
     assert.equal(parsed.providerFilter, null);
+  });
+});
+
+describe('formatStatusJson — provider keyset symmetry (issue #120)', () => {
+  // v0.5.0: codex / claude provider snapshot 의 keyset 이 동일해야 함.
+  // 핵심 키: enabled / authSource / credentialsPath / usageSnapshots /
+  // accountFilter / filteredOut.
+
+  it('codex / claude snapshot expose the same keyset', () => {
+    const json = formatStatusJson({
+      schemaVersion: '0.5.0',
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: {},
+      codex: {
+        enabled: true,
+        authSource: 'agent-store',
+        credentialsPath: null,
+        usageSnapshots: [],
+        accountFilter: null,
+        filteredOut: false,
+      },
+      claude: {
+        enabled: true,
+        authSource: 'agent-store',
+        credentialsPath: null,
+        usageSnapshots: [],
+        accountFilter: null,
+        filteredOut: false,
+      },
+    });
+    const parsed = JSON.parse(json);
+    const codex = parsed.providers.find((p) => p.id === 'codex').snapshot;
+    const claude = parsed.providers.find((p) => p.id === 'claude').snapshot;
+    assert.deepEqual(Object.keys(codex).sort(), Object.keys(claude).sort());
+  });
+
+  it('removed legacy keys are absent (snapshots / networkUsages / networkUsage / detected / found / parsed / selectedAccount / importedAccount)', () => {
+    const json = formatStatusJson({
+      schemaVersion: '0.5.0',
+      configPath: '/x',
+      providers: { codex: { enabled: true }, claude: { enabled: true } },
+      sync: {},
+      codex: { enabled: true, authSource: 'agent-store', usageSnapshots: [] },
+      claude: { enabled: true, authSource: 'agent-store', usageSnapshots: [] },
+    });
+    const parsed = JSON.parse(json);
+    for (const p of parsed.providers) {
+      const s = p.snapshot;
+      assert.equal('snapshots' in s, false, `${p.id}.snapshot has legacy 'snapshots'`);
+      assert.equal('networkUsages' in s, false, `${p.id}.snapshot has legacy 'networkUsages'`);
+      assert.equal('networkUsage' in s, false, `${p.id}.snapshot has legacy 'networkUsage'`);
+      assert.equal('detected' in s, false, `${p.id}.snapshot has legacy 'detected'`);
+      assert.equal('found' in s, false, `${p.id}.snapshot has legacy 'found'`);
+      assert.equal('parsed' in s, false, `${p.id}.snapshot has legacy 'parsed'`);
+      assert.equal('selectedAccount' in s, false, `${p.id}.snapshot has legacy 'selectedAccount'`);
+      assert.equal('importedAccount' in s, false, `${p.id}.snapshot has legacy 'importedAccount'`);
+    }
   });
 });
 

--- a/packages/agent/test/services/claude-provider.test.js
+++ b/packages/agent/test/services/claude-provider.test.js
@@ -116,13 +116,18 @@ describe('resolveClaudeProfileFromSnapshot (via claude-provider)', () => {
 });
 
 describe('getClaudeSnapshot — disabled config contract', () => {
-  it('returns networkUsages=[] when claude provider is disabled (issue #119: networkUsage alias 제거됨)', async () => {
+  it('returns enabled=false / usageSnapshots=[] when claude provider is disabled (issue #120)', async () => {
     const snap = await getClaudeSnapshot({ providers: { claude: { enabled: false } } });
-    assert.deepEqual(snap.networkUsages, []);
-    // backward-compat alias 부재 회귀 가드
+    assert.equal(snap.enabled, false);
+    assert.deepEqual(snap.usageSnapshots, []);
+    // backward-compat alias / 제거된 키 회귀 가드 (Phase 1+2)
     assert.equal('networkUsage' in snap, false);
+    assert.equal('networkUsages' in snap, false);
     assert.equal('importedAccount' in snap, false);
     assert.equal('parsed' in snap, false);
+    assert.equal('detected' in snap, false);
+    assert.equal('found' in snap, false);
+    assert.equal('selectedAccount' in snap, false);
     assert.ok(typeof snap.authSource === 'string');
   });
 });

--- a/packages/agent/test/services/codex-provider.test.js
+++ b/packages/agent/test/services/codex-provider.test.js
@@ -54,11 +54,13 @@ describe('filterRealCodexAccounts (via codex-provider)', () => {
 // disabled config → 항상 고정된 shape. live 케이스는 수동 smoke로 확인.
 
 describe('getCodexSnapshot — disabled config contract', () => {
-  it('returns enabled=false with empty snapshots when codex disabled', async () => {
+  it('returns enabled=false with empty usageSnapshots when codex disabled (issue #120)', async () => {
     const snap = await getCodexSnapshot({ providers: { codex: { enabled: false } } });
     assert.equal(snap.enabled, false);
-    assert.deepEqual(snap.snapshots, []);
-    // issue #113 — authProfilesPath (OpenClaw 전용) → credentialsPath (Codex CLI 와 정렬, claude 와 대칭)
+    // v0.5.0 (issue #120): snapshots → usageSnapshots rename
+    assert.deepEqual(snap.usageSnapshots, []);
+    assert.equal('snapshots' in snap, false);
+    // issue #113 — credentialsPath (Codex CLI 와 정렬, claude 와 대칭)
     assert.equal(typeof snap.credentialsPath, 'string');
     assert.match(snap.credentialsPath, /\/\.codex\/auth\.json$/);
   });

--- a/packages/agent/test/services/codex-provider.test.js
+++ b/packages/agent/test/services/codex-provider.test.js
@@ -60,9 +60,10 @@ describe('getCodexSnapshot — disabled config contract', () => {
     // v0.5.0 (issue #120): snapshots → usageSnapshots rename
     assert.deepEqual(snap.usageSnapshots, []);
     assert.equal('snapshots' in snap, false);
-    // issue #113 — credentialsPath (Codex CLI 와 정렬, claude 와 대칭)
-    assert.equal(typeof snap.credentialsPath, 'string');
-    assert.match(snap.credentialsPath, /\/\.codex\/auth\.json$/);
+    // PR #123 review: credentialsPath 는 'codex-cli-import' 시점만 노출 — disabled
+    // 또는 not-found 시 null. claude 와 동일 정책.
+    assert.equal(snap.credentialsPath, null);
+    assert.equal(snap.authSource, 'not-found');
   });
 });
 

--- a/packages/agent/test/services/provider-registry.test.js
+++ b/packages/agent/test/services/provider-registry.test.js
@@ -41,9 +41,11 @@ describe('runProviderSnapshots', () => {
       providers: { codex: { enabled: false }, claude: { enabled: false } },
     });
     assert.equal(out.codex.enabled, false);
-    // Claude snapshot always returns base + networkUsages=[] when disabled (issue #119:
-    // networkUsage 단일 alias 제거됨).
-    assert.deepEqual(out.claude.networkUsages, []);
+    // v0.5.0 (issue #120): provider keyset 정합 — codex/claude 모두 enabled +
+    // usageSnapshots[] (배열). claude 의 networkUsages wrapper 패턴은 제거됨.
+    assert.equal(out.claude.enabled, false);
+    assert.deepEqual(out.claude.usageSnapshots, []);
+    assert.deepEqual(out.codex.usageSnapshots, []);
   });
 
   it('CLI accountFilter and config.defaults.profiles do not throw when both supplied', async () => {

--- a/packages/schemas/src/index.js
+++ b/packages/schemas/src/index.js
@@ -1,2 +1,2 @@
-export const SCHEMA_VERSION = '0.4.0';
+export const SCHEMA_VERSION = '0.5.0';
 export { validateUsageSnapshot, validateUsageEvent } from './validate.js';

--- a/packages/schemas/test/schema-version.test.js
+++ b/packages/schemas/test/schema-version.test.js
@@ -26,12 +26,17 @@ import { SCHEMA_VERSION } from '../src/index.js';
  *  - 0.4.0 (issue #119) — `status --json` claude 영역의 backward-compat
  *    alias 3 종 제거: `networkUsage` (단일, → `networkUsages[]` 만) /
  *    `importedAccount` (→ `selectedAccount` 만) / `parsed` (→ `found` 만)
+ *  - 0.5.0 (issue #120) — `status --json` provider 영역 shape 정합 (codex /
+ *    claude 키셋 통일): `snapshots[]`/`networkUsages[]` → `usageSnapshots[]`
+ *    (wrapper 도 제거, UsageSnapshot 직접 배열). claude 의 `detected`/`found`
+ *    → `enabled` 단일 boolean. claude `selectedAccount` 제거. credentialsPath
+ *    null-when-not-cli-import 정책 양 provider 정렬.
  */
 describe('SCHEMA_VERSION lock', () => {
   it('현재 값이 정책과 일치한다', () => {
     assert.equal(
       SCHEMA_VERSION,
-      '0.4.0',
+      '0.5.0',
       'SCHEMA_VERSION 변경 시 docs/release-policy.md §3 / docs/cli-json-output.md / 본 테스트를 같이 갱신',
     );
   });


### PR DESCRIPTION
Closes #120

## 요약

`status --json` 의 codex / claude provider entry shape 를 동일 키셋으로 정합. 외부 consumer 가 provider 분기 없이 단일 path 로 데이터를 조회 가능. `SCHEMA_VERSION` 0.4.0 → 0.5.0.

3-phase JSON contract 정리 plan 의 **Phase 2** (Phase 1 #119 후속).

## 통일된 provider entry shape (v0.5.0)

```
providers[].snapshot = {
  enabled: bool,                        // config flag (codex / claude 공통)
  authSource: string,                   // 'agent-store' / 'codex-cli-import' / 'claude-cli-import' / 'not-found'
  credentialsPath: string|null,         // cli-import 시점만 path, 그 외 null (양 provider 동일 정책)
  usageSnapshots: Array<UsageSnapshot>, // 계정별 snapshot 직접 배열 (wrapper 제거)
  accountFilter: string|null,
  filteredOut: boolean,
}
```

## 변경 내용

### Provider shape (Breaking — release-policy §1)

| 측면 | v0.4.x (Codex) | v0.4.x (Claude) | v0.5.0+ (양 provider 동일) |
|---|---|---|---|
| usage 배열 키 | `snapshots[]` | `networkUsages[]` | **`usageSnapshots[]`** |
| 배열 element | `UsageSnapshot` 직접 | `{ accountKey, account, snapshot }` wrapper | **`UsageSnapshot` 직접** |
| 활성 여부 | `enabled: bool` | `detected` / `found` (2 키) | **`enabled: bool`** |
| 기본 계정 | (없음) | `selectedAccount` | (없음, 양 provider 제거) |
| credentialsPath | cli-import 시만 | 항상 | **cli-import 시만** |

### 코드 변경

- **`packages/agent/src/services/codex-provider.js`**: `snapshots` → `usageSnapshots` (return + disabled 경로).
- **`packages/agent/src/services/claude-provider.js`**: `getClaudeSnapshot` 완전 재작성 — config flag 우선 확인 + 통일된 shape 반환. `settled.map(e => e.snapshot)` 으로 wrapper unwrap.
- **`packages/agent/src/cli/status-formatters.js`**: `formatCodexSection` / `formatClaudeNetworkUsages` 가 새 shape 사용. `accountLabel` fallback 에 `profileId` 추가.
- **`packages/agent/src/cli/doctor-helpers.js`**: doctor 의 `formatClaudeSection` 도 새 키 사용.

### SCHEMA / Lock

- **`packages/schemas/src/index.js`**: `SCHEMA_VERSION` 0.4.0 → 0.5.0
- **`packages/schemas/test/schema-version.test.js`**: lock + 변경 이력 갱신

### 회귀 가드 (status-json.test.js 신규 describe)

- codex / claude provider snapshot keyset 동일성 단언 (`Object.keys(codex).sort() === Object.keys(claude).sort()`)
- legacy 키 부재 단언 8 종: `snapshots` / `networkUsages` / `networkUsage` / `detected` / `found` / `parsed` / `selectedAccount` / `importedAccount`

### 테스트 일괄 마이그레이션 (6 파일)

- `codex-provider.test.js` / `claude-provider.test.js` / `provider-registry.test.js` — 새 shape 단언
- `status-command.test.js` / `status-json.test.js` — fixture 의 wrapper 제거 + accountLabel profileId fallback 활용
- `doctor-command.test.js` — `formatClaudeSection` 의 7 케이스 → `enabled` / `usageSnapshots` 기반 5 케이스로 재작성

### Docs

- `docs/cli-json-output.md` — Provider entry shape 표 + Migration 비교 표 + before/after 코드 예시
- `docs/release-policy.md` §6 변경 이력 + §3 현재 값 갱신

### Changeset

`.changeset/provider-shape-symmetry.md` — 3 패키지 minor + `!`. Breaking changes 5 항목 + Migration before/after 코드.

## Migration (외부 consumer)

```js
// before (v0.4.x)
const provider = (id) => providers.find((p) => p.id === id).snapshot;
const codexEnabled = provider('codex').enabled;
const codexSnaps = provider('codex').snapshots;                    // ← 이전 키
const claudeEnabled = provider('claude').detected;                 // ← 이전 키
const claudeWindows =
  provider('claude').networkUsages[0].snapshot.usageWindows;       // ← wrapper
const claudeAccount = provider('claude').selectedAccount;          // ← 이전 키

// after (v0.5.0+) — codex / claude 동일 path
const provider = (id) => providers.find((p) => p.id === id).snapshot;
const codexEnabled = provider('codex').enabled;
const codexSnaps = provider('codex').usageSnapshots;               // ← 통일
const claudeEnabled = provider('claude').enabled;                  // ← 통일
const claudeWindows = provider('claude').usageSnapshots[0].usageWindows; // ← unwrap
const claudeAccount = provider('claude').usageSnapshots.find(/* ... */)?.account;
//   default account 개념 제거 — usageSnapshots[] 순회로 식별.
```

자세한 표 + 예시: `docs/cli-json-output.md` §"Provider shape symmetry (v0.5.0)".

## 영향 없음

- 평문 출력 (`status` / `usage`) — 내부 키 rename 만, 사용자 가시 시각 동일
- 단일 snapshot shape (`usageSnapshots[]` element = `buildUsageSnapshot` 결과) — schema 그대로
- redaction (`SENSITIVE_KEYS`) — 무변경
- runtime deps — 무변경
- public API surface — 무변경 (CLI 내부만)

## 트레이드오프

- 외부 consumer 의 4 경로 모두 갱신 필요 — Migration 비용 큼. Phase 1 (#119) 의 alias 정리 직후라 시기 적절.
- v0.4.0 → v0.5.0 두 번째 minor bump가 짧은 시간에 — 의도된 sequential roll-out (3-phase plan).
- `selectedAccount` 제거로 doctor 명령의 default account 표기 사라짐 — multi-account UI 도입 후 의미 약해져 수용 가능.

## 테스트 / 확인

- [x] `npm test` 850 통과 (회귀 가드 신규 + fixture 마이그레이션)
- [x] `npm run lint` 통과
- [x] `npm run format:check` 통과
- [x] `npm run build:types` 통과
- [x] `npm run cli:status -- --json | jq '.schemaVersion'` → `"0.5.0"`
- [x] `npm run cli:status -- --json | jq '[.providers[] | {id, keys: (.snapshot|keys)}]'` → 양 provider keys 동일
- [x] 평문 `npm run cli:status` 시각 동일성 확인

## 참고 사항

- 본 PR 은 3-phase plan (`~/.claude/plans/dreamy-tinkering-reddy.md`) 의 Phase 2.
- 다음: Phase 3 (#121) — docs 정합 + schemaVersion lock 회귀 가드.
- 본 PR 머지 → release PR force-update → publish 시 v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)