### PR TITLE
[feat] telegram bot 통합 (2/5) — long-poll 루프 + 명령 라우터 + user_id allowlist + Telegram formatter

### DIFF
--- a/.changeset/telegram-bot-core.md
+++ b/.changeset/telegram-bot-core.md
@@ -16,30 +16,44 @@ daemon lifecycle 과 미들웨어 / 출력 가공 helpers 를 채운다. 명령 
 본 release 의 `@token-weather/telegram` 은 아직 **end-user 가 단독 사용할 수 없는
 상태** 이다. `runTelegramCommand` 는 여전히 Phase 1 placeholder 라 `token-weather
 telegram` 명령은 Phase 3 머지 후 활성화. 다만 Phase 2 에서 공개되는 helpers
-(`createBotServer` / `parseCommand` / `authAllowlistMiddleware` / `wrapPre` 등) 는
-외부 사용자가 직접 import 해 자체 봇을 띄울 수 있는 **부분적 API** 가 된다.
+(`createBotServer` / `parseCommand` / `authAllowlistMiddleware` 등) 는 외부 사용자가
+직접 import 해 자체 봇을 띄울 수 있는 **부분적 API** 가 된다.
 
 **신규 public export** (`@token-weather/telegram`):
 
-- `createBotServer({ botToken, allowedChatIds, dispatcher, logger }) → { start, stop, bot }`
+- `createBotServer({ botToken, allowedUserIds, dispatcher, logger, botFactory? }) → { start, stop, bot }`
   — grammy `Bot` 인스턴스 + token-weather 미들웨어 + 라우팅을 묶은 factory.
-  `start()` 는 fire-and-forget polling 시작, 409 Conflict (단일 인스턴스 lock 위반)
-  시 친절한 메시지 + `process.exitCode = 1`.
-- `startBot(config)` / `stopBot()` — process 단일 인스턴스 lock 보강 래퍼.
-- `parseCommand(text)` — slash 명령 파싱 + `/cmd@MyBot` mention strip + lowercase
-  정규화. non-command 입력 모두 null.
+  `start()` 는 boot 단계 (`bot.init()` 으로 token validation) 만 await 하고
+  polling 은 fire-and-forget — boot 실패 시 lock 해제 + throw (재시도 가능).
+  `botFactory` 옵션으로 테스트 mock 주입 가능 (PR #133 review).
+- `startBot(config)` / `stopBot()` — process 단일 인스턴스 lock 보강. boot 실패
+  시 `_activeServer` 미점유 → 재시도 가능 (PR #133 review).
+- `parseCommand(text, { botUsername }?)` — slash 명령 파싱 + mention filtering.
+  `/cmd@OtherBot` 처럼 다른 봇 mention 은 null 반환 (group chat 명령 충돌
+  방지, PR #133 review). botUsername 미지정 시 기존 동작.
 - `listAvailableCommands(dispatcher)` — dispatcher 의 키를 `/cmd` 형식으로 정렬해
   안내 문구 직렬화.
-- `authAllowlistMiddleware(allowedChatIds, opts?)` — `ctx.from.id` 가 allowlist 에
-  없으면 silent ignore (응답 X, 로그만 부분 마스킹). 봇 토큰 누설 시 1차 방어막.
-- `maskChatId(id)` — 4 자 이하 전체 / 5+ 자 부분 마스킹 (`123****90`).
+- `authAllowlistMiddleware(allowedUserIds, opts?)` — `ctx.from.id` 가 allowlist 에
+  없으면 silent ignore. "허용된 사용자" 보안 모델 — DM / group / supergroup
+  어디서든 동일 사용자가 명령 가능 (PR #133 review).
+- `maskUserId(id)` — 4 자 이하 전체 / 5+ 자 부분 마스킹 (`123****90`).
 - `stripAnsi(text)` — ANSI CSI sequence 제거. `eslint no-control-regex` lint-safe
   하게 `String.fromCharCode(0x1b)` + `RegExp` 생성자 사용.
 - `wrapPre(text)` — Telegram HTML 모드 `<pre>` wrap + `< > &` escape.
-- `splitForTelegram(text, limit=4000)` — 4096 자 한도 + tag overhead 안전 마진.
-  줄 단위 split, 한 줄이 limit 초과 시 글자 단위 강제 분할.
+- `splitForTelegram(text, limit=4000)` — **raw text 길이 기준** 줄 단위 split.
+  escape entity expansion 영향 없는 plain text 분할용.
+- `formatPreChunksForTelegram(rawText, limit=4000)` — **escape 후 + `<pre>` tag
+  포함 길이 기준** chunking. HTML escape entity expansion (`&` → `&amp;`) 으로
+  Telegram 4096 자 한도 초과 가능성을 차단 (PR #133 review).
 - `formatErrorForTelegram(err)` — name + message 만 노출 (stack 제외) + HTML
   escape — XSS 방지 + 정보 노출 최소화.
+
+**기존 패키지 변경** (`@token-weather/cli`):
+
+- `config.channels.telegram.allowedChatIds` → `allowedUserIds` rename (PR #133
+  review — `ctx.from.id` 기준 보안 모델 정합). Phase 1 의 release note (
+  `.changeset/telegram-package-scaffold.md`) 도 함께 정정.
+- SENSITIVE_KEYS redaction fixture 의 키 이름 동기 갱신.
 
 **의존성 정책** (PR #131 review 정합):
 

--- a/.changeset/telegram-bot-core.md
+++ b/.changeset/telegram-bot-core.md
@@ -1,0 +1,51 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): grammy 기반 봇 코어 — long-poll daemon / 명령 라우터 / allowlist / formatter (issue #127).
+
+5-phase Telegram 봇 통합 plan 의 Phase 2. Phase 1 의 scaffold 위에 실제 long-poll
+daemon lifecycle 과 미들웨어 / 출력 가공 helpers 를 채운다. 명령 핸들러 / `run-cli`
+연결은 Phase 3 (#128).
+
+**중요 — Phase 2 publish 성격**:
+
+본 release 의 `@token-weather/telegram` 은 아직 **end-user 가 단독 사용할 수 없는
+상태** 이다. `runTelegramCommand` 는 여전히 Phase 1 placeholder 라 `token-weather
+telegram` 명령은 Phase 3 머지 후 활성화. 다만 Phase 2 에서 공개되는 helpers
+(`createBotServer` / `parseCommand` / `authAllowlistMiddleware` / `wrapPre` 등) 는
+외부 사용자가 직접 import 해 자체 봇을 띄울 수 있는 **부분적 API** 가 된다.
+
+**신규 public export** (`@token-weather/telegram`):
+
+- `createBotServer({ botToken, allowedChatIds, dispatcher, logger }) → { start, stop, bot }`
+  — grammy `Bot` 인스턴스 + token-weather 미들웨어 + 라우팅을 묶은 factory.
+  `start()` 는 fire-and-forget polling 시작, 409 Conflict (단일 인스턴스 lock 위반)
+  시 친절한 메시지 + `process.exitCode = 1`.
+- `startBot(config)` / `stopBot()` — process 단일 인스턴스 lock 보강 래퍼.
+- `parseCommand(text)` — slash 명령 파싱 + `/cmd@MyBot` mention strip + lowercase
+  정규화. non-command 입력 모두 null.
+- `listAvailableCommands(dispatcher)` — dispatcher 의 키를 `/cmd` 형식으로 정렬해
+  안내 문구 직렬화.
+- `authAllowlistMiddleware(allowedChatIds, opts?)` — `ctx.from.id` 가 allowlist 에
+  없으면 silent ignore (응답 X, 로그만 부분 마스킹). 봇 토큰 누설 시 1차 방어막.
+- `maskChatId(id)` — 4 자 이하 전체 / 5+ 자 부분 마스킹 (`123****90`).
+- `stripAnsi(text)` — ANSI CSI sequence 제거. `eslint no-control-regex` lint-safe
+  하게 `String.fromCharCode(0x1b)` + `RegExp` 생성자 사용.
+- `wrapPre(text)` — Telegram HTML 모드 `<pre>` wrap + `< > &` escape.
+- `splitForTelegram(text, limit=4000)` — 4096 자 한도 + tag overhead 안전 마진.
+  줄 단위 split, 한 줄이 limit 초과 시 글자 단위 강제 분할.
+- `formatErrorForTelegram(err)` — name + message 만 노출 (stack 제외) + HTML
+  escape — XSS 방지 + 정보 노출 최소화.
+
+**의존성 정책** (PR #131 review 정합):
+
+본 패키지는 `@token-weather/cli` 를 import 하지 않는다. `runTelegramCommand` 의
+`deps` 매개변수 + `createBotServer` 의 `dispatcher` 매개변수가 CLI 가 주입하는
+core 함수의 통로 — 순환 의존 회피.
+
+**SCHEMA_VERSION** 무변경. **Migration** 없음 — 외부 사용자가 본 API 를 아직
+공식 의존하지 않는다는 전제 (NotImplemented 라벨링 유지).

--- a/.changeset/telegram-bot-core.md
+++ b/.changeset/telegram-bot-core.md
@@ -31,6 +31,11 @@ telegram` 명령은 Phase 3 머지 후 활성화. 다만 Phase 2 에서 공개�
 - `parseCommand(text, { botUsername }?)` — slash 명령 파싱 + mention filtering.
   `/cmd@OtherBot` 처럼 다른 봇 mention 은 null 반환 (group chat 명령 충돌
   방지, PR #133 review). botUsername 미지정 시 기존 동작.
+- `extractMention(text)` — `/cmd@mention` 의 username 부분 반환. bot-server 의
+  silent ignore 경로에서 사용 (PR #133 추가 review).
+- `handleTextMessage(ctx, { dispatcher })` — `message:text` 처리 helper.
+  다른 봇 mention 은 silent return (reply 도 보내지 않음 — group chat 의 다른
+  봇 명령에 token-weather 가 응답하지 않도록, PR #133 추가 review).
 - `listAvailableCommands(dispatcher)` — dispatcher 의 키를 `/cmd` 형식으로 정렬해
   안내 문구 직렬화.
 - `authAllowlistMiddleware(allowedUserIds, opts?)` — `ctx.from.id` 가 allowlist 에

--- a/.changeset/telegram-package-scaffold.md
+++ b/.changeset/telegram-package-scaffold.md
@@ -31,11 +31,13 @@ release 부터. package.json description 에 "Phase 1 scaffold" 라벨링.
 
 **기존 패키지 변경** (`@token-weather/cli`):
 
-- `config.channels.telegram = { enabled: false, botToken: '', allowedChatIds: [] }`
+- `config.channels.telegram = { enabled: false, botToken: '', allowedUserIds: [] }`
   신규. `providers` (usage 조회 대상 — codex / claude) 와 의도적으로 분리 —
   PROVIDER_REGISTRY / `--provider` 필터 / `status --json providers[]` / `authSource`
   / `usageSnapshots` 가 모두 usage provider 의미에 묶여 있어, Telegram 같은
-  transport / channel 은 별도 네임스페이스 (PR #131 review 반영).
+  transport / channel 은 별도 네임스페이스 (PR #131 review 반영). `allowedUserIds`
+  는 `ctx.from.id` 기준 — DM / group 어디서든 동일 사용자 명령 가능 (PR #133
+  review 반영).
 - `SENSITIVE_KEYS` 확장: `botToken` / `bot_token` / `telegramBotToken` —
   Phase 2 이후 raw 영역에 흘러갈 가능성 대비 redaction 가드 선 등록.
 - redaction 회귀 테스트 2건 신설 (`channels.telegram` 경로 fixture).

--- a/packages/agent/src/config/default-config.js
+++ b/packages/agent/src/config/default-config.js
@@ -32,13 +32,14 @@ export const DEFAULT_AGENT_CONFIG = {
      * `token-weather telegram setup` 명령이 자동 갱신한다 (Phase 4).
      *
      *   - botToken: BotFather 가 발급한 토큰. SENSITIVE_KEYS 로 redact 됨.
-     *   - allowedChatIds: 명령 수신을 허용할 Telegram user_id 배열 (단일
-     *     사용자여도 array 형태 유지 — 추후 가족 / 멀티 디바이스 확장 여지).
+     *   - allowedUserIds: 명령 수신을 허용할 Telegram user_id 배열 (ctx.from.id
+     *     기준 — group chat / supergroup / DM 어디서든 동일 사용자가 명령 가능).
+     *     단일 사용자여도 array 형태 유지 — 추후 가족 / 멀티 디바이스 확장 여지.
      */
     telegram: {
       enabled: false,
       botToken: '',
-      allowedChatIds: [],
+      allowedUserIds: [],
     },
   },
   /**

--- a/packages/agent/test/cli/status-json.test.js
+++ b/packages/agent/test/cli/status-json.test.js
@@ -214,7 +214,7 @@ describe('redactSensitive — objects', () => {
           botToken: '1234567890:ABCDEF',
           bot_token: '1234567890:GHIJKL',
           telegramBotToken: '1234567890:MNOPQR',
-          allowedChatIds: [42],
+          allowedUserIds: [42],
         },
       },
     });
@@ -222,7 +222,7 @@ describe('redactSensitive — objects', () => {
       channels: {
         telegram: {
           enabled: true,
-          allowedChatIds: [42],
+          allowedUserIds: [42],
         },
       },
     });

--- a/packages/telegram/src/auth-allowlist.js
+++ b/packages/telegram/src/auth-allowlist.js
@@ -1,10 +1,15 @@
 /**
- * Telegram update 의 `ctx.from.id` (Telegram user id) 를 allowlist 와 대조해
+ * Telegram update 의 `ctx.from.id` (Telegram user_id) 를 allowlist 와 대조해
  * 미허용 발신자의 메시지를 silent 하게 거부하는 grammy 미들웨어.
+ *
+ * "허용된 사용자" 보안 모델 — `chat.id` 가 아니라 `from.id` 를 검사한다.
+ * DM 에서는 둘이 같지만, group / supergroup 에서는 다르며 본 모듈은 "이
+ * 사용자가 보낸 명령인가" 를 기준으로 한다. 단일 사용자가 자기 user_id 를
+ * allowlist 에 등록하면 어떤 채팅방에서도 동일하게 명령 가능.
  *
  * "silent" 인 이유: 미등록자가 봇에게 명령을 시도했을 때 응답하지 않음으로써
  * 봇의 존재 / 동작 여부를 외부에 minimal 노출한다. 봇 토큰이 누설된 시점의
- * 1차 방어막 역할. 로그에는 chat_id 부분 마스킹으로 흔적만 남긴다.
+ * 1차 방어막. 로그에는 user_id 부분 마스킹으로 흔적만 남긴다.
  *
  * Phase 4 (#129) 의 setup 명령이 일시적으로 빈 allowlist 로 daemon 을 띄울 때는
  * 본 미들웨어가 모든 메시지를 거부하지만, setup flow 자체가 `bot.use` 가
@@ -13,18 +18,18 @@
  */
 
 /**
- * @param {Array<number|string> | undefined | null} allowedChatIds
+ * @param {Array<number|string> | undefined | null} allowedUserIds
  * @param {{ logger?: { log?: (msg: string) => void } }} [options]
  * @returns {(ctx: object, next: () => Promise<void>) => Promise<void>}
  */
-export function authAllowlistMiddleware(allowedChatIds, options) {
-  const allowed = new Set((allowedChatIds ?? []).map((id) => String(id)));
+export function authAllowlistMiddleware(allowedUserIds, options) {
+  const allowed = new Set((allowedUserIds ?? []).map((id) => String(id)));
   const log = options?.logger?.log ?? ((msg) => console.log(msg));
   return async (ctx, next) => {
     const fromId = ctx?.from?.id != null ? String(ctx.from.id) : null;
     if (!fromId || !allowed.has(fromId)) {
       if (fromId) {
-        log(`[token-weather/telegram] 미허용 chat_id 거부: ${maskChatId(fromId)}`);
+        log(`[token-weather/telegram] 미허용 user_id 거부: ${maskUserId(fromId)}`);
       }
       return;
     }
@@ -33,14 +38,14 @@ export function authAllowlistMiddleware(allowedChatIds, options) {
 }
 
 /**
- * chat_id 의 앞 3 자 / 뒤 2 자만 남기고 가운데를 마스킹. 4 자 이하 id 는 전체
- * 마스킹. 단일 사용자 환경에서도 로그 / 디버깅 시점에 raw id 가 그대로 평문에
- * 남지 않도록 보호.
+ * Telegram user_id 의 앞 3 자 / 뒤 2 자만 남기고 가운데를 마스킹. 4 자 이하 id 는
+ * 전체 마스킹. 단일 사용자 환경에서도 로그 / 디버깅 시점에 raw id 가 그대로
+ * 평문에 남지 않도록 보호.
  *
  * @param {string|number} id
  * @returns {string}
  */
-export function maskChatId(id) {
+export function maskUserId(id) {
   const s = String(id);
   if (s.length <= 4) return '****';
   return `${s.slice(0, 3)}****${s.slice(-2)}`;

--- a/packages/telegram/src/auth-allowlist.js
+++ b/packages/telegram/src/auth-allowlist.js
@@ -1,0 +1,47 @@
+/**
+ * Telegram update 의 `ctx.from.id` (Telegram user id) 를 allowlist 와 대조해
+ * 미허용 발신자의 메시지를 silent 하게 거부하는 grammy 미들웨어.
+ *
+ * "silent" 인 이유: 미등록자가 봇에게 명령을 시도했을 때 응답하지 않음으로써
+ * 봇의 존재 / 동작 여부를 외부에 minimal 노출한다. 봇 토큰이 누설된 시점의
+ * 1차 방어막 역할. 로그에는 chat_id 부분 마스킹으로 흔적만 남긴다.
+ *
+ * Phase 4 (#129) 의 setup 명령이 일시적으로 빈 allowlist 로 daemon 을 띄울 때는
+ * 본 미들웨어가 모든 메시지를 거부하지만, setup flow 자체가 `bot.use` 가
+ * 등록되기 전 단계에서 `/pair <code>` 메시지를 직접 listen 하는 패턴을 쓸
+ * 예정이라 (Phase 4 에서 상세) 충돌 없음.
+ */
+
+/**
+ * @param {Array<number|string> | undefined | null} allowedChatIds
+ * @param {{ logger?: { log?: (msg: string) => void } }} [options]
+ * @returns {(ctx: object, next: () => Promise<void>) => Promise<void>}
+ */
+export function authAllowlistMiddleware(allowedChatIds, options) {
+  const allowed = new Set((allowedChatIds ?? []).map((id) => String(id)));
+  const log = options?.logger?.log ?? ((msg) => console.log(msg));
+  return async (ctx, next) => {
+    const fromId = ctx?.from?.id != null ? String(ctx.from.id) : null;
+    if (!fromId || !allowed.has(fromId)) {
+      if (fromId) {
+        log(`[token-weather/telegram] 미허용 chat_id 거부: ${maskChatId(fromId)}`);
+      }
+      return;
+    }
+    await next();
+  };
+}
+
+/**
+ * chat_id 의 앞 3 자 / 뒤 2 자만 남기고 가운데를 마스킹. 4 자 이하 id 는 전체
+ * 마스킹. 단일 사용자 환경에서도 로그 / 디버깅 시점에 raw id 가 그대로 평문에
+ * 남지 않도록 보호.
+ *
+ * @param {string|number} id
+ * @returns {string}
+ */
+export function maskChatId(id) {
+  const s = String(id);
+  if (s.length <= 4) return '****';
+  return `${s.slice(0, 3)}****${s.slice(-2)}`;
+}

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -20,7 +20,7 @@
 import { Bot, GrammyError } from 'grammy';
 
 import { authAllowlistMiddleware } from './auth-allowlist.js';
-import { parseCommand, listAvailableCommands } from './command-router.js';
+import { parseCommand, extractMention, listAvailableCommands } from './command-router.js';
 import { formatErrorForTelegram } from './formatters.js';
 
 /**
@@ -62,23 +62,7 @@ export function createBotServer(options) {
   bot.use(authAllowlistMiddleware(allowedUserIds, { logger: { log } }));
 
   bot.on('message:text', async (ctx) => {
-    // ctx.me.username — grammy 가 bot.init 후 자동 채움. group chat 에서
-    // /cmd@OtherBot 같이 다른 봇 mention 은 parseCommand 가 null 반환 → silent.
-    const parsed = parseCommand(ctx.message.text, {
-      botUsername: ctx.me?.username,
-    });
-    if (!parsed) {
-      await ctx.reply(
-        `알 수 없는 입력입니다. 사용 가능한 명령: ${listAvailableCommands(dispatcher)}`,
-      );
-      return;
-    }
-    const handler = dispatcher?.[parsed.cmd];
-    if (!handler) {
-      await ctx.reply(`아직 구현되지 않은 명령입니다: /${parsed.cmd} (Phase 3 머지 후 활성화)`);
-      return;
-    }
-    await handler(ctx, parsed.args);
+    await handleTextMessage(ctx, { dispatcher });
   });
 
   bot.catch((errCtx) => {
@@ -147,6 +131,46 @@ export function createBotServer(options) {
       started = false;
     },
   };
+}
+
+/**
+ * `message:text` 처리 핸들러 — group chat 의 다른 봇 mention 을 silent ignore
+ * 한 뒤 dispatcher 로 라우팅한다. createBotServer 가 grammy bot.on 안에서
+ * 호출하며, 단위 테스트 친화를 위해 별도 export.
+ *
+ * 책임 분리 (PR #133 review):
+ *   1) raw text 의 mention 이 본인이 아니면 silent return — "알 수 없는 입력"
+ *      reply 도 보내지 않음 (group chat 의 다른 봇 명령에 token-weather 가
+ *      응답하지 않도록).
+ *   2) 그 외는 parseCommand → dispatcher 호출. mention 분기는 parseCommand 의
+ *      botUsername 옵션과도 중복 검사이지만, bot-server 가 명시적으로 silent
+ *      vs reply 경로를 가르는 것이 의도.
+ *
+ * @param {object} ctx - grammy Context.
+ * @param {{ dispatcher?: Record<string, Function> }} options
+ * @returns {Promise<void>}
+ */
+export async function handleTextMessage(ctx, options) {
+  const text = ctx?.message?.text;
+  const myUsername = ctx?.me?.username;
+  const mention = extractMention(text);
+  if (mention && myUsername && mention.toLowerCase() !== myUsername.toLowerCase()) {
+    // 다른 봇 mention — silent (reply 도 보내지 않음).
+    return;
+  }
+  const parsed = parseCommand(text, { botUsername: myUsername });
+  if (!parsed) {
+    await ctx.reply(
+      `알 수 없는 입력입니다. 사용 가능한 명령: ${listAvailableCommands(options?.dispatcher)}`,
+    );
+    return;
+  }
+  const handler = options?.dispatcher?.[parsed.cmd];
+  if (!handler) {
+    await ctx.reply(`아직 구현되지 않은 명령입니다: /${parsed.cmd} (Phase 3 머지 후 활성화)`);
+    return;
+  }
+  await handler(ctx, parsed.args);
 }
 
 /**

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -32,6 +32,8 @@ import { formatErrorForTelegram } from './formatters.js';
  *   "구현 예정" placeholder 응답.
  * @property {{ log?: (msg: string) => void, error?: (msg: string) => void }} [logger]
  *   stdout/stderr 로그를 가로채기 위한 hook. 테스트에서 주입.
+ * @property {(token: string) => object} [botFactory] - grammy `Bot` 생성을 가로채는
+ *   훅. 기본은 `new Bot(token)` — 테스트에서 mock 주입 시점.
  */
 
 /**
@@ -48,14 +50,14 @@ import { formatErrorForTelegram } from './formatters.js';
  * @returns {BotServer}
  */
 export function createBotServer(options) {
-  const { botToken, allowedUserIds, dispatcher, logger } = options ?? {};
+  const { botToken, allowedUserIds, dispatcher, logger, botFactory } = options ?? {};
   if (!botToken || typeof botToken !== 'string') {
     throw new Error('createBotServer: botToken (string) is required');
   }
   const log = logger?.log ?? ((msg) => console.log(msg));
   const errorLog = logger?.error ?? ((msg) => console.error(msg));
 
-  const bot = new Bot(botToken);
+  const bot = botFactory ? botFactory(botToken) : new Bot(botToken);
 
   bot.use(authAllowlistMiddleware(allowedUserIds, { logger: { log } }));
 
@@ -104,13 +106,22 @@ export function createBotServer(options) {
         throw new Error('createBotServer.start: already started');
       }
       started = true;
+      // Boot validation — grammy bot.init 이 getMe 호출로 token 유효성 검사.
+      // 실패하면 lock 해제 + throw (PR #133 review 반영 — startBot 의 active
+      // lock 잔존 방지). 정상 시 ctx.me.username 이 채워져 mention filter 동작.
+      try {
+        await bot.init();
+      } catch (err) {
+        started = false;
+        throw err;
+      }
       if (!shutdownHandlersRegistered) {
         registerShutdownHandlers(bot);
         shutdownHandlersRegistered = true;
       }
       // bot.start 는 polling 루프라 normal flow 에서 resolve 되지 않음 —
-      // fire-and-forget 으로 띄우고, 시작 단계의 에러 (token 오류 / 409 등) 는
-      // .catch 로 받는다.
+      // fire-and-forget. polling 단계 실패 (409 conflict 등) 는 .catch 로 받아
+      // daemon 종료 처리 (lock 은 그대로 — process exit 으로 정리됨).
       bot
         .start({
           drop_pending_updates: false,

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -60,7 +60,11 @@ export function createBotServer(options) {
   bot.use(authAllowlistMiddleware(allowedUserIds, { logger: { log } }));
 
   bot.on('message:text', async (ctx) => {
-    const parsed = parseCommand(ctx.message.text);
+    // ctx.me.username — grammy 가 bot.init 후 자동 채움. group chat 에서
+    // /cmd@OtherBot 같이 다른 봇 mention 은 parseCommand 가 null 반환 → silent.
+    const parsed = parseCommand(ctx.message.text, {
+      botUsername: ctx.me?.username,
+    });
     if (!parsed) {
       await ctx.reply(
         `알 수 없는 입력입니다. 사용 가능한 명령: ${listAvailableCommands(dispatcher)}`,

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -26,7 +26,7 @@ import { formatErrorForTelegram } from './formatters.js';
 /**
  * @typedef {object} BotServerOptions
  * @property {string} botToken - BotFather 가 발급한 토큰.
- * @property {Array<number|string>} allowedChatIds - 명령 수신을 허용할 user_id.
+ * @property {Array<number|string>} allowedUserIds - 명령 수신을 허용할 user_id.
  * @property {Record<string, (ctx: object, args: string[]) => Promise<void>>} [dispatcher]
  *   명령 이름 → 핸들러 mapping. Phase 3 (#128) 에서 채워짐. 비어 있으면 모든 명령에
  *   "구현 예정" placeholder 응답.
@@ -48,7 +48,7 @@ import { formatErrorForTelegram } from './formatters.js';
  * @returns {BotServer}
  */
 export function createBotServer(options) {
-  const { botToken, allowedChatIds, dispatcher, logger } = options ?? {};
+  const { botToken, allowedUserIds, dispatcher, logger } = options ?? {};
   if (!botToken || typeof botToken !== 'string') {
     throw new Error('createBotServer: botToken (string) is required');
   }
@@ -57,7 +57,7 @@ export function createBotServer(options) {
 
   const bot = new Bot(botToken);
 
-  bot.use(authAllowlistMiddleware(allowedChatIds, { logger: { log } }));
+  bot.use(authAllowlistMiddleware(allowedUserIds, { logger: { log } }));
 
   bot.on('message:text', async (ctx) => {
     const parsed = parseCommand(ctx.message.text);

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -1,0 +1,149 @@
+/**
+ * Telegram 봇 long-poll daemon 의 lifecycle factory.
+ *
+ * grammy `Bot` 인스턴스를 생성하고 token-weather 의 미들웨어 (auth allowlist) +
+ * 라우팅 (command router → dispatcher) 를 연결한다. 실제 명령 핸들러 (status /
+ * usage / doctor / auth-list) 는 Phase 3 (#128) 의 dispatcher 가 채운다.
+ *
+ * 본 모듈은 다음 책임만 진다:
+ *   - grammy Bot 생성 + 미들웨어 체인 구성
+ *   - message:text → parseCommand → dispatcher 라우팅
+ *   - 단일-인스턴스 lock 보강 (409 Conflict 감지 시 친절한 종료)
+ *   - SIGINT / SIGTERM 핸들러 등록 → graceful bot.stop()
+ *
+ * `@token-weather/cli` 의 `run-cli` 가 본 패키지를 dynamic import 한다는 점에서
+ * 본 모듈은 절대 `@token-weather/cli` 를 import 해서는 안 된다 (순환 의존 회피
+ * — PR #131 review 정책). 명령 핸들러가 필요로 하는 core 함수 (status snapshot /
+ * formatters / config loader) 는 dispatcher 의 closure 가 통해서만 들어온다.
+ */
+
+import { Bot, GrammyError } from 'grammy';
+
+import { authAllowlistMiddleware } from './auth-allowlist.js';
+import { parseCommand, listAvailableCommands } from './command-router.js';
+import { formatErrorForTelegram } from './formatters.js';
+
+/**
+ * @typedef {object} BotServerOptions
+ * @property {string} botToken - BotFather 가 발급한 토큰.
+ * @property {Array<number|string>} allowedChatIds - 명령 수신을 허용할 user_id.
+ * @property {Record<string, (ctx: object, args: string[]) => Promise<void>>} [dispatcher]
+ *   명령 이름 → 핸들러 mapping. Phase 3 (#128) 에서 채워짐. 비어 있으면 모든 명령에
+ *   "구현 예정" placeholder 응답.
+ * @property {{ log?: (msg: string) => void, error?: (msg: string) => void }} [logger]
+ *   stdout/stderr 로그를 가로채기 위한 hook. 테스트에서 주입.
+ */
+
+/**
+ * @typedef {object} BotServer
+ * @property {() => Promise<void>} start - long-poll 시작 (fire-and-forget).
+ * @property {() => Promise<void>} stop - graceful 종료.
+ * @property {object} bot - 내부 grammy Bot 인스턴스 (테스트 / 확장 용).
+ */
+
+/**
+ * grammy 기반 봇 서버를 구성해 반환한다. start() 를 호출해야 polling 시작.
+ *
+ * @param {BotServerOptions} options
+ * @returns {BotServer}
+ */
+export function createBotServer(options) {
+  const { botToken, allowedChatIds, dispatcher, logger } = options ?? {};
+  if (!botToken || typeof botToken !== 'string') {
+    throw new Error('createBotServer: botToken (string) is required');
+  }
+  const log = logger?.log ?? ((msg) => console.log(msg));
+  const errorLog = logger?.error ?? ((msg) => console.error(msg));
+
+  const bot = new Bot(botToken);
+
+  bot.use(authAllowlistMiddleware(allowedChatIds, { logger: { log } }));
+
+  bot.on('message:text', async (ctx) => {
+    const parsed = parseCommand(ctx.message.text);
+    if (!parsed) {
+      await ctx.reply(
+        `알 수 없는 입력입니다. 사용 가능한 명령: ${listAvailableCommands(dispatcher)}`,
+      );
+      return;
+    }
+    const handler = dispatcher?.[parsed.cmd];
+    if (!handler) {
+      await ctx.reply(`아직 구현되지 않은 명령입니다: /${parsed.cmd} (Phase 3 머지 후 활성화)`);
+      return;
+    }
+    await handler(ctx, parsed.args);
+  });
+
+  bot.catch((errCtx) => {
+    const err = errCtx.error;
+    if (err instanceof GrammyError && err.error_code === 409) {
+      errorLog(
+        '[token-weather/telegram] 다른 daemon 이 이미 같은 봇 토큰으로 polling 중입니다 (Conflict 409). 종료합니다.',
+      );
+      process.exitCode = 1;
+      void bot.stop();
+      return;
+    }
+    errorLog(`[token-weather/telegram] 메시지 처리 중 오류: ${err?.message ?? String(err)}`);
+    // 사용자에게는 stack 노출 없이 간결한 메시지만.
+    void errCtx.ctx?.reply?.(formatErrorForTelegram(err), { parse_mode: 'HTML' }).catch(() => {});
+  });
+
+  let started = false;
+  let shutdownHandlersRegistered = false;
+
+  return {
+    bot,
+    async start() {
+      if (started) {
+        throw new Error('createBotServer.start: already started');
+      }
+      started = true;
+      if (!shutdownHandlersRegistered) {
+        registerShutdownHandlers(bot);
+        shutdownHandlersRegistered = true;
+      }
+      // bot.start 는 polling 루프라 normal flow 에서 resolve 되지 않음 —
+      // fire-and-forget 으로 띄우고, 시작 단계의 에러 (token 오류 / 409 등) 는
+      // .catch 로 받는다.
+      bot
+        .start({
+          drop_pending_updates: false,
+          onStart: (info) => {
+            log(`[token-weather/telegram] @${info.username} polling 시작`);
+          },
+        })
+        .catch((err) => {
+          if (err instanceof GrammyError && err.error_code === 409) {
+            errorLog(
+              '[token-weather/telegram] 다른 daemon 이 이미 같은 봇 토큰으로 polling 중입니다 (Conflict 409). 종료합니다.',
+            );
+            process.exitCode = 1;
+            return;
+          }
+          errorLog(`[token-weather/telegram] polling 시작 실패: ${err?.message ?? String(err)}`);
+          process.exitCode = 1;
+        });
+    },
+    async stop() {
+      if (!started) return;
+      await bot.stop();
+      started = false;
+    },
+  };
+}
+
+/**
+ * SIGINT / SIGTERM 발생 시 bot.stop() 을 호출해 long-poll 을 graceful 종료한다.
+ * once 로 등록 — 동일 시그널 재진입은 OS 의 기본 핸들러로 fall through.
+ *
+ * @param {object} bot - grammy Bot 인스턴스.
+ */
+export function registerShutdownHandlers(bot) {
+  const handler = () => {
+    void bot.stop();
+  };
+  process.once('SIGINT', handler);
+  process.once('SIGTERM', handler);
+}

--- a/packages/telegram/src/command-router.js
+++ b/packages/telegram/src/command-router.js
@@ -1,0 +1,46 @@
+/**
+ * Telegram 메시지 텍스트 → 명령 / 인자 파싱.
+ *
+ * 책임 한계: 파싱과 dispatcher 메타 (available commands 표시) 만. 명령 실 dispatch
+ * 는 bot-server.js 가 message:text 핸들러에서 dispatcher 객체를 lookup 하는 방식이고,
+ * dispatcher 의 실 내용물 채우는 작업은 Phase 3 (#128).
+ */
+
+/**
+ * @typedef {object} ParsedCommand
+ * @property {string} cmd  - lowercase 명령 이름 (slash / mention 제거 후).
+ * @property {string[]} args - 공백으로 split 된 추가 인자.
+ */
+
+/**
+ * @param {string} text
+ * @returns {ParsedCommand | null} 명령이 아니면 null.
+ */
+export function parseCommand(text) {
+  if (typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('/')) return null;
+  const body = trimmed.slice(1);
+  if (!body) return null;
+  const [rawCmd, ...rest] = body.split(/\s+/);
+  if (!rawCmd) return null;
+  // /cmd@MyBot → cmd  (group chat 에서 다른 봇 멘션 분리 패턴).
+  const cmd = rawCmd.split('@')[0].toLowerCase();
+  if (!cmd) return null;
+  return { cmd, args: rest };
+}
+
+/**
+ * dispatcher 객체의 키를 사람-읽기 친화 형태로 표시 — 미등록 명령 응답에 사용.
+ * Phase 1/2 단계처럼 dispatcher 가 비어 있으면 안내 문구 반환.
+ *
+ * @param {Record<string, unknown> | undefined | null} dispatcher
+ * @returns {string}
+ */
+export function listAvailableCommands(dispatcher) {
+  const cmds = Object.keys(dispatcher ?? {}).sort();
+  if (cmds.length === 0) {
+    return '(등록된 명령 없음 — Phase 3 머지 후 활성화)';
+  }
+  return cmds.map((c) => `/${c}`).join(' ');
+}

--- a/packages/telegram/src/command-router.js
+++ b/packages/telegram/src/command-router.js
@@ -13,10 +13,19 @@
  */
 
 /**
- * @param {string} text
- * @returns {ParsedCommand | null} 명령이 아니면 null.
+ * @typedef {object} ParseCommandOptions
+ * @property {string} [botUsername] - 현재 봇의 Telegram username (`@` 제외).
+ *   지정 시 `/cmd@OtherBot` 처럼 본인이 아닌 봇을 mention 한 명령은 null 로
+ *   필터링 (group chat 에서 다른 봇과 공존 시 명령 충돌 방지). 미지정 시
+ *   기존 동작 — mention suffix 만 strip.
  */
-export function parseCommand(text) {
+
+/**
+ * @param {string} text
+ * @param {ParseCommandOptions} [options]
+ * @returns {ParsedCommand | null} 명령이 아니거나 본인이 아닌 봇 mention 이면 null.
+ */
+export function parseCommand(text, options) {
   if (typeof text !== 'string') return null;
   const trimmed = text.trim();
   if (!trimmed.startsWith('/')) return null;
@@ -24,8 +33,19 @@ export function parseCommand(text) {
   if (!body) return null;
   const [rawCmd, ...rest] = body.split(/\s+/);
   if (!rawCmd) return null;
-  // /cmd@MyBot → cmd  (group chat 에서 다른 봇 멘션 분리 패턴).
-  const cmd = rawCmd.split('@')[0].toLowerCase();
+  // /cmd@bot — `@` 가 있으면 mention 분리. botUsername 옵션이 주어진 경우
+  // 본인이 아닌 mention 은 null 반환 (group chat 의 다른 봇 명령 차단).
+  const atIdx = rawCmd.indexOf('@');
+  let cmdPart = rawCmd;
+  if (atIdx >= 0) {
+    cmdPart = rawCmd.slice(0, atIdx);
+    const mention = rawCmd.slice(atIdx + 1);
+    const expected = options?.botUsername;
+    if (expected != null && mention.toLowerCase() !== String(expected).toLowerCase()) {
+      return null;
+    }
+  }
+  const cmd = cmdPart.toLowerCase();
   if (!cmd) return null;
   return { cmd, args: rest };
 }

--- a/packages/telegram/src/command-router.js
+++ b/packages/telegram/src/command-router.js
@@ -51,6 +51,24 @@ export function parseCommand(text, options) {
 }
 
 /**
+ * `text` 가 `/cmd@mention` 형식이면 mention 부분 (`@` 뒤 username) 을 반환.
+ * 명령 형식이 아니거나 mention 이 없으면 null.
+ *
+ * bot-server 가 `parseCommand` 호출 *전* 에 mention 분기 (본인이 아닌 봇 mention
+ * 은 silent ignore — group chat 충돌 방지) 에 사용 (PR #133 review).
+ *
+ * @param {string} text
+ * @returns {string | null}
+ */
+export function extractMention(text) {
+  if (typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('/')) return null;
+  const m = trimmed.match(/^\/\S+@(\S+)/);
+  return m ? m[1] : null;
+}
+
+/**
  * dispatcher 객체의 키를 사람-읽기 친화 형태로 표시 — 미등록 명령 응답에 사용.
  * Phase 1/2 단계처럼 dispatcher 가 비어 있으면 안내 문구 반환.
  *

--- a/packages/telegram/src/formatters.js
+++ b/packages/telegram/src/formatters.js
@@ -24,21 +24,32 @@ export function stripAnsi(text) {
 }
 
 /**
- * Telegram HTML 모드의 `<pre>` 블록으로 wrap. `<` `>` `&` 3 문자만 escape.
+ * Telegram HTML 모드 안전 escape — `<` `>` `&` 3 문자만 처리.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Telegram HTML 모드의 `<pre>` 블록으로 wrap. 짧은 단일 메시지 용도 (4096 자
+ * 한도 안 가까운 출력) — 4096 자에 근접하거나 entity expansion 영향이 큰 출력
+ * 은 `formatPreChunksForTelegram` 사용.
  *
  * @param {string} text
  * @returns {string}
  */
 export function wrapPre(text) {
-  const escaped = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  return `<pre>${escaped}</pre>`;
+  return `<pre>${escapeHtml(text)}</pre>`;
 }
 
 /**
- * Telegram 메시지 1 건의 최대 길이 (4096 자) 에 안전 마진을 두고 줄 단위로 split.
- * `<pre>` wrap 의 tag overhead 까지 감안해 기본 limit 은 4000.
- *
- * 한 줄 자체가 limit 초과면 글자 단위로 강제 분할.
+ * 줄 단위 분할 helper — **raw text 길이 기준** 으로 chunking 한다. HTML escape
+ * 후 entity expansion (`&` → `&amp;` 등) 은 고려하지 않으므로, escape 가 들어가는
+ * 시나리오 (`<pre>` wrap 등) 에서는 `formatPreChunksForTelegram` 사용 권장. 본
+ * 함수는 escape 가 없거나 영향이 작은 plain text 분할용.
  *
  * @param {string} text
  * @param {number} [limit=4000]
@@ -71,6 +82,57 @@ export function splitForTelegram(text, limit = 4000) {
     }
   }
   if (current) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * raw text → HTML escape → `<pre>` wrap 까지 한 번에 처리해 Telegram 전송 가능한
+ * 메시지 배열을 반환. `splitForTelegram` 이 raw 길이만 보던 한계 (entity
+ * expansion 으로 4096 초과 가능) 를 보완 (PR #133 review).
+ *
+ * 알고리즘:
+ *   1) raw 를 줄 단위로 split.
+ *   2) 각 줄을 escapeHtml 로 변환.
+ *   3) `<pre>` + `</pre>` (11 자) 까지 포함한 message 길이가 limit 이하가 되도록
+ *      escape 된 줄을 누적 chunk 에 추가.
+ *   4) 한 줄이 단독으로 limit 초과면 escape 후 글자 단위 강제 분할.
+ *   5) 각 chunk 는 self-contained `<pre>...</pre>` 로 wrap 되어 반환.
+ *
+ * @param {string} rawText
+ * @param {number} [limit=4000] - `<pre>` 포함 message 전체 길이 한도 (Telegram
+ *   4096 마진 96).
+ * @returns {string[]} 각 element 가 `<pre>...</pre>` 형태인 message 배열.
+ */
+export function formatPreChunksForTelegram(rawText, limit = 4000) {
+  if (typeof rawText !== 'string') return [];
+  if (rawText.length === 0) return [];
+  const TAG_OPEN = '<pre>';
+  const TAG_CLOSE = '</pre>';
+  const contentLimit = limit - TAG_OPEN.length - TAG_CLOSE.length;
+  const lines = rawText.split('\n');
+  const chunks = [];
+  let current = '';
+  for (const line of lines) {
+    const escapedLine = escapeHtml(line);
+    if (escapedLine.length > contentLimit) {
+      if (current) {
+        chunks.push(`${TAG_OPEN}${current}${TAG_CLOSE}`);
+        current = '';
+      }
+      for (let i = 0; i < escapedLine.length; i += contentLimit) {
+        chunks.push(`${TAG_OPEN}${escapedLine.slice(i, i + contentLimit)}${TAG_CLOSE}`);
+      }
+      continue;
+    }
+    const next = current ? `${current}\n${escapedLine}` : escapedLine;
+    if (next.length > contentLimit) {
+      chunks.push(`${TAG_OPEN}${current}${TAG_CLOSE}`);
+      current = escapedLine;
+    } else {
+      current = next;
+    }
+  }
+  if (current) chunks.push(`${TAG_OPEN}${current}${TAG_CLOSE}`);
   return chunks;
 }
 

--- a/packages/telegram/src/formatters.js
+++ b/packages/telegram/src/formatters.js
@@ -1,0 +1,88 @@
+/**
+ * Telegram 응답 전용 텍스트 가공 helpers.
+ *
+ * 본 모듈의 모든 함수는 pure — Telegram API 와 직접 통신하지 않는다.
+ * bot-server.js 또는 Phase 3 의 handler 가 결과 메시지를 만들 때 호출.
+ */
+
+// ESC (0x1b) + [ + ... + letter — generic CSI sequence. ESC 문자를 정규식 리터럴에
+// 직접 넣으면 eslint no-control-regex 가 잡으므로 RegExp 생성자로 우회. String.
+// fromCharCode 가 lint-safe 한 ESC 문자 산출.
+const ANSI_CSI_PATTERN = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*[A-Za-z]`, 'g');
+
+/**
+ * ANSI escape sequence (CSI) 를 제거한다. token-weather 의 평문 출력은
+ * `shouldUseColor === false` 면 ANSI 가 안 들어가지만, daemon 내 다른 stdio
+ * helper 가 색을 넣을 가능성에 대한 방어적 strip.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripAnsi(text) {
+  if (typeof text !== 'string') return text;
+  return text.replace(ANSI_CSI_PATTERN, '');
+}
+
+/**
+ * Telegram HTML 모드의 `<pre>` 블록으로 wrap. `<` `>` `&` 3 문자만 escape.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function wrapPre(text) {
+  const escaped = String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return `<pre>${escaped}</pre>`;
+}
+
+/**
+ * Telegram 메시지 1 건의 최대 길이 (4096 자) 에 안전 마진을 두고 줄 단위로 split.
+ * `<pre>` wrap 의 tag overhead 까지 감안해 기본 limit 은 4000.
+ *
+ * 한 줄 자체가 limit 초과면 글자 단위로 강제 분할.
+ *
+ * @param {string} text
+ * @param {number} [limit=4000]
+ * @returns {string[]}
+ */
+export function splitForTelegram(text, limit = 4000) {
+  if (typeof text !== 'string') return [];
+  if (text.length === 0) return [];
+  if (text.length <= limit) return [text];
+  const lines = text.split('\n');
+  const chunks = [];
+  let current = '';
+  for (const line of lines) {
+    if (line.length > limit) {
+      if (current) {
+        chunks.push(current);
+        current = '';
+      }
+      for (let i = 0; i < line.length; i += limit) {
+        chunks.push(line.slice(i, i + limit));
+      }
+      continue;
+    }
+    const next = current ? `${current}\n${line}` : line;
+    if (next.length > limit) {
+      chunks.push(current);
+      current = line;
+    } else {
+      current = next;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * 에러를 Telegram <pre> 블록으로 안전 직렬화. stack trace 는 노출하지 않고
+ * name + message 만 표시 — 정보 노출 최소화.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function formatErrorForTelegram(err) {
+  const name = err && typeof err === 'object' && 'name' in err ? err.name : 'Error';
+  const msg = err && typeof err === 'object' && 'message' in err ? err.message : String(err);
+  return wrapPre(`${name}: ${msg}`);
+}

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -15,8 +15,8 @@
 
 import { createBotServer } from './bot-server.js';
 
-export { createBotServer } from './bot-server.js';
-export { parseCommand, listAvailableCommands } from './command-router.js';
+export { createBotServer, handleTextMessage } from './bot-server.js';
+export { parseCommand, extractMention, listAvailableCommands } from './command-router.js';
 export { authAllowlistMiddleware, maskUserId } from './auth-allowlist.js';
 export {
   stripAnsi,

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -1,36 +1,62 @@
 /**
- * @token-weather/telegram — Telegram 봇 통합 패키지 진입점.
+ * @token-weather/telegram — public API.
  *
- * 5-phase plan (issue #126~#130) 의 Phase 1 시점에서는 워크스페이스 scaffold +
- * placeholder export 만 제공한다. 실제 long-poll daemon / 명령 라우터 / 핸들러는
- * Phase 2~3 (#127, #128) 에서 채워지고, 사용자 setup 흐름은 Phase 4 (#129).
+ * Phase 2 (#127) 부터 createBotServer / startBot / stopBot 가 실제 long-poll
+ * daemon 을 띄운다. `runTelegramCommand` 는 여전히 Phase 1 placeholder —
+ * Phase 3 (#128) 에서 dispatcher 를 채우고 `run-cli` 와 연결한다.
  *
- * ## 의존성 방향 (PR #131 review 지적 반영)
+ * ## 의존성 방향 (PR #131 review 정책)
  *
- * `@token-weather/cli` 가 본 패키지를 dynamic import 로 호출하므로, 본 패키지가
- * 다시 `@token-weather/cli` 를 import 하면 순환이 생긴다. 반대로 core 로직 (status
- * snapshot / formatter / config loader) 을 본 패키지가 재구현하면 CLI 와 drift
- * 발생.
- *
- * 본 패키지는 그 두 경로 모두 피하기 위해 **의존성 주입 (deps injection)** 을
- * 채택한다 — `runTelegramCommand(argv, deps)` 의 `deps` 로 CLI 측이 core 함수
- * 묶음을 그대로 넘긴다. 본 패키지는 `@token-weather/provider-adapters` 와
- * `@token-weather/schemas` 만 직접 의존하고, status / usage / doctor / auth-list
- * 같은 CLI-소유 함수는 deps 를 통해서만 접근한다.
- *
- * Phase 3 (#128) 에서 `deps` 의 정확한 shape 가 typedef 로 굳어진다. 현재는
- * Phase 3 가 채울 핵심 키만 주석으로 가이드.
+ * 본 패키지는 `@token-weather/cli` 를 import 하지 않는다. `runTelegramCommand`
+ * 의 `deps` 매개변수가 CLI 가 주입하는 core 함수 묶음 (getStatusSnapshot /
+ * formatStatusOutput / formatStatusJson / collectDoctorReport /
+ * collectAuthListData / resolveAgentConfigPath) 의 통로 — 순환 의존 회피.
  */
+
+import { createBotServer } from './bot-server.js';
+
+export { createBotServer } from './bot-server.js';
+export { parseCommand, listAvailableCommands } from './command-router.js';
+export { authAllowlistMiddleware, maskChatId } from './auth-allowlist.js';
+export { stripAnsi, wrapPre, splitForTelegram, formatErrorForTelegram } from './formatters.js';
+
+let _activeServer = null;
+
+/**
+ * Telegram 봇 daemon 을 띄운다. long-poll 루프는 fire-and-forget 으로 시작되고,
+ * lifecycle 핸들은 internal cache 에 저장된다. process 가 살아 있는 동안 daemon
+ * 이 계속 돈다고 가정해도 된다.
+ *
+ * @param {import('./bot-server.js').BotServerOptions} config
+ * @returns {Promise<import('./bot-server.js').BotServer>}
+ */
+export async function startBot(config) {
+  if (_activeServer) {
+    throw new Error(
+      'startBot: Telegram bot is already running in this process (single-instance lock).',
+    );
+  }
+  _activeServer = createBotServer(config);
+  await _activeServer.start();
+  return _activeServer;
+}
+
+/**
+ * 현재 프로세스에서 띄운 daemon 을 graceful 하게 종료한다. 미작동 상태면 noop.
+ */
+export async function stopBot() {
+  if (!_activeServer) return;
+  await _activeServer.stop();
+  _activeServer = null;
+}
 
 /**
  * `@token-weather/cli` 의 `run-cli` 가 `telegram` 서브명령에서 dynamic import 로
- * 호출하는 진입점.
+ * 호출하는 진입점. Phase 3 (#128) 에서 setup / check / start subcommand dispatch
+ * 가 채워진다.
  *
  * @param {string[]} _argv - `token-weather telegram <subcommand> ...` 의 나머지 인자.
- * @param {object} [_deps] - CLI 가 주입하는 core 함수 묶음. Phase 3 에서 다음 키들이
- *   채워진다: `getStatusSnapshot`, `formatStatusOutput`, `formatStatusJson`,
- *   `collectDoctorReport`, `collectAuthListData`, `resolveAgentConfigPath`. 본 패키지가
- *   `@token-weather/cli` 를 직접 import 하지 않도록 막아 순환 의존을 방지한다.
+ * @param {object} [_deps] - CLI 가 주입하는 core 함수 묶음.
  * @returns {Promise<void>}
  */
 export async function runTelegramCommand(_argv, _deps) {

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -42,8 +42,11 @@ export async function startBot(config) {
       'startBot: Telegram bot is already running in this process (single-instance lock).',
     );
   }
-  _activeServer = createBotServer(config);
-  await _activeServer.start();
+  const server = createBotServer(config);
+  // Boot 실패 시 _activeServer 는 설정되지 않음 — lock 미점유 상태로 재시도
+  // 가능 (PR #133 review 반영 — token 오류 후 lock 잔존 회피).
+  await server.start();
+  _activeServer = server;
   return _activeServer;
 }
 

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -18,7 +18,13 @@ import { createBotServer } from './bot-server.js';
 export { createBotServer } from './bot-server.js';
 export { parseCommand, listAvailableCommands } from './command-router.js';
 export { authAllowlistMiddleware, maskUserId } from './auth-allowlist.js';
-export { stripAnsi, wrapPre, splitForTelegram, formatErrorForTelegram } from './formatters.js';
+export {
+  stripAnsi,
+  wrapPre,
+  splitForTelegram,
+  formatPreChunksForTelegram,
+  formatErrorForTelegram,
+} from './formatters.js';
 
 let _activeServer = null;
 

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -17,7 +17,7 @@ import { createBotServer } from './bot-server.js';
 
 export { createBotServer } from './bot-server.js';
 export { parseCommand, listAvailableCommands } from './command-router.js';
-export { authAllowlistMiddleware, maskChatId } from './auth-allowlist.js';
+export { authAllowlistMiddleware, maskUserId } from './auth-allowlist.js';
 export { stripAnsi, wrapPre, splitForTelegram, formatErrorForTelegram } from './formatters.js';
 
 let _activeServer = null;

--- a/packages/telegram/test/auth-allowlist.test.js
+++ b/packages/telegram/test/auth-allowlist.test.js
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { authAllowlistMiddleware, maskChatId } from '../src/auth-allowlist.js';
+
+function buildCtx(fromId) {
+  return { from: { id: fromId } };
+}
+
+function makeNextSpy() {
+  let called = 0;
+  return {
+    fn: async () => {
+      called += 1;
+    },
+    get called() {
+      return called;
+    },
+  };
+}
+
+function makeLogger() {
+  const logs = [];
+  return {
+    logger: {
+      log: (msg) => {
+        logs.push(msg);
+      },
+    },
+    logs,
+  };
+}
+
+describe('authAllowlistMiddleware', () => {
+  it('허용 chat_id 는 next() 호출', async () => {
+    const { logger, logs } = makeLogger();
+    const mw = authAllowlistMiddleware([42], { logger });
+    const next = makeNextSpy();
+    await mw(buildCtx(42), next.fn);
+    assert.equal(next.called, 1);
+    assert.equal(logs.length, 0);
+  });
+
+  it('미허용 chat_id 는 silent ignore (next() 호출 안 됨, 로그만)', async () => {
+    const { logger, logs } = makeLogger();
+    const mw = authAllowlistMiddleware([42], { logger });
+    const next = makeNextSpy();
+    await mw(buildCtx(99), next.fn);
+    assert.equal(next.called, 0);
+    assert.equal(logs.length, 1);
+    assert.match(logs[0], /미허용 chat_id/);
+  });
+
+  it('string / number id 혼용도 같은 값으로 매칭', async () => {
+    const { logger } = makeLogger();
+    const mw = authAllowlistMiddleware(['42'], { logger });
+    const next = makeNextSpy();
+    await mw(buildCtx(42), next.fn);
+    assert.equal(next.called, 1);
+  });
+
+  it('빈 allowlist 는 모든 발신자 거부', async () => {
+    const { logger } = makeLogger();
+    const mw = authAllowlistMiddleware([], { logger });
+    const next = makeNextSpy();
+    await mw(buildCtx(42), next.fn);
+    assert.equal(next.called, 0);
+  });
+
+  it('null / undefined allowlist 도 안전 (모두 거부)', async () => {
+    const { logger } = makeLogger();
+    const mw1 = authAllowlistMiddleware(null, { logger });
+    const mw2 = authAllowlistMiddleware(undefined, { logger });
+    const next = makeNextSpy();
+    await mw1(buildCtx(42), next.fn);
+    await mw2(buildCtx(42), next.fn);
+    assert.equal(next.called, 0);
+  });
+
+  it('ctx.from 자체가 없으면 silent ignore (로그도 안 남김)', async () => {
+    const { logger, logs } = makeLogger();
+    const mw = authAllowlistMiddleware([42], { logger });
+    const next = makeNextSpy();
+    await mw({}, next.fn);
+    assert.equal(next.called, 0);
+    assert.equal(logs.length, 0);
+  });
+});
+
+describe('maskChatId', () => {
+  it('4 자 이하는 전체 마스킹', () => {
+    assert.equal(maskChatId('42'), '****');
+    assert.equal(maskChatId('1234'), '****');
+  });
+
+  it('5 자 이상은 앞 3 / 뒤 2 만 노출', () => {
+    assert.equal(maskChatId('1234567890'), '123****90');
+    assert.equal(maskChatId('8308098400'), '830****00');
+  });
+
+  it('number 입력도 string 처리', () => {
+    assert.equal(maskChatId(8308098400), '830****00');
+  });
+});

--- a/packages/telegram/test/auth-allowlist.test.js
+++ b/packages/telegram/test/auth-allowlist.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { authAllowlistMiddleware, maskChatId } from '../src/auth-allowlist.js';
+import { authAllowlistMiddleware, maskUserId } from '../src/auth-allowlist.js';
 
 function buildCtx(fromId) {
   return { from: { id: fromId } };
@@ -41,14 +41,14 @@ describe('authAllowlistMiddleware', () => {
     assert.equal(logs.length, 0);
   });
 
-  it('미허용 chat_id 는 silent ignore (next() 호출 안 됨, 로그만)', async () => {
+  it('미허용 user_id 는 silent ignore (next() 호출 안 됨, 로그만)', async () => {
     const { logger, logs } = makeLogger();
     const mw = authAllowlistMiddleware([42], { logger });
     const next = makeNextSpy();
     await mw(buildCtx(99), next.fn);
     assert.equal(next.called, 0);
     assert.equal(logs.length, 1);
-    assert.match(logs[0], /미허용 chat_id/);
+    assert.match(logs[0], /미허용 user_id/);
   });
 
   it('string / number id 혼용도 같은 값으로 매칭', async () => {
@@ -87,18 +87,18 @@ describe('authAllowlistMiddleware', () => {
   });
 });
 
-describe('maskChatId', () => {
+describe('maskUserId', () => {
   it('4 자 이하는 전체 마스킹', () => {
-    assert.equal(maskChatId('42'), '****');
-    assert.equal(maskChatId('1234'), '****');
+    assert.equal(maskUserId('42'), '****');
+    assert.equal(maskUserId('1234'), '****');
   });
 
   it('5 자 이상은 앞 3 / 뒤 2 만 노출', () => {
-    assert.equal(maskChatId('1234567890'), '123****90');
-    assert.equal(maskChatId('8308098400'), '830****00');
+    assert.equal(maskUserId('1234567890'), '123****90');
+    assert.equal(maskUserId('8308098400'), '830****00');
   });
 
   it('number 입력도 string 처리', () => {
-    assert.equal(maskChatId(8308098400), '830****00');
+    assert.equal(maskUserId(8308098400), '830****00');
   });
 });

--- a/packages/telegram/test/bot-server.test.js
+++ b/packages/telegram/test/bot-server.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createBotServer } from '../src/bot-server.js';
+import { createBotServer, handleTextMessage } from '../src/bot-server.js';
 import { startBot, stopBot } from '../src/index.js';
 
 function makeMockBot({ initFails = false, initError } = {}) {
@@ -91,6 +91,82 @@ describe('createBotServer boot validation (PR #133 review)', () => {
     await server.start();
     await server.stop();
     assert.equal(mock._stopCalled, 1);
+  });
+});
+
+function makeMockCtx(text, { username, replies = [] } = {}) {
+  return {
+    message: { text },
+    me: username ? { username } : undefined,
+    reply: async (msg) => {
+      replies.push(msg);
+    },
+    _replies: replies,
+  };
+}
+
+describe('handleTextMessage (PR #133 review)', () => {
+  it('다른 봇 mention 은 silent — ctx.reply 호출 안 됨', async () => {
+    const replies = [];
+    const ctx = makeMockCtx('/status@OtherBot', { username: 'TokenWeatherBot', replies });
+    await handleTextMessage(ctx, { dispatcher: {} });
+    assert.deepEqual(replies, []);
+  });
+
+  it('본인 mention 은 명령 처리 진행 (dispatcher 비어 있으면 placeholder reply)', async () => {
+    const replies = [];
+    const ctx = makeMockCtx('/status@TokenWeatherBot', {
+      username: 'TokenWeatherBot',
+      replies,
+    });
+    await handleTextMessage(ctx, { dispatcher: {} });
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /아직 구현되지 않은/);
+  });
+
+  it('mention 없는 명령은 통과 → placeholder reply', async () => {
+    const replies = [];
+    const ctx = makeMockCtx('/status', { username: 'TokenWeatherBot', replies });
+    await handleTextMessage(ctx, { dispatcher: {} });
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /아직 구현되지 않은/);
+  });
+
+  it('non-command 입력은 "알 수 없는 입력" reply', async () => {
+    const replies = [];
+    const ctx = makeMockCtx('hello', { username: 'TokenWeatherBot', replies });
+    await handleTextMessage(ctx, { dispatcher: {} });
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /알 수 없는 입력/);
+  });
+
+  it('dispatcher 에 등록된 명령은 handler 호출', async () => {
+    let handlerCalled = 0;
+    let receivedArgs = null;
+    const dispatcher = {
+      status: async (ctx, args) => {
+        handlerCalled += 1;
+        receivedArgs = args;
+        await ctx.reply('status response');
+      },
+    };
+    const replies = [];
+    const ctx = makeMockCtx('/status --json', { username: 'TokenWeatherBot', replies });
+    await handleTextMessage(ctx, { dispatcher });
+    assert.equal(handlerCalled, 1);
+    assert.deepEqual(receivedArgs, ['--json']);
+    assert.deepEqual(replies, ['status response']);
+  });
+
+  it('case-insensitive mention 매칭 — 본인 봇이면 silent 아님', async () => {
+    const replies = [];
+    const ctx = makeMockCtx('/status@tokenweatherbot', {
+      username: 'TokenWeatherBot',
+      replies,
+    });
+    await handleTextMessage(ctx, { dispatcher: {} });
+    assert.equal(replies.length, 1);
+    assert.match(replies[0], /아직 구현되지 않은/);
   });
 });
 

--- a/packages/telegram/test/bot-server.test.js
+++ b/packages/telegram/test/bot-server.test.js
@@ -4,6 +4,31 @@ import assert from 'node:assert/strict';
 import { createBotServer } from '../src/bot-server.js';
 import { startBot, stopBot } from '../src/index.js';
 
+function makeMockBot({ initFails = false, initError } = {}) {
+  let initAttempts = 0;
+  let stopCalled = 0;
+  return {
+    api: {},
+    use() {},
+    on() {},
+    catch() {},
+    init: async () => {
+      initAttempts += 1;
+      if (initFails) throw initError ?? new Error('mock init failure');
+    },
+    start: () => Promise.resolve(),
+    stop: async () => {
+      stopCalled += 1;
+    },
+    get _initAttempts() {
+      return initAttempts;
+    },
+    get _stopCalled() {
+      return stopCalled;
+    },
+  };
+}
+
 describe('createBotServer (Phase 2)', () => {
   it('botToken 없으면 throw', () => {
     assert.throws(() => createBotServer({}), /botToken/);
@@ -27,6 +52,45 @@ describe('createBotServer (Phase 2)', () => {
       allowedUserIds: [42],
     });
     await server.stop();
+  });
+});
+
+describe('createBotServer boot validation (PR #133 review)', () => {
+  it('init 실패 시 throw + lock 해제 (재시도 가능)', async () => {
+    const mock = makeMockBot({ initFails: true, initError: new Error('Unauthorized') });
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+    });
+    await assert.rejects(() => server.start(), /Unauthorized/);
+    // lock 해제 단언 — 같은 server 인스턴스로 다시 start 가능 (init 또 시도).
+    await assert.rejects(() => server.start(), /Unauthorized/);
+    assert.equal(mock._initAttempts, 2);
+  });
+
+  it('init 성공 후 두 번째 start 는 already started throw', async () => {
+    const mock = makeMockBot();
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+    });
+    await server.start();
+    await assert.rejects(() => server.start(), /already started/);
+    assert.equal(mock._initAttempts, 1);
+  });
+
+  it('start 성공 후 stop 호출 시 bot.stop 호출', async () => {
+    const mock = makeMockBot();
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+    });
+    await server.start();
+    await server.stop();
+    assert.equal(mock._stopCalled, 1);
   });
 });
 

--- a/packages/telegram/test/bot-server.test.js
+++ b/packages/telegram/test/bot-server.test.js
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBotServer } from '../src/bot-server.js';
+import { startBot, stopBot } from '../src/index.js';
+
+describe('createBotServer (Phase 2)', () => {
+  it('botToken 없으면 throw', () => {
+    assert.throws(() => createBotServer({}), /botToken/);
+    assert.throws(() => createBotServer({ botToken: '' }), /botToken/);
+    assert.throws(() => createBotServer({ botToken: null }), /botToken/);
+  });
+
+  it('반환 객체에 start / stop / bot 노출 (grammy Bot 인스턴스 캐리어)', () => {
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedChatIds: [42],
+    });
+    assert.equal(typeof server.start, 'function');
+    assert.equal(typeof server.stop, 'function');
+    assert.ok(server.bot, 'bot instance should be exposed for tests / extensions');
+  });
+
+  it('stop() 을 start 전에 호출하면 noop (no throw)', async () => {
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedChatIds: [42],
+    });
+    await server.stop();
+  });
+});
+
+describe('startBot / stopBot single-instance lock', () => {
+  it('stopBot 을 미작동 상태에서 호출해도 noop', async () => {
+    await stopBot();
+    // 두 번 호출도 안전.
+    await stopBot();
+  });
+
+  // 실 startBot 호출은 grammy 가 외부 Telegram API 로 polling 시도 — 단위
+  // 테스트에서는 실행하지 않는다 (네트워크 의존). single-instance lock 의
+  // assertion 만 분리해서 검증.
+  it('단일 인스턴스 lock 조건 검증 (state 검사용 직접 호출 X)', () => {
+    // 본 케이스는 startBot 의 두 번째 호출이 throw 한다는 사실을 코드 리뷰가
+    // 가능하게 두는 sentinel — 실 동작은 e2e 또는 Phase 4 의 setup 명령에서
+    // 수동으로 검증한다. 여기서는 startBot 이 함수로 export 되는지만 확인.
+    assert.equal(typeof startBot, 'function');
+  });
+});

--- a/packages/telegram/test/bot-server.test.js
+++ b/packages/telegram/test/bot-server.test.js
@@ -14,7 +14,7 @@ describe('createBotServer (Phase 2)', () => {
   it('반환 객체에 start / stop / bot 노출 (grammy Bot 인스턴스 캐리어)', () => {
     const server = createBotServer({
       botToken: '123:fake',
-      allowedChatIds: [42],
+      allowedUserIds: [42],
     });
     assert.equal(typeof server.start, 'function');
     assert.equal(typeof server.stop, 'function');
@@ -24,7 +24,7 @@ describe('createBotServer (Phase 2)', () => {
   it('stop() 을 start 전에 호출하면 noop (no throw)', async () => {
     const server = createBotServer({
       botToken: '123:fake',
-      allowedChatIds: [42],
+      allowedUserIds: [42],
     });
     await server.stop();
   });

--- a/packages/telegram/test/command-router.test.js
+++ b/packages/telegram/test/command-router.test.js
@@ -15,8 +15,30 @@ describe('parseCommand', () => {
     });
   });
 
-  it('group chat mention suffix /cmd@MyBot 은 제거', () => {
+  it('group chat mention suffix /cmd@MyBot 은 제거 (botUsername 미지정 — 기존 동작)', () => {
     assert.deepEqual(parseCommand('/status@TokenWeatherBot'), {
+      cmd: 'status',
+      args: [],
+    });
+  });
+
+  it('botUsername 일치 시 통과 (case-insensitive)', () => {
+    assert.deepEqual(parseCommand('/status@TokenWeatherBot', { botUsername: 'TokenWeatherBot' }), {
+      cmd: 'status',
+      args: [],
+    });
+    assert.deepEqual(parseCommand('/status@TokenWeatherBot', { botUsername: 'tokenweatherbot' }), {
+      cmd: 'status',
+      args: [],
+    });
+  });
+
+  it('다른 봇 mention 은 null (group chat 명령 충돌 방지 — PR #133 review)', () => {
+    assert.equal(parseCommand('/status@OtherBot', { botUsername: 'TokenWeatherBot' }), null);
+  });
+
+  it('mention 없는 명령은 botUsername 지정 시에도 통과', () => {
+    assert.deepEqual(parseCommand('/status', { botUsername: 'TokenWeatherBot' }), {
       cmd: 'status',
       args: [],
     });

--- a/packages/telegram/test/command-router.test.js
+++ b/packages/telegram/test/command-router.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseCommand, listAvailableCommands } from '../src/command-router.js';
+import { parseCommand, extractMention, listAvailableCommands } from '../src/command-router.js';
 
 describe('parseCommand', () => {
   it('slash + cmd → { cmd, args: [] }', () => {
@@ -65,6 +65,30 @@ describe('parseCommand', () => {
     assert.equal(parseCommand(undefined), null);
     assert.equal(parseCommand(123), null);
     assert.equal(parseCommand({}), null);
+  });
+});
+
+describe('extractMention (PR #133 review)', () => {
+  it('`/cmd@bot` mention 의 username 부분 반환', () => {
+    assert.equal(extractMention('/status@TokenWeatherBot'), 'TokenWeatherBot');
+    assert.equal(extractMention('/usage@OtherBot --json'), 'OtherBot');
+  });
+
+  it('mention 없는 명령은 null', () => {
+    assert.equal(extractMention('/status'), null);
+    assert.equal(extractMention('/status --json'), null);
+  });
+
+  it('명령 형식이 아니면 null', () => {
+    assert.equal(extractMention('hello@bot'), null);
+    assert.equal(extractMention(''), null);
+    assert.equal(extractMention(null), null);
+    assert.equal(extractMention(undefined), null);
+    assert.equal(extractMention(42), null);
+  });
+
+  it('leading whitespace trim', () => {
+    assert.equal(extractMention('   /status@bot'), 'bot');
   });
 });
 

--- a/packages/telegram/test/command-router.test.js
+++ b/packages/telegram/test/command-router.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseCommand, listAvailableCommands } from '../src/command-router.js';
+
+describe('parseCommand', () => {
+  it('slash + cmd → { cmd, args: [] }', () => {
+    assert.deepEqual(parseCommand('/status'), { cmd: 'status', args: [] });
+  });
+
+  it('slash + cmd + args → split on whitespace', () => {
+    assert.deepEqual(parseCommand('/status --json --account work'), {
+      cmd: 'status',
+      args: ['--json', '--account', 'work'],
+    });
+  });
+
+  it('group chat mention suffix /cmd@MyBot 은 제거', () => {
+    assert.deepEqual(parseCommand('/status@TokenWeatherBot'), {
+      cmd: 'status',
+      args: [],
+    });
+  });
+
+  it('lowercase 로 정규화 (/Status → status)', () => {
+    assert.deepEqual(parseCommand('/Status'), { cmd: 'status', args: [] });
+    assert.deepEqual(parseCommand('/USAGE'), { cmd: 'usage', args: [] });
+  });
+
+  it('leading / trailing 공백 trim', () => {
+    assert.deepEqual(parseCommand('   /status   '), { cmd: 'status', args: [] });
+  });
+
+  it('non-command 입력은 null', () => {
+    assert.equal(parseCommand('hello'), null);
+    assert.equal(parseCommand(''), null);
+    assert.equal(parseCommand('/'), null);
+    assert.equal(parseCommand('  '), null);
+  });
+
+  it('non-string 은 null', () => {
+    assert.equal(parseCommand(null), null);
+    assert.equal(parseCommand(undefined), null);
+    assert.equal(parseCommand(123), null);
+    assert.equal(parseCommand({}), null);
+  });
+});
+
+describe('listAvailableCommands', () => {
+  it('dispatcher 가 비어 있으면 "Phase 3 머지 후 활성화" 안내', () => {
+    assert.match(listAvailableCommands({}), /Phase 3/);
+    assert.match(listAvailableCommands(null), /Phase 3/);
+    assert.match(listAvailableCommands(undefined), /Phase 3/);
+  });
+
+  it('dispatcher 키를 /cmd 형식으로 정렬해 표시', () => {
+    const result = listAvailableCommands({
+      usage: () => {},
+      status: () => {},
+      doctor: () => {},
+    });
+    assert.equal(result, '/doctor /status /usage');
+  });
+});

--- a/packages/telegram/test/formatters.test.js
+++ b/packages/telegram/test/formatters.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stripAnsi, wrapPre, splitForTelegram, formatErrorForTelegram } from '../src/formatters.js';
+
+const ESC = String.fromCharCode(0x1b);
+
+describe('stripAnsi', () => {
+  it('ANSI CSI sequence 제거', () => {
+    assert.equal(stripAnsi(`${ESC}[31mred${ESC}[0m`), 'red');
+    assert.equal(stripAnsi(`${ESC}[1;33mbold yellow${ESC}[0m`), 'bold yellow');
+  });
+
+  it('일반 텍스트 그대로 통과', () => {
+    assert.equal(stripAnsi('plain text'), 'plain text');
+    assert.equal(stripAnsi(''), '');
+  });
+
+  it('non-string 은 그대로 반환', () => {
+    assert.equal(stripAnsi(null), null);
+    assert.equal(stripAnsi(undefined), undefined);
+    assert.equal(stripAnsi(42), 42);
+  });
+
+  it('일반 대괄호 표현은 ANSI 가 아니므로 보존', () => {
+    assert.equal(stripAnsi('[hello]'), '[hello]');
+    assert.equal(stripAnsi('arr[0]'), 'arr[0]');
+  });
+});
+
+describe('wrapPre', () => {
+  it('HTML 모드 안전 escape + <pre> wrap', () => {
+    assert.equal(wrapPre('hello'), '<pre>hello</pre>');
+    assert.equal(wrapPre('<tag>'), '<pre>&lt;tag&gt;</pre>');
+    assert.equal(wrapPre('a & b'), '<pre>a &amp; b</pre>');
+  });
+
+  it('& 가 다른 entity 안에 있어도 먼저 escape (이중 escape 방지)', () => {
+    assert.equal(wrapPre('&lt;'), '<pre>&amp;lt;</pre>');
+  });
+
+  it('non-string 입력도 string 변환', () => {
+    assert.equal(wrapPre(42), '<pre>42</pre>');
+  });
+});
+
+describe('splitForTelegram', () => {
+  it('limit 이하 한 chunk', () => {
+    assert.deepEqual(splitForTelegram('hello', 100), ['hello']);
+  });
+
+  it('빈 문자열은 빈 배열', () => {
+    assert.deepEqual(splitForTelegram(''), []);
+  });
+
+  it('non-string 은 빈 배열', () => {
+    assert.deepEqual(splitForTelegram(null), []);
+    assert.deepEqual(splitForTelegram(undefined), []);
+  });
+
+  it('줄 단위 split — 결합 시 limit 초과면 다음 chunk', () => {
+    // limit=12, 3 줄 (각 5자). 'aaaaa\nbbbbb'=11(≤12) 한 chunk, 다음 'ccccc'.
+    const chunks = splitForTelegram('aaaaa\nbbbbb\nccccc', 12);
+    assert.deepEqual(chunks, ['aaaaa\nbbbbb', 'ccccc']);
+  });
+
+  it('한 줄이 limit 초과면 글자 단위 강제 분할', () => {
+    const long = 'x'.repeat(25);
+    const chunks = splitForTelegram(long, 10);
+    assert.equal(chunks.length, 3);
+    assert.equal(chunks[0], 'x'.repeat(10));
+    assert.equal(chunks[1], 'x'.repeat(10));
+    assert.equal(chunks[2], 'x'.repeat(5));
+  });
+
+  it('모든 chunk 가 limit 이하임을 보장', () => {
+    const input = `${'a'.repeat(50)}\n${'b'.repeat(50)}\n${'c'.repeat(50)}`;
+    const chunks = splitForTelegram(input, 60);
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 60, `chunk size ${chunk.length} exceeds limit 60`);
+    }
+  });
+});
+
+describe('formatErrorForTelegram', () => {
+  it('Error 의 name + message 만 노출 (stack 없음)', () => {
+    const err = new TypeError('something broke');
+    const out = formatErrorForTelegram(err);
+    assert.match(out, /<pre>TypeError: something broke<\/pre>/);
+    assert.doesNotMatch(out, /at /); // stack 의 "at " 패턴 부재.
+  });
+
+  it('plain object 도 name / message 추출', () => {
+    const out = formatErrorForTelegram({ name: 'CustomErr', message: 'oops' });
+    assert.equal(out, '<pre>CustomErr: oops</pre>');
+  });
+
+  it('non-object 는 String() 으로 직렬화', () => {
+    assert.match(formatErrorForTelegram('plain string'), /<pre>Error: plain string<\/pre>/);
+    assert.match(formatErrorForTelegram(42), /<pre>Error: 42<\/pre>/);
+  });
+
+  it('HTML escape 적용 (XSS 방지)', () => {
+    const out = formatErrorForTelegram(new Error('<script>'));
+    assert.match(out, /&lt;script&gt;/);
+  });
+});

--- a/packages/telegram/test/formatters.test.js
+++ b/packages/telegram/test/formatters.test.js
@@ -1,7 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { stripAnsi, wrapPre, splitForTelegram, formatErrorForTelegram } from '../src/formatters.js';
+import {
+  stripAnsi,
+  wrapPre,
+  splitForTelegram,
+  formatPreChunksForTelegram,
+  formatErrorForTelegram,
+} from '../src/formatters.js';
 
 const ESC = String.fromCharCode(0x1b);
 
@@ -79,6 +85,57 @@ describe('splitForTelegram', () => {
     for (const chunk of chunks) {
       assert.ok(chunk.length <= 60, `chunk size ${chunk.length} exceeds limit 60`);
     }
+  });
+});
+
+describe('formatPreChunksForTelegram (PR #133 review)', () => {
+  it('빈 입력은 빈 배열', () => {
+    assert.deepEqual(formatPreChunksForTelegram(''), []);
+    assert.deepEqual(formatPreChunksForTelegram(null), []);
+    assert.deepEqual(formatPreChunksForTelegram(undefined), []);
+  });
+
+  it('짧은 입력은 1 chunk 로 wrap', () => {
+    assert.deepEqual(formatPreChunksForTelegram('hello'), ['<pre>hello</pre>']);
+  });
+
+  it('HTML escape 적용 — `<`, `>`, `&`', () => {
+    const out = formatPreChunksForTelegram('a <b> & c');
+    assert.deepEqual(out, ['<pre>a &lt;b&gt; &amp; c</pre>']);
+  });
+
+  it('각 chunk 가 limit 이하 (tag 포함) — entity expansion 영향 포함', () => {
+    // `&` 30 개 = 30 자 raw, escape 후 150 자. limit=80 이면 여러 chunk 로 split.
+    const input = '&'.repeat(30);
+    const chunks = formatPreChunksForTelegram(input, 80);
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 80, `chunk length ${chunk.length} exceeds limit 80`);
+    }
+    // 각 chunk 가 self-contained <pre>...</pre>.
+    for (const chunk of chunks) {
+      assert.ok(chunk.startsWith('<pre>'));
+      assert.ok(chunk.endsWith('</pre>'));
+    }
+    // 복원하면 원본 escape 와 일치.
+    const reassembled = chunks
+      .map((c) => c.slice('<pre>'.length, c.length - '</pre>'.length))
+      .join('');
+    assert.equal(reassembled, '&amp;'.repeat(30));
+  });
+
+  it('한 줄이 limit 초과 — escape 후 글자 단위 강제 분할', () => {
+    const input = 'x'.repeat(200);
+    const chunks = formatPreChunksForTelegram(input, 100);
+    for (const chunk of chunks) {
+      assert.ok(chunk.length <= 100);
+      assert.ok(chunk.startsWith('<pre>'));
+      assert.ok(chunk.endsWith('</pre>'));
+    }
+  });
+
+  it('줄바꿈 보존 — `\\n` 으로 구분된 두 줄이 한 chunk 에 들어감', () => {
+    const out = formatPreChunksForTelegram('line one\nline two');
+    assert.deepEqual(out, ['<pre>line one\nline two</pre>']);
   });
 });
 


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan 의 두 번째 PR (Phase 2). Phase 1 의 scaffold 위에 grammy 기반 long-poll daemon lifecycle 과 미들웨어 / 출력 가공 helpers 를 채운다. 명령 핸들러 / `run-cli` 연결은 Phase 3 (#128) 에서 진행.

본 PR 머지 후에도 `token-weather telegram` 명령은 여전히 NotImplemented — Phase 2 가 노출하는 표면은 라이브러리 API (직접 import 해 자체 봇을 띄울 수 있는 부분적 표면) 까지.

리뷰 라운드 2 회 (4 + 1 critical fix) 반영 완료.

## 변경 내용

### 신규 모듈 `packages/telegram/src/`
- `formatters.js`:
  - `stripAnsi` (lint-safe `RegExp` 생성자 패턴)
  - `wrapPre` (HTML `<` `>` `&` escape, 공통 `escapeHtml` 사용)
  - `splitForTelegram(text, limit=4000)` — **raw text 길이 기준** 줄 단위 split (plain text 분할용)
  - `formatPreChunksForTelegram(rawText, limit=4000)` — **escape 후 `<pre>` 포함 길이 기준** chunking (HTML entity expansion 대응)
  - `formatErrorForTelegram` — name+message + HTML escape, stack 제외
- `command-router.js`:
  - `parseCommand(text, { botUsername }?)` — slash 명령 파싱 + `/cmd@OtherBot` mention 시 null
  - `extractMention(text)` — `/cmd@mention` 의 username 추출 (bot-server 의 silent ignore 경로용)
  - `listAvailableCommands(dispatcher)` — 정렬 표시
- `auth-allowlist.js`:
  - `authAllowlistMiddleware(allowedUserIds, opts?)` — `ctx.from.id` 기준 "허용된 사용자" 보안 모델 (group/DM 어디서든 동일 사용자가 명령 가능), 미허용 silent ignore + 부분 마스킹 로그
  - `maskUserId(id)` — 4 자 이하 전체 / 5+ 자 `123****90`
- `bot-server.js`:
  - `createBotServer({ botToken, allowedUserIds, dispatcher, logger, botFactory? }) → { start, stop, bot }` factory
  - `handleTextMessage(ctx, { dispatcher })` — message:text 처리 helper (단위 테스트 친화). 다른 봇 mention silent return → parseCommand → dispatcher.
  - `registerShutdownHandlers(bot)` — SIGINT/TERM once
  - 409 Conflict 친절 종료 + `process.exitCode = 1`
  - `bot.init()` boot 단계 await → token validation 실패 시 lock 해제 (재시도 가능)

### 갱신
- `packages/telegram/src/index.js` — 신규 public export.
- `packages/agent/src/config/default-config.js` — `channels.telegram.allowedUserIds` (`ctx.from.id` 기준).
- `packages/agent/test/cli/status-json.test.js` — redaction fixture 의 키 이름 동기 갱신.

### 테스트
- `test/formatters.test.js` (23 it), `test/command-router.test.js` (14 it), `test/auth-allowlist.test.js` (10 it), `test/bot-server.test.js` (11 it) — 총 65 telegram unit + 기존 858 = 923 tests pass.
- bot-server 의 실 polling 은 e2e (Phase 4 setup 의 수동 검증) — 단위 테스트는 boot validation / mention silent / handler dispatch 까지.

### 저장소
- `.changeset/telegram-bot-core.md` — 4 패키지 모두 minor.
- `.changeset/telegram-package-scaffold.md` — Phase 1 release note body 의 `allowedChatIds` 도 `allowedUserIds` 로 정정.

## 리뷰 라운드 별 fix

### Round 1 (4 critical)
- `allowedChatIds` → `allowedUserIds` rename (보안 모델 정합 — `ctx.from.id` 기준)
- `parseCommand` mention filtering — `/cmd@OtherBot` 시 null
- `formatPreChunksForTelegram` 신설 (HTML entity expansion 대응)
- `startBot` boot failure 시 lock 해제 + `botFactory` mock 훅

### Round 2 (1 critical)
- 다른 봇 mention 메시지를 bot-server 가 silent ignore — 기존 `!parsed` reply 경로가 group chat 의 다른 봇 명령에도 응답하던 문제 정정. `extractMention` + `handleTextMessage` 신설.

## 변경 이유

Phase 1 의 scaffold + redaction 인프라 위에 봇 코어 모듈을 leaves first 의 의존성 순서로 분리해 쌓는다. 각 모듈은 단일 책임 (formatters / parser / allowlist / lifecycle / handler), 모두 pure 함수 또는 factory 패턴이라 단위 테스트 친화.

`@token-weather/cli` 를 import 하지 않는다는 정책 (PR #131 review) 을 본 phase 부터 코드 구조로 확인 — `bot-server.js` 의 dispatcher / `runTelegramCommand` 의 deps 가 CLI 가 주입하는 core 함수의 유일한 통로.

## 영향 범위

- [x] `packages/telegram` — Phase 2 코어 모듈 + 테스트
- [x] `packages/agent` — config 의 `channels.telegram.allowedUserIds` rename
- [ ] `packages/schemas` / `packages/provider-adapters` — 무변경
- [x] `repo` — `.changeset/*`
- [ ] `docs` — Phase 5 에서 일괄 갱신

## 테스트 / 확인

- `npm test` — 923 통과
- `npm run lint` / `npm run format:check` / `npm run build:types` 전부 통과
- `bash scripts/install-smoke.sh` 6 단계 통과
- `npx changeset status` — 4 패키지 모두 minor 인식

## 참고 사항

- Closes #127 (의 한 부분).
- bump: minor (linked 정책).
- 후속 PR: Phase 3 (#128) — 명령 핸들러 (status / usage / status-json / doctor / auth-list) + `run-cli` 의 `telegram` 분기 + agent 의 doctor / auth-list 데이터 반환형 분리.