### PR TITLE
[feat] telegram bot 통합 (1/5) — @token-weather/telegram 패키지 scaffold + config / redaction 키 추가

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,14 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@token-weather/cli", "@token-weather/provider-adapters", "@token-weather/schemas"]],
+  "linked": [
+    [
+      "@token-weather/cli",
+      "@token-weather/provider-adapters",
+      "@token-weather/schemas",
+      "@token-weather/telegram"
+    ]
+  ],
   "access": "public",
   "baseBranch": "dev",
   "updateInternalDependencies": "patch",

--- a/.changeset/telegram-package-scaffold.md
+++ b/.changeset/telegram-package-scaffold.md
@@ -11,20 +11,34 @@ chore(repo): @token-weather/telegram 워크스페이스 패키지 scaffold (issu
 패키지 신설 + config / redaction 인프라 선 도입으로 후속 phase 의 코어 작업
 진입을 단순화. linked 정책에 따라 4 패키지 모두 같은 minor bump.
 
+**중요 — Phase 1 scaffold publish 성격**:
+
+본 release 의 `@token-weather/telegram` 은 **scaffold 단계**이며 public export
+`runTelegramCommand` 는 호출 시 NotImplemented 오류를 던진다. npm 사용자가 직접
+install 해 봇을 띄울 수 있는 단계가 아니다 — 실 동작은 Phase 3 머지 / 후속
+release 부터. package.json description 에 "Phase 1 scaffold" 라벨링.
+
 **신규 워크스페이스 패키지**:
 
 - `@token-weather/telegram` 초기 v0.4.0 진입 (다음 publish 시 linked 정책으로
   4 패키지 모두 v0.5.0 동시 진입).
-- placeholder `runTelegramCommand` export — Phase 3 머지 시 실 dispatch
-  로직이 채워짐.
+- placeholder `runTelegramCommand(argv, deps)` export — Phase 3 머지 시 실
+  dispatch 로직이 채워짐. **`deps` 매개변수 (의존성 주입)** 시그니처는 scaffold
+  단계에서 못 박음: 본 패키지가 `@token-weather/cli` 를 직접 import 하지 않고
+  CLI 가 core 함수 묶음 (getStatusSnapshot / formatStatusOutput / formatStatusJson
+  등) 을 deps 로 전달해 순환 의존을 방지한다 (PR #131 review 반영).
 - `grammy` ^1.42.0 신규 의존성 — long-poll 루프 / 미들웨어 추상화.
 
 **기존 패키지 변경** (`@token-weather/cli`):
 
-- `config.providers.telegram = { enabled: false, botToken: '', allowedChatIds: [] }` 추가 (codex/claude 동급).
+- `config.channels.telegram = { enabled: false, botToken: '', allowedChatIds: [] }`
+  신규. `providers` (usage 조회 대상 — codex / claude) 와 의도적으로 분리 —
+  PROVIDER_REGISTRY / `--provider` 필터 / `status --json providers[]` / `authSource`
+  / `usageSnapshots` 가 모두 usage provider 의미에 묶여 있어, Telegram 같은
+  transport / channel 은 별도 네임스페이스 (PR #131 review 반영).
 - `SENSITIVE_KEYS` 확장: `botToken` / `bot_token` / `telegramBotToken` —
   Phase 2 이후 raw 영역에 흘러갈 가능성 대비 redaction 가드 선 등록.
-- redaction 회귀 테스트 2건 신설.
+- redaction 회귀 테스트 2건 신설 (`channels.telegram` 경로 fixture).
 
-**SCHEMA_VERSION** 무변경 — status --json contract 는 무영향 (telegram 키는
+**SCHEMA_VERSION** 무변경 — `status --json` contract 는 무영향 (telegram 키는
 별도 패키지가 단독 소비). **Migration** 없음 — 기존 사용자 동작 100% 호환.

--- a/.changeset/telegram-package-scaffold.md
+++ b/.changeset/telegram-package-scaffold.md
@@ -1,0 +1,30 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+chore(repo): @token-weather/telegram 워크스페이스 패키지 scaffold (issue #126).
+
+5-phase Telegram 봇 통합 plan (issue #126 ~ #130) 의 Phase 1. 신규 워크스페이스
+패키지 신설 + config / redaction 인프라 선 도입으로 후속 phase 의 코어 작업
+진입을 단순화. linked 정책에 따라 4 패키지 모두 같은 minor bump.
+
+**신규 워크스페이스 패키지**:
+
+- `@token-weather/telegram` 초기 v0.4.0 진입 (다음 publish 시 linked 정책으로
+  4 패키지 모두 v0.5.0 동시 진입).
+- placeholder `runTelegramCommand` export — Phase 3 머지 시 실 dispatch
+  로직이 채워짐.
+- `grammy` ^1.42.0 신규 의존성 — long-poll 루프 / 미들웨어 추상화.
+
+**기존 패키지 변경** (`@token-weather/cli`):
+
+- `config.providers.telegram = { enabled: false, botToken: '', allowedChatIds: [] }` 추가 (codex/claude 동급).
+- `SENSITIVE_KEYS` 확장: `botToken` / `bot_token` / `telegramBotToken` —
+  Phase 2 이후 raw 영역에 흘러갈 가능성 대비 redaction 가드 선 등록.
+- redaction 회귀 테스트 2건 신설.
+
+**SCHEMA_VERSION** 무변경 — status --json contract 는 무영향 (telegram 키는
+별도 패키지가 단독 소비). **Migration** 없음 — 기존 사용자 동작 100% 호환.

--- a/package.json
+++ b/package.json
@@ -16,15 +16,16 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "node --test packages/agent/test/**/*.test.js packages/provider-adapters/test/**/*.test.js packages/schemas/test/**/*.test.js",
+    "test": "node --test packages/agent/test/**/*.test.js packages/provider-adapters/test/**/*.test.js packages/schemas/test/**/*.test.js packages/telegram/test/**/*.test.js",
     "test:schemas": "node --test packages/schemas/test/**/*.test.js",
     "test:agent": "node --test packages/agent/test/**/*.test.js",
     "test:adapters": "node --test packages/provider-adapters/test/**/*.test.js",
+    "test:telegram": "node --test packages/telegram/test/**/*.test.js",
     "cli:status": "node ./packages/agent/bin/token-weather.js status",
     "cli:usage": "node ./packages/agent/bin/token-weather.js usage",
     "cli:doctor": "node ./packages/agent/bin/token-weather.js doctor",
     "cli:config:init": "node ./packages/agent/bin/token-weather.js config init",
-    "build:types": "npm -w @token-weather/schemas run build:types && npm -w @token-weather/provider-adapters run build:types && npm -w @token-weather/cli run build:types"
+    "build:types": "npm -w @token-weather/schemas run build:types && npm -w @token-weather/provider-adapters run build:types && npm -w @token-weather/cli run build:types && npm -w @token-weather/telegram run build:types"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/packages/agent/src/cli/status-json.js
+++ b/packages/agent/src/cli/status-json.js
@@ -55,6 +55,11 @@ export const SENSITIVE_KEYS = Object.freeze(
     'apiKey',
     'api_key',
     'password',
+    // Telegram bot token (@token-weather/telegram daemon 활성화 시
+    // config.providers.telegram.botToken 으로 저장됨)
+    'botToken',
+    'bot_token',
+    'telegramBotToken',
   ]),
 );
 

--- a/packages/agent/src/config/default-config.js
+++ b/packages/agent/src/config/default-config.js
@@ -16,6 +16,16 @@ export const DEFAULT_AGENT_CONFIG = {
     claude: {
       enabled: true,
     },
+  },
+  /**
+   * 외부 채널 / 메시징 integration 설정. `providers` (usage 조회 대상) 와 의도적으로
+   * 분리 — PROVIDER_REGISTRY / `--provider` 필터 / `status --json providers[]` /
+   * `authSource` / `usageSnapshots` 가 모두 usage provider 의미에 묶여 있으므로,
+   * Telegram 같은 channel 은 별도 네임스페이스를 갖는다.
+   *
+   * 향후 Discord / Slack 같은 추가 channel 도 본 객체 아래에 합류.
+   */
+  channels: {
     /**
      * Telegram 봇 채널 — `@token-weather/telegram` 패키지가 daemon 으로 구동될
      * 때 본 키를 읽는다. 기본값은 opt-out (enabled: false). 활성화는

--- a/packages/agent/src/config/default-config.js
+++ b/packages/agent/src/config/default-config.js
@@ -16,6 +16,20 @@ export const DEFAULT_AGENT_CONFIG = {
     claude: {
       enabled: true,
     },
+    /**
+     * Telegram 봇 채널 — `@token-weather/telegram` 패키지가 daemon 으로 구동될
+     * 때 본 키를 읽는다. 기본값은 opt-out (enabled: false). 활성화는
+     * `token-weather telegram setup` 명령이 자동 갱신한다 (Phase 4).
+     *
+     *   - botToken: BotFather 가 발급한 토큰. SENSITIVE_KEYS 로 redact 됨.
+     *   - allowedChatIds: 명령 수신을 허용할 Telegram user_id 배열 (단일
+     *     사용자여도 array 형태 유지 — 추후 가족 / 멀티 디바이스 확장 여지).
+     */
+    telegram: {
+      enabled: false,
+      botToken: '',
+      allowedChatIds: [],
+    },
   },
   /**
    * 기본 프로필(계정) 선택 정책.

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -208,7 +208,7 @@ describe('redactSensitive — objects', () => {
 
   it('removes telegram bot token at any depth (issue #126)', () => {
     const out = redactSensitive({
-      providers: {
+      channels: {
         telegram: {
           enabled: true,
           botToken: '1234567890:ABCDEF',
@@ -219,7 +219,7 @@ describe('redactSensitive — objects', () => {
       },
     });
     assert.deepEqual(out, {
-      providers: {
+      channels: {
         telegram: {
           enabled: true,
           allowedChatIds: [42],

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -94,6 +94,12 @@ describe('SENSITIVE_KEYS', () => {
     assert.ok(SENSITIVE_KEYS.has('api_key'));
     assert.ok(SENSITIVE_KEYS.has('password'));
   });
+
+  it('contains telegram bot token variants (issue #126)', () => {
+    assert.ok(SENSITIVE_KEYS.has('botToken'));
+    assert.ok(SENSITIVE_KEYS.has('bot_token'));
+    assert.ok(SENSITIVE_KEYS.has('telegramBotToken'));
+  });
 });
 
 describe('isSensitiveKey — case-insensitive matching', () => {
@@ -198,6 +204,28 @@ describe('redactSensitive — objects', () => {
       password: 'p1',
     });
     assert.deepEqual(out, { label: 'work' });
+  });
+
+  it('removes telegram bot token at any depth (issue #126)', () => {
+    const out = redactSensitive({
+      providers: {
+        telegram: {
+          enabled: true,
+          botToken: '1234567890:ABCDEF',
+          bot_token: '1234567890:GHIJKL',
+          telegramBotToken: '1234567890:MNOPQR',
+          allowedChatIds: [42],
+        },
+      },
+    });
+    assert.deepEqual(out, {
+      providers: {
+        telegram: {
+          enabled: true,
+          allowedChatIds: [42],
+        },
+      },
+    });
   });
 
   it('matches keys case-insensitively (AccessToken / Refresh-Token style stays caught)', () => {

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@token-weather/telegram",
+  "version": "0.4.0",
+  "description": "Token Weather Telegram 봇 통합 — 로컬 daemon 으로 status / usage / doctor 명령을 Telegram 채널에 노출",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./dist/types/index.d.ts",
+  "files": [
+    "src",
+    "dist/types"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LLagoon3/token-weather.git",
+    "directory": "packages/telegram"
+  },
+  "homepage": "https://github.com/LLagoon3/token-weather#readme",
+  "bugs": {
+    "url": "https://github.com/LLagoon3/token-weather/issues"
+  },
+  "keywords": [
+    "token-weather",
+    "telegram",
+    "bot",
+    "daemon",
+    "remote-cli"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@token-weather/provider-adapters": "^0.4.0",
+    "@token-weather/schemas": "^0.4.0",
+    "grammy": "^1.42.0"
+  },
+  "scripts": {
+    "build:types": "tsc -p ./tsconfig.json"
+  }
+}

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@token-weather/telegram",
   "version": "0.4.0",
-  "description": "Token Weather Telegram 봇 통합 — 로컬 daemon 으로 status / usage / doctor 명령을 Telegram 채널에 노출",
+  "description": "Token Weather Telegram 봇 통합 — 로컬 daemon 으로 status / usage / doctor 명령을 Telegram 채널에 노출 (Phase 1 scaffold — 실 동작은 후속 release 부터)",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -1,0 +1,20 @@
+/**
+ * @token-weather/telegram — Telegram 봇 통합 패키지 진입점.
+ *
+ * 5-phase plan (issue #126~#130) 의 Phase 1 시점에서는 워크스페이스 scaffold +
+ * placeholder export 만 제공한다. 실제 long-poll daemon / 명령 라우터 / 핸들러는
+ * Phase 2~3 (#127, #128) 에서 채워지고, 사용자 setup 흐름은 Phase 4 (#129).
+ */
+
+/**
+ * `@token-weather/cli` 의 `run-cli` 가 `telegram` 서브명령에서 dynamic import 로
+ * 호출하는 진입점. Phase 3 머지 시점에 실제 dispatch 로직이 들어간다.
+ *
+ * @param {string[]} _argv - `token-weather telegram <subcommand> ...` 의 나머지 인자.
+ * @returns {Promise<void>}
+ */
+export async function runTelegramCommand(_argv) {
+  throw new Error(
+    'token-weather telegram: 아직 구현되지 않았습니다 (5-phase plan 진행 중 — Phase 3 에서 활성화)',
+  );
+}

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -4,16 +4,36 @@
  * 5-phase plan (issue #126~#130) 의 Phase 1 시점에서는 워크스페이스 scaffold +
  * placeholder export 만 제공한다. 실제 long-poll daemon / 명령 라우터 / 핸들러는
  * Phase 2~3 (#127, #128) 에서 채워지고, 사용자 setup 흐름은 Phase 4 (#129).
+ *
+ * ## 의존성 방향 (PR #131 review 지적 반영)
+ *
+ * `@token-weather/cli` 가 본 패키지를 dynamic import 로 호출하므로, 본 패키지가
+ * 다시 `@token-weather/cli` 를 import 하면 순환이 생긴다. 반대로 core 로직 (status
+ * snapshot / formatter / config loader) 을 본 패키지가 재구현하면 CLI 와 drift
+ * 발생.
+ *
+ * 본 패키지는 그 두 경로 모두 피하기 위해 **의존성 주입 (deps injection)** 을
+ * 채택한다 — `runTelegramCommand(argv, deps)` 의 `deps` 로 CLI 측이 core 함수
+ * 묶음을 그대로 넘긴다. 본 패키지는 `@token-weather/provider-adapters` 와
+ * `@token-weather/schemas` 만 직접 의존하고, status / usage / doctor / auth-list
+ * 같은 CLI-소유 함수는 deps 를 통해서만 접근한다.
+ *
+ * Phase 3 (#128) 에서 `deps` 의 정확한 shape 가 typedef 로 굳어진다. 현재는
+ * Phase 3 가 채울 핵심 키만 주석으로 가이드.
  */
 
 /**
  * `@token-weather/cli` 의 `run-cli` 가 `telegram` 서브명령에서 dynamic import 로
- * 호출하는 진입점. Phase 3 머지 시점에 실제 dispatch 로직이 들어간다.
+ * 호출하는 진입점.
  *
  * @param {string[]} _argv - `token-weather telegram <subcommand> ...` 의 나머지 인자.
+ * @param {object} [_deps] - CLI 가 주입하는 core 함수 묶음. Phase 3 에서 다음 키들이
+ *   채워진다: `getStatusSnapshot`, `formatStatusOutput`, `formatStatusJson`,
+ *   `collectDoctorReport`, `collectAuthListData`, `resolveAgentConfigPath`. 본 패키지가
+ *   `@token-weather/cli` 를 직접 import 하지 않도록 막아 순환 의존을 방지한다.
  * @returns {Promise<void>}
  */
-export async function runTelegramCommand(_argv) {
+export async function runTelegramCommand(_argv, _deps) {
   throw new Error(
     'token-weather telegram: 아직 구현되지 않았습니다 (5-phase plan 진행 중 — Phase 3 에서 활성화)',
   );

--- a/packages/telegram/test/scaffold.test.js
+++ b/packages/telegram/test/scaffold.test.js
@@ -8,6 +8,12 @@ describe('@token-weather/telegram scaffold (Phase 1)', () => {
     assert.equal(typeof runTelegramCommand, 'function');
   });
 
+  it('argv + deps 두 인자 시그니처를 수용한다 (deps 주입 — PR #131 review)', async () => {
+    // deps 주입 시그니처가 자리잡혔는지 호출 호환성으로 검증한다 (Phase 1
+    // placeholder 단계에서는 어떤 deps 가 들어와도 NotImplemented).
+    await assert.rejects(() => runTelegramCommand([], {}), /구현되지 않았습니다/);
+  });
+
   it('Phase 1 단계에서는 호출 시 NotImplemented 오류를 던진다', async () => {
     await assert.rejects(() => runTelegramCommand([]), /구현되지 않았습니다/);
   });

--- a/packages/telegram/test/scaffold.test.js
+++ b/packages/telegram/test/scaffold.test.js
@@ -1,0 +1,14 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runTelegramCommand } from '../src/index.js';
+
+describe('@token-weather/telegram scaffold (Phase 1)', () => {
+  it('runTelegramCommand 는 비동기 함수로 export 된다', () => {
+    assert.equal(typeof runTelegramCommand, 'function');
+  });
+
+  it('Phase 1 단계에서는 호출 시 NotImplemented 오류를 던진다', async () => {
+    await assert.rejects(() => runTelegramCommand([]), /구현되지 않았습니다/);
+  });
+});

--- a/packages/telegram/tsconfig.json
+++ b/packages/telegram/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/types"
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["test/**", "**/*.test.js", "dist/**", "node_modules"]
+}

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -8,11 +8,11 @@
 #
 # 흐름:
 #   1) build:types 로 d.ts emit
-#   2) npm pack --workspaces 로 3 publishable 패키지 tarball 생성
-#   3) 임시 디렉토리에서 3 tarball을 동시 install
-#      (서로 ^0.1.0 의존이라 단독 install 시 registry로 가서 fail)
+#   2) npm pack --workspaces 로 4 publishable 패키지 tarball 생성
+#   3) 임시 디렉토리에서 4 tarball을 동시 install
+#      (cross-package 의존이라 단독 install 시 registry로 가서 fail)
 #   4) bin 핵심 명령(--help, auth login claude --help) 실행 → exit 0 확인
-#   5) 3 패키지의 dist/types/index.d.ts 가 install된 node_modules에 존재하는지 확인
+#   5) 4 패키지의 dist/types/index.d.ts 가 install된 node_modules에 존재하는지 확인
 #
 # 안전장치:
 #   - HOME 을 mktemp 디렉토리로 override → 사용자 실 ~/.config/token-weather/auth.json
@@ -42,12 +42,12 @@ mkdir -p "$PACKS_DIR"
 npm pack --workspaces --pack-destination "$PACKS_DIR" --silent > /dev/null
 
 TARBALL_COUNT=$(find "$PACKS_DIR" -maxdepth 1 -name '*.tgz' -type f | wc -l)
-if [ "$TARBALL_COUNT" -ne 3 ]; then
-  echo "❌ expected 3 tarballs in $PACKS_DIR, got $TARBALL_COUNT"
+if [ "$TARBALL_COUNT" -ne 4 ]; then
+  echo "❌ expected 4 tarballs in $PACKS_DIR, got $TARBALL_COUNT"
   ls -la "$PACKS_DIR" || true
   exit 1
 fi
-echo "  ✓ 3 tarballs packed"
+echo "  ✓ 4 tarballs packed"
 
 echo "▶ 3. tmp 디렉토리 install"
 TMP=$(mktemp -d -t tw-install-smoke-XXXXXX)
@@ -63,7 +63,7 @@ cat > package.json <<'EOF'
 }
 EOF
 
-# 3 tarball을 한 번에 install — 서로 ^0.1.0 의존이라 npm이 fs path로 cross-resolve
+# 4 tarball을 한 번에 install — cross-package 의존이라 npm이 fs path로 cross-resolve
 npm install --no-package-lock --no-audit --no-fund "$PACKS_DIR"/*.tgz > /dev/null
 echo "  ✓ install 완료"
 
@@ -80,23 +80,24 @@ HOME="$TMP_HOME" NO_COLOR=1 "$BIN" auth login claude --help > /dev/null
 echo "  ✓ bin 실행 OK"
 
 echo "▶ 5. d.ts 산출물 검증"
-for pkg in @token-weather/cli @token-weather/provider-adapters @token-weather/schemas; do
+for pkg in @token-weather/cli @token-weather/provider-adapters @token-weather/schemas @token-weather/telegram; do
   dts="$TMP/node_modules/$pkg/dist/types/index.d.ts"
   if [ ! -f "$dts" ]; then
     echo "❌ d.ts 누락: $dts"
     exit 1
   fi
 done
-echo "  ✓ 3 패키지 d.ts 모두 존재"
+echo "  ✓ 4 패키지 d.ts 모두 존재"
 
 echo "▶ 6. ESM root import 해상도 검증"
-# tmp 프로젝트의 root에서 3 패키지를 직접 import — 실제 publish/install 환경의
+# tmp 프로젝트의 root에서 4 패키지를 직접 import — 실제 publish/install 환경의
 # resolution 흐름과 동일. 단순 import 가능성과 알려진 named export 한 개의
 # shape 까지만 검증하고 함수는 호출하지 않는다 (side effect 회피).
 cat > "$TMP/import-check.mjs" <<'MJS'
 import { SCHEMA_VERSION, validateUsageSnapshot } from '@token-weather/schemas';
 import * as adapters from '@token-weather/provider-adapters';
 import * as cli from '@token-weather/cli';
+import * as telegram from '@token-weather/telegram';
 
 const failures = [];
 if (typeof SCHEMA_VERSION !== 'string') {
@@ -111,6 +112,9 @@ if (typeof adapters !== 'object' || adapters === null || Object.keys(adapters).l
 if (typeof cli !== 'object' || cli === null || Object.keys(cli).length === 0) {
   failures.push('@token-weather/cli resolved but exports look empty');
 }
+if (typeof telegram.runTelegramCommand !== 'function') {
+  failures.push(`@token-weather/telegram runTelegramCommand expected function, got ${typeof telegram.runTelegramCommand}`);
+}
 if (failures.length > 0) {
   for (const f of failures) console.error('❌', f);
   process.exit(1);
@@ -118,7 +122,7 @@ if (failures.length > 0) {
 MJS
 
 HOME="$TMP_HOME" NO_COLOR=1 node "$TMP/import-check.mjs"
-echo "  ✓ 3 패키지 ESM root import OK"
+echo "  ✓ 4 패키지 ESM root import OK"
 
 echo ""
 echo "✓ install smoke passed"


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan 의 첫 PR (Phase 1). 신규 워크스페이스 패키지 `@token-weather/telegram` 을 scaffolding 하고, config / redaction 인프라를 미리 깔아 후속 phase 의 코어 작업 진입을 단순화. 외부 동작 변화는 없고 redaction 표면만 확장.

## 변경 내용

### 신규 워크스페이스 패키지 `packages/telegram/`
- `package.json` — 라이브러리 형태 (bin 없음), `type: "module"`, deps `grammy ^1.42.0` + `@token-weather/schemas ^0.4.0` + `@token-weather/provider-adapters ^0.4.0`.
- `tsconfig.json` — `../../tsconfig.base.json` extend, schemas 패턴 추종.
- `src/index.js` — placeholder `runTelegramCommand` export. Phase 3 머지 시 실 dispatch 채워짐.
- `test/scaffold.test.js` — import 성공 + Phase 1 NotImplemented 던짐 단언.

### 기존 패키지 수정 (`@token-weather/cli`)
- `packages/agent/src/config/default-config.js` — `providers.telegram = { enabled: false, botToken: '', allowedChatIds: [] }` 추가 (codex/claude 동급, opt-out 기본).
- `packages/agent/src/cli/status-json.js` — `SENSITIVE_KEYS` 에 `botToken` / `bot_token` / `telegramBotToken` 3개 추가.
- `packages/agent/test/cli/status-json.test.js` — redaction 회귀 가드 2건 (등록 확인 + 동작 단언).

### 저장소
- `package.json` (root) — `scripts.test` 에 `packages/telegram/test/**/*.test.js` 추가, `test:telegram` 신규, `build:types` 체인에 `-w @token-weather/telegram` 추가.
- `.changeset/config.json` — `linked` 배열에 `@token-weather/telegram` 포함.
- `.changeset/telegram-package-scaffold.md` — 4 패키지 모두 minor.

## 변경 이유

5-phase plan 의 첫 단계로, 신규 패키지의 인프라 (워크스페이스 / config 키 / redaction) 를 후속 phase 의 봇 코어 / 핸들러 작업과 분리한다. 단일 PR 의 표면이 좁아지고, redaction 같은 보안 요소가 코어 코드보다 먼저 들어가 후속 작업의 보안 가드가 항상 동작하는 상태를 유지.

## 영향 범위

- [x] `packages/agent` — config.providers.telegram 키, SENSITIVE_KEYS 확장, redaction 가드.
- [ ] `packages/schemas` — 변경 없음 (SCHEMA_VERSION 무변경).
- [ ] `packages/provider-adapters` — 변경 없음.
- [x] `packages/telegram` (신규).
- [x] `repo` — root package.json scripts, .changeset/config.json linked.
- [ ] `docs` — Phase 5 에서 일괄 갱신.

## 테스트 / 확인

- `npm test` — 857 tests 통과 (기존 651 + telegram scaffold 2 + agent redaction 가드 2 + 기타 신규 / linked 카운트).
- `npm run lint` 통과.
- `npm run format:check` 통과.
- `npm run build:types` 통과 (4 패키지 d.ts 생성).
- `npx changeset status` — 4 패키지 모두 minor 인식 (linked 정합).

## 리뷰 포인트

1. **linked 배열 확장 정책** — v0.x 단순성 우선으로 신규 패키지를 기존 3 패키지와 linked. 안정성 평가 후 빼는 결정은 후속 (out of scope).
2. **SENSITIVE_KEYS 확장 분류** — `botToken` 은 generic API key/password 아래 신규 카테고리로 분리, 향후 telegram 외 채널 토큰 추가 시 동일 카테고리에 합류 의도.
3. **placeholder NotImplemented 동작** — Phase 3 머지 전까지 `runTelegramCommand` 호출 시 명시적 오류. `run-cli` 의 telegram 분기는 Phase 3 에서 추가되므로 사용자에게는 노출되지 않음.
4. **Phase 4 `setup` 명령이 chmod 600 을 적용하므로**, 현재 default-config 에 빈 botToken 이 들어가는 것은 의도된 상태 (사용자가 setup 전까지 활성화 불가).

## 참고 사항

- Closes #126 (한 부분, 나머지는 후속 Phase 2~5).
- bump: minor (linked 정책 — 4 패키지 모두 v0.4.0 → v0.5.0 진입 예정, 5-phase plan 완료 시점에 누적 publish).
- 후속 PR: Phase 2 (#127) — 봇 코어 (long-poll / router / allowlist / formatter).