### PR TITLE
[feat] telegram bot 통합 (4/5) — telegram setup (페어링 + OS service 템플릿 print) + telegram check 진단

### DIFF
--- a/.changeset/telegram-setup-check.md
+++ b/.changeset/telegram-setup-check.md
@@ -1,0 +1,59 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): setup (페어링 + OS service template print) + check 진단 (issue #129).
+
+5-phase Telegram 봇 통합 plan 의 Phase 4. Phase 3 까지 `token-weather telegram
+start` 만 활성화되었던 상태에서 **end-user 가 처음부터 끝까지 자체 봇을 띄울
+수 있는** 흐름을 완성한다 — 봇 토큰 prompt → getMe 검증 → `/pair <code>` 페어링
+→ config write + chmod 600 → OS service template print. 진단용 `check` 도
+동시에 등록.
+
+**신규 public export** (`@token-weather/telegram`):
+
+- `validateBotToken(botToken, { fetchFn?, apiBase? })` — Telegram Bot API getMe
+  로 token 유효성 검증. `{ ok, botInfo | error }`.
+- `generatePairingCode()` — 1회용 `TGW-XXXXXX` 코드 (0/1/I/O 제외, OCR 친화).
+- `runPairingBot(botToken, expectedCode, { timeoutMs?, botFactory?, logger? })`
+  — 페어링 전용 1회 daemon. allowlist 없이 `/pair <code>` 만 listen, ctx.from.id
+  캡처 후 `{ userId, username }` resolve. 5 분 timeout, mock 주입 가능.
+- `linuxSystemdUnit` / `macosLaunchAgent` / `windowsTaskScheduler` /
+  `pickServiceTemplate({ nodeBinPath, cliScriptPath, homeDir? })` — OS 별 service
+  unit / plist / Task Scheduler 명령 블록 반환. pure, 파일 시스템 변경 X.
+- `runSetupSubcommand(args, deps, options?)` — 대화형 setup 흐름.
+- `runCheckSubcommand(args, deps, options?)` — read-only 진단.
+- `formatTelegramSetupHelp()` / `formatTelegramCheckHelp()` — 각 subcommand 의
+  `--help` 안내.
+
+**CLI 통합** (`@token-weather/cli`):
+
+- `run-cli` 의 `telegram` 분기는 Phase 3 그대로 — `runTelegramCommand` 가 setup
+  / start / check 모두 dispatch.
+- `formatTelegramHelp` 의 Subcommands 목록에 `setup` / `check` 추가 (start 와
+  동급).
+
+**UX 정책** (PR #131 / #133 의 review 정신과 정합):
+
+- **자동 OS service 등록은 안 함** — print 만, 사용자가 복사 / 붙여넣기로
+  활성화. 도구가 시스템 파일 (`~/.config/systemd/user/...` / `~/Library/
+LaunchAgents/...`) 을 직접 만들지 않음. token-weather 의 "로컬 only" 약속
+  표면적 최소화.
+- 페어링 daemon 은 1회용 — allowlist 없이 `/pair <code>` 만 listen, code 일치
+  시 즉시 종료. createBotServer 의 single-instance lock 과 다른 lifecycle.
+- 모든 외부 의존성 (fetch / readline / Bot / fs / execSync / platform) 옵션
+  주입 — 단위 테스트가 외부 네트워크 / 실 파일 / 실 bot 없이 e2e 시나리오 검증.
+
+**기존 패키지 변경**:
+
+- 없음 — Phase 3 의 `run-cli` 분기 + 8 deps 가 그대로 통과. Phase 4 의 추가
+  deps (`resolveAgentConfigPath`) 도 Phase 3 에서 이미 주입.
+
+**SCHEMA_VERSION** 무변경 — status --json contract 무영향. **Migration** 없음.
+
+**다음 phase**: Phase 5 (#130) — docs/telegram-bot.md / README / SECURITY 갱신
+
+- release publish.

--- a/.changeset/telegram-setup-check.md
+++ b/.changeset/telegram-setup-check.md
@@ -18,6 +18,8 @@ start` 만 활성화되었던 상태에서 **end-user 가 처음부터 끝까지
 - `validateBotToken(botToken, { fetchFn?, apiBase? })` — Telegram Bot API getMe
   로 token 유효성 검증. `{ ok, botInfo | error }`.
 - `generatePairingCode()` — 1회용 `TGW-XXXXXX` 코드 (0/1/I/O 제외, OCR 친화).
+  `node:crypto.randomInt` 기반 — 1회용 authorization token 성격이므로 cryptographically
+  secure RNG (PR #135 review).
 - `runPairingBot(botToken, expectedCode, { timeoutMs?, botFactory?, logger? })`
   — 페어링 전용 1회 daemon. allowlist 없이 `/pair <code>` 만 listen, ctx.from.id
   캡처 후 `{ userId, username }` resolve. 5 분 timeout, mock 주입 가능.
@@ -35,6 +37,9 @@ start` 만 활성화되었던 상태에서 **end-user 가 처음부터 끝까지
   / start / check 모두 dispatch.
 - `formatTelegramHelp` 의 Subcommands 목록에 `setup` / `check` 추가 (start 와
   동급).
+- `runTelegramSubcommand` 의 deps 에 `createDefaultConfig` 주입 추가 — setup
+  이 config 가 없을 때 default config 기반으로 시작하도록 (PR #135 review
+  blocker — setup 직후 status/usage provider disabled 회피).
 
 **UX 정책** (PR #131 / #133 의 review 정신과 정합):
 
@@ -47,10 +52,10 @@ LaunchAgents/...`) 을 직접 만들지 않음. token-weather 의 "로컬 only" 
 - 모든 외부 의존성 (fetch / readline / Bot / fs / execSync / platform) 옵션
   주입 — 단위 테스트가 외부 네트워크 / 실 파일 / 실 bot 없이 e2e 시나리오 검증.
 
-**기존 패키지 변경**:
+**기존 패키지 변경** (`@token-weather/cli`):
 
-- 없음 — Phase 3 의 `run-cli` 분기 + 8 deps 가 그대로 통과. Phase 4 의 추가
-  deps (`resolveAgentConfigPath`) 도 Phase 3 에서 이미 주입.
+- `run-cli` 의 telegram deps 에 `createDefaultConfig` 추가 (PR #135 review
+  blocker fix). Phase 3 의 8 deps 가 9 deps 로 확장.
 
 **SCHEMA_VERSION** 무변경 — status --json contract 무영향. **Migration** 없음.
 

--- a/packages/agent/src/cli/run-cli.js
+++ b/packages/agent/src/cli/run-cli.js
@@ -20,6 +20,7 @@ import { getStatusSnapshot } from '../services/status-service.js';
 import { formatStatusOutput } from './status-formatters.js';
 import { formatStatusJson } from './status-json.js';
 import { resolveAgentConfigPath } from '../config/config-path.js';
+import { createDefaultConfig } from '../config/default-config.js';
 
 /**
  * CLI 진입점. `bin/token-weather.js`가 process.argv.slice(2)를 그대로 전달.
@@ -110,6 +111,7 @@ async function runTelegramSubcommand(argv) {
     collectAuthListData,
     formatAuthListLines,
     resolveAgentConfigPath,
+    createDefaultConfig,
   };
   await telegram.runTelegramCommand(argv, deps);
 }

--- a/packages/telegram/src/check-subcommand.js
+++ b/packages/telegram/src/check-subcommand.js
@@ -36,14 +36,14 @@ import { validateBotToken } from './pairing.js';
  * @returns {Promise<{ checks: Array<{ name: string, ok: boolean | 'warn', message: string }> }>}
  */
 export async function runCheckSubcommand(args, deps, options = {}) {
+  const log = options.log ?? ((msg) => console.log(msg));
   if (Array.isArray(args) && (args.includes('--help') || args.includes('-h'))) {
-    for (const line of formatTelegramCheckHelp()) console.log(line);
+    for (const line of formatTelegramCheckHelp()) log(line);
     return { checks: [] };
   }
   if (!deps?.resolveAgentConfigPath) {
     throw new Error('runCheckSubcommand: deps.resolveAgentConfigPath 가 필요합니다.');
   }
-  const log = options.log ?? ((msg) => console.log(msg));
   const fsImpl = options.fsImpl ?? fs;
   const platform = options.platform ?? process.platform;
   const fetchFn = options.fetchFn ?? fetch;
@@ -126,9 +126,7 @@ export async function runCheckSubcommand(args, deps, options = {}) {
     checks.push({
       name: 'getMe API',
       ok: validation.ok,
-      message: validation.ok
-        ? `@${validation.botInfo?.username ?? '(unknown)'}`
-        : validation.error,
+      message: validation.ok ? `@${validation.botInfo?.username ?? '(unknown)'}` : validation.error,
     });
   }
 

--- a/packages/telegram/src/check-subcommand.js
+++ b/packages/telegram/src/check-subcommand.js
@@ -14,7 +14,7 @@
  */
 
 import fs from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 import { validateBotToken } from './pairing.js';
 
@@ -23,7 +23,9 @@ import { validateBotToken } from './pairing.js';
  * @property {typeof fetch} [fetchFn]
  * @property {(msg: string) => void} [log]
  * @property {{ statSync: Function, existsSync: Function, readFileSync: Function }} [fsImpl]
- * @property {(cmd: string) => string} [execImpl] - linger 검사용 execSync wrapper.
+ * @property {(cmd: string, args: string[]) => string} [execImpl] - linger 검사용
+ *   execFileSync wrapper. 시그니처 `(cmd, args)` — shell 문자열 조립 회피
+ *   (PR #135 review).
  * @property {NodeJS.Platform} [platform] - process.platform override (테스트 용).
  */
 
@@ -47,7 +49,7 @@ export async function runCheckSubcommand(args, deps, options = {}) {
   const fsImpl = options.fsImpl ?? fs;
   const platform = options.platform ?? process.platform;
   const fetchFn = options.fetchFn ?? fetch;
-  const execImpl = options.execImpl ?? ((cmd) => execSync(cmd).toString());
+  const execImpl = options.execImpl ?? ((cmd, args) => execFileSync(cmd, args).toString());
 
   const configPath = deps.resolveAgentConfigPath();
   const checks = [];
@@ -134,7 +136,7 @@ export async function runCheckSubcommand(args, deps, options = {}) {
   if (platform === 'linux') {
     try {
       const user = process.env.USER ?? '';
-      const out = execImpl(`loginctl show-user "${user}" --property=Linger`);
+      const out = execImpl('loginctl', ['show-user', user, '--property=Linger']);
       const linger = /Linger=yes/.test(out);
       checks.push({
         name: 'systemd linger',

--- a/packages/telegram/src/check-subcommand.js
+++ b/packages/telegram/src/check-subcommand.js
@@ -1,0 +1,187 @@
+/**
+ * `telegram check` 서브명령 — read-only 진단.
+ *
+ * Phase 4 (#129) 의 보조 명령. 시스템 파일을 만들지 않고, 다음 항목을 검사해
+ * 친화 출력으로 사용자에게 상태 안내:
+ *
+ *   1) config 파일 존재 / 권한 (chmod 600 권장).
+ *   2) channels.telegram.enabled / botToken / allowedUserIds 채워짐.
+ *   3) getMe API 로 botToken 유효성.
+ *   4) Linux: `loginctl show-user $USER --property=Linger` 가 yes 인지
+ *      (linger 비활성화면 로그아웃 시 daemon 종료 경고).
+ *
+ * 본 명령은 부수효과 없음 — 파일 / 네트워크 (POST) 변경 X. getMe (GET) 만.
+ */
+
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+import { validateBotToken } from './pairing.js';
+
+/**
+ * @typedef {object} CheckOptions
+ * @property {typeof fetch} [fetchFn]
+ * @property {(msg: string) => void} [log]
+ * @property {{ statSync: Function, existsSync: Function, readFileSync: Function }} [fsImpl]
+ * @property {(cmd: string) => string} [execImpl] - linger 검사용 execSync wrapper.
+ * @property {NodeJS.Platform} [platform] - process.platform override (테스트 용).
+ */
+
+/**
+ * `token-weather telegram check` 의 dispatch 진입점.
+ *
+ * @param {string[]} args
+ * @param {{ resolveAgentConfigPath: () => string }} deps
+ * @param {CheckOptions} [options]
+ * @returns {Promise<{ checks: Array<{ name: string, ok: boolean | 'warn', message: string }> }>}
+ */
+export async function runCheckSubcommand(args, deps, options = {}) {
+  if (Array.isArray(args) && (args.includes('--help') || args.includes('-h'))) {
+    for (const line of formatTelegramCheckHelp()) console.log(line);
+    return { checks: [] };
+  }
+  if (!deps?.resolveAgentConfigPath) {
+    throw new Error('runCheckSubcommand: deps.resolveAgentConfigPath 가 필요합니다.');
+  }
+  const log = options.log ?? ((msg) => console.log(msg));
+  const fsImpl = options.fsImpl ?? fs;
+  const platform = options.platform ?? process.platform;
+  const fetchFn = options.fetchFn ?? fetch;
+  const execImpl = options.execImpl ?? ((cmd) => execSync(cmd).toString());
+
+  const configPath = deps.resolveAgentConfigPath();
+  const checks = [];
+
+  // 1) config 존재.
+  if (!fsImpl.existsSync(configPath)) {
+    checks.push({
+      name: 'config 파일',
+      ok: false,
+      message: `없음 — ${configPath}. \`token-weather telegram setup\` 으로 생성.`,
+    });
+    printChecks(log, checks);
+    process.exitCode = 1;
+    return { checks };
+  }
+  checks.push({ name: 'config 파일', ok: true, message: configPath });
+
+  // 2) chmod 권한.
+  try {
+    const stat = fsImpl.statSync(configPath);
+    const worldOrGroupBits = stat.mode & 0o077;
+    if (worldOrGroupBits !== 0) {
+      checks.push({
+        name: 'config 권한',
+        ok: 'warn',
+        message: `mode=${(stat.mode & 0o777).toString(8).padStart(3, '0')} — group/world 비트 노출. chmod 600 권장.`,
+      });
+    } else {
+      checks.push({ name: 'config 권한', ok: true, message: 'chmod 600 (group/world 차단)' });
+    }
+  } catch (err) {
+    checks.push({ name: 'config 권한', ok: false, message: `stat 실패: ${err?.message ?? err}` });
+  }
+
+  // 3) channels.telegram 키 검증.
+  let config;
+  try {
+    config = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
+  } catch (err) {
+    checks.push({ name: 'config JSON', ok: false, message: `parse 실패: ${err?.message ?? err}` });
+    printChecks(log, checks);
+    process.exitCode = 1;
+    return { checks };
+  }
+  const tg = config?.channels?.telegram;
+  if (!tg) {
+    checks.push({
+      name: 'channels.telegram',
+      ok: false,
+      message: '키 없음 — setup 미완료.',
+    });
+    printChecks(log, checks);
+    process.exitCode = 1;
+    return { checks };
+  }
+  checks.push({
+    name: 'channels.telegram.enabled',
+    ok: Boolean(tg.enabled),
+    message: tg.enabled ? 'true' : 'false (setup 미완료 또는 비활성화)',
+  });
+  checks.push({
+    name: 'channels.telegram.botToken',
+    ok: Boolean(tg.botToken),
+    message: tg.botToken ? '비어 있지 않음' : '비어 있음',
+  });
+  const allowedCount = Array.isArray(tg.allowedUserIds) ? tg.allowedUserIds.length : 0;
+  checks.push({
+    name: 'channels.telegram.allowedUserIds',
+    ok: allowedCount > 0,
+    message: `${allowedCount} 개`,
+  });
+
+  // 4) getMe 로 botToken 유효성.
+  if (tg.botToken) {
+    const validation = await validateBotToken(tg.botToken, { fetchFn });
+    checks.push({
+      name: 'getMe API',
+      ok: validation.ok,
+      message: validation.ok
+        ? `@${validation.botInfo?.username ?? '(unknown)'}`
+        : validation.error,
+    });
+  }
+
+  // 5) Linux: linger 상태.
+  if (platform === 'linux') {
+    try {
+      const user = process.env.USER ?? '';
+      const out = execImpl(`loginctl show-user "${user}" --property=Linger`);
+      const linger = /Linger=yes/.test(out);
+      checks.push({
+        name: 'systemd linger',
+        ok: linger ? true : 'warn',
+        message: linger
+          ? '활성화 (로그아웃 후에도 daemon 유지)'
+          : '비활성화 — `loginctl enable-linger "$USER"` 권장',
+      });
+    } catch {
+      // loginctl 미사용 환경 (alpine init / docker / WSL 일부) 은 정보 결여로 skip.
+    }
+  }
+
+  printChecks(log, checks);
+  if (checks.some((c) => c.ok === false)) {
+    process.exitCode = 1;
+  }
+  return { checks };
+}
+
+function printChecks(log, checks) {
+  log('▶ token-weather telegram check');
+  log('');
+  for (const c of checks) {
+    const icon = c.ok === true ? '✓' : c.ok === 'warn' ? '⚠' : '✗';
+    log(`  ${icon} ${c.name}: ${c.message}`);
+  }
+}
+
+/**
+ * `token-weather telegram check --help` 출력. Pure function.
+ */
+export function formatTelegramCheckHelp() {
+  return [
+    'token-weather telegram check',
+    '',
+    'Telegram 봇 설정 / token / linger 상태를 read-only 진단합니다.',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+    '',
+    '검사 항목:',
+    '  - config 파일 존재 / chmod 권한',
+    '  - channels.telegram.enabled / botToken / allowedUserIds 채워짐',
+    '  - Telegram Bot API getMe 로 botToken 유효성 (네트워크)',
+    '  - Linux 한정: systemd linger 활성화 (로그아웃 후 daemon 유지)',
+  ];
+}

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -15,8 +15,8 @@ import fs from 'node:fs';
 
 import { createBotServer } from './bot-server.js';
 import { buildDispatcher } from './dispatcher.js';
-import { runSetupSubcommand, formatTelegramSetupHelp } from './setup-subcommand.js';
-import { runCheckSubcommand, formatTelegramCheckHelp } from './check-subcommand.js';
+import { runSetupSubcommand } from './setup-subcommand.js';
+import { runCheckSubcommand } from './check-subcommand.js';
 
 export { createBotServer, handleTextMessage } from './bot-server.js';
 export { buildDispatcher } from './dispatcher.js';
@@ -29,11 +29,7 @@ export {
   formatPreChunksForTelegram,
   formatErrorForTelegram,
 } from './formatters.js';
-export {
-  validateBotToken,
-  generatePairingCode,
-  runPairingBot,
-} from './pairing.js';
+export { validateBotToken, generatePairingCode, runPairingBot } from './pairing.js';
 export {
   linuxSystemdUnit,
   macosLaunchAgent,

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -15,6 +15,8 @@ import fs from 'node:fs';
 
 import { createBotServer } from './bot-server.js';
 import { buildDispatcher } from './dispatcher.js';
+import { runSetupSubcommand, formatTelegramSetupHelp } from './setup-subcommand.js';
+import { runCheckSubcommand, formatTelegramCheckHelp } from './check-subcommand.js';
 
 export { createBotServer, handleTextMessage } from './bot-server.js';
 export { buildDispatcher } from './dispatcher.js';
@@ -27,6 +29,19 @@ export {
   formatPreChunksForTelegram,
   formatErrorForTelegram,
 } from './formatters.js';
+export {
+  validateBotToken,
+  generatePairingCode,
+  runPairingBot,
+} from './pairing.js';
+export {
+  linuxSystemdUnit,
+  macosLaunchAgent,
+  windowsTaskScheduler,
+  pickServiceTemplate,
+} from './os-service-templates.js';
+export { runSetupSubcommand, formatTelegramSetupHelp } from './setup-subcommand.js';
+export { runCheckSubcommand, formatTelegramCheckHelp } from './check-subcommand.js';
 
 let _activeServer = null;
 
@@ -76,6 +91,14 @@ export async function runTelegramCommand(argv, deps) {
     await runStartSubcommand(rest, deps);
     return;
   }
+  if (subcommand === 'setup') {
+    await runSetupSubcommand(rest, deps);
+    return;
+  }
+  if (subcommand === 'check') {
+    await runCheckSubcommand(rest, deps);
+    return;
+  }
   console.error(`알 수 없는 telegram 서브명령: ${subcommand}`);
   for (const line of formatTelegramHelp()) console.error(line);
   process.exitCode = 1;
@@ -91,9 +114,9 @@ export function formatTelegramHelp() {
     'Telegram 봇 daemon 으로 status / usage / doctor / auth list 명령을 원격 호출.',
     '',
     'Subcommands:',
+    '  setup    대화형 봇 토큰 등록 + 페어링 + OS service template 안내',
     '  start    Telegram 봇 long-poll daemon 시작 (foreground, Ctrl+C 종료)',
-    '',
-    'Phase 4 예정: setup (페어링 + OS service 템플릿), check (진단)',
+    '  check    설정 / token / linger 상태 read-only 진단',
     '',
     'Options:',
     '  -h, --help   이 도움말 출력',

--- a/packages/telegram/src/os-service-templates.js
+++ b/packages/telegram/src/os-service-templates.js
@@ -1,0 +1,150 @@
+/**
+ * OS 별 service unit / plist / task scheduler 템플릿 — `telegram setup` 의 print
+ * 대상.
+ *
+ * Phase 4 (#129) 의 UX 절충안 — 도구가 시스템 파일을 직접 작성하지 않고 사용자가
+ * 복사 / 붙여넣기로 활성화 가능한 명령 블록을 print 만 한다. 자동 등록은
+ * 후속 plan 의 `--auto-register` 플래그 (out of scope) 로 확장 여지.
+ *
+ * 본 모듈의 모든 함수는 pure — 절대 경로 / 명령 문자열만 가공한다. 파일 시스템
+ * 변경 없음.
+ */
+
+/**
+ * @typedef {object} ServiceTemplate
+ * @property {string} kind - 'systemd' | 'launchd' | 'taskscheduler'.
+ * @property {string} title - 사람-읽기 제목 ("Linux systemd --user unit" 등).
+ * @property {string[]} instructions - 사용자가 그대로 셸에 복사 / 붙여넣기 할 명령
+ *   블록. 한 줄에 한 명령 또는 multi-line heredoc.
+ */
+
+/**
+ * @typedef {object} TemplateInput
+ * @property {string} nodeBinPath - daemon 을 실행할 node 바이너리 절대 경로
+ *   (`process.execPath`).
+ * @property {string} cliScriptPath - `bin/token-weather.js` 절대 경로.
+ *   `process.argv[1]` 또는 cli 의 `import.meta.url` 에서 추출. 환경에 따라
+ *   nvm/fnm 의 그림자 경로일 수 있으므로 setup 재실행 시 갱신될 수 있음.
+ * @property {string} [homeDir] - 사용자 HOME 경로 (logs 위치 등에 사용).
+ *   미지정 시 `process.env.HOME`.
+ */
+
+/**
+ * Linux systemd `--user` unit 템플릿 + 활성화 명령.
+ *
+ * @param {TemplateInput} input
+ * @returns {ServiceTemplate}
+ */
+export function linuxSystemdUnit({ nodeBinPath, cliScriptPath }) {
+  const unitContent = [
+    '[Unit]',
+    'Description=Token Weather Telegram bot',
+    'After=network-online.target',
+    '',
+    '[Service]',
+    `ExecStart=${nodeBinPath} ${cliScriptPath} telegram start`,
+    'Restart=on-failure',
+    'RestartSec=5s',
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+  ].join('\n');
+  return {
+    kind: 'systemd',
+    title: 'Linux systemd --user unit (user-level, sudo 불필요)',
+    instructions: [
+      'mkdir -p ~/.config/systemd/user',
+      "cat > ~/.config/systemd/user/token-weather-bot.service <<'EOF'",
+      unitContent,
+      'EOF',
+      'systemctl --user daemon-reload',
+      'systemctl --user enable --now token-weather-bot.service',
+      '# 로그아웃 후에도 daemon 이 살아 있게 하려면:',
+      'loginctl enable-linger "$USER"',
+    ],
+  };
+}
+
+/**
+ * macOS launchd `LaunchAgent` 템플릿 + load 명령.
+ *
+ * @param {TemplateInput} input
+ * @returns {ServiceTemplate}
+ */
+export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
+  const home = homeDir ?? process.env.HOME ?? '~';
+  const plistContent = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"',
+    '  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<dict>',
+    '  <key>Label</key>',
+    '  <string>com.token-weather.bot</string>',
+    '  <key>ProgramArguments</key>',
+    '  <array>',
+    `    <string>${nodeBinPath}</string>`,
+    `    <string>${cliScriptPath}</string>`,
+    '    <string>telegram</string>',
+    '    <string>start</string>',
+    '  </array>',
+    '  <key>RunAtLoad</key>',
+    '  <true/>',
+    '  <key>KeepAlive</key>',
+    '  <true/>',
+    '  <key>StandardOutPath</key>',
+    `  <string>${home}/Library/Logs/token-weather-bot.log</string>`,
+    '  <key>StandardErrorPath</key>',
+    `  <string>${home}/Library/Logs/token-weather-bot-error.log</string>`,
+    '</dict>',
+    '</plist>',
+  ].join('\n');
+  return {
+    kind: 'launchd',
+    title: 'macOS LaunchAgent (user-level, sudo 불필요)',
+    instructions: [
+      'mkdir -p ~/Library/LaunchAgents',
+      "cat > ~/Library/LaunchAgents/com.token-weather.bot.plist <<'EOF'",
+      plistContent,
+      'EOF',
+      'launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist',
+      '# 종료하려면:',
+      'launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist',
+    ],
+  };
+}
+
+/**
+ * Windows Task Scheduler 등록 명령 (user task — sudo 불필요).
+ *
+ * @param {TemplateInput} input
+ * @returns {ServiceTemplate}
+ */
+export function windowsTaskScheduler({ nodeBinPath, cliScriptPath }) {
+  return {
+    kind: 'taskscheduler',
+    title: 'Windows Task Scheduler (user task, 관리자 권한 불필요)',
+    instructions: [
+      // cmd.exe 의 escape 규칙 — 경로에 공백 시 따옴표 필수.
+      'schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED ' +
+        `/TR "\\"${nodeBinPath}\\" \\"${cliScriptPath}\\" telegram start"`,
+      'rem 종료 / 제거하려면:',
+      'schtasks /End /TN "TokenWeatherBot"',
+      'schtasks /Delete /TN "TokenWeatherBot" /F',
+    ],
+  };
+}
+
+/**
+ * 현재 OS 에 맞는 템플릿을 자동 선택 — `process.platform` detect.
+ * 알려지지 않은 OS 면 systemd 를 기본 (linux 가정) 으로 반환.
+ *
+ * @param {TemplateInput} input
+ * @returns {ServiceTemplate}
+ */
+export function pickServiceTemplate(input) {
+  const platform = process.platform;
+  if (platform === 'darwin') return macosLaunchAgent(input);
+  if (platform === 'win32') return windowsTaskScheduler(input);
+  return linuxSystemdUnit(input);
+}

--- a/packages/telegram/src/pairing.js
+++ b/packages/telegram/src/pairing.js
@@ -8,6 +8,8 @@
  * 모든 외부 의존성 (fetch / Bot) 은 옵션으로 주입 가능 — 단위 테스트 친화.
  */
 
+import { randomInt } from 'node:crypto';
+
 import { Bot } from 'grammy';
 
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
@@ -44,6 +46,10 @@ export async function validateBotToken(botToken, options = {}) {
 /**
  * 1회용 페어링 코드 생성 — `TGW-XXXXXX` (대소문자 가독성 문자만).
  *
+ * 본 코드는 allowlist 가 비어 있는 setup 단계에서 최초 user_id 를 등록하는
+ * 경로의 1회용 authorization token 성격이라 `node:crypto.randomInt` 로 추출
+ * (Math.random 의 예측 가능한 PRNG 회피, PR #135 review).
+ *
  * @returns {string}
  */
 export function generatePairingCode() {
@@ -51,7 +57,7 @@ export function generatePairingCode() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
   let suffix = '';
   for (let i = 0; i < 6; i++) {
-    suffix += chars[Math.floor(Math.random() * chars.length)];
+    suffix += chars[randomInt(0, chars.length)];
   }
   return `TGW-${suffix}`;
 }

--- a/packages/telegram/src/pairing.js
+++ b/packages/telegram/src/pairing.js
@@ -91,7 +91,11 @@ export async function runPairingBot(botToken, expectedCode, options = {}) {
         ),
       );
     }, timeoutMs);
-    if (typeof timer?.unref === 'function') timer.unref();
+    // unref 는 production 에서만 의미 (polling 이 event loop 를 잡고 있으므로
+    // unref 가 무해). test 에서 mock bot 의 polling 이 keep-alive 안 하면 unref
+    // 가 timer-only 상태로 process 가 일찍 종료되어 pending promise 가 미해결로
+    // cancelled 됨. 따라서 기본 비활성화, 옵션으로만 활성화.
+    if (options.unrefTimer && typeof timer?.unref === 'function') timer.unref();
 
     bot.on?.('message:text', async (ctx) => {
       if (settled) return;

--- a/packages/telegram/src/pairing.js
+++ b/packages/telegram/src/pairing.js
@@ -1,0 +1,147 @@
+/**
+ * Telegram setup 의 페어링 helpers — bot token 검증 + 1회용 페어링 daemon.
+ *
+ * Phase 4 (#129). createBotServer 와 별도 — 페어링은 allowlist 없이 raw `/pair
+ * <code>` 메시지를 받아 chat_id 를 캡처해야 하므로 (사용자가 allowlist 등록을
+ * 받지 않은 첫 메시지), 별도 1회용 daemon 패턴.
+ *
+ * 모든 외부 의존성 (fetch / Bot) 은 옵션으로 주입 가능 — 단위 테스트 친화.
+ */
+
+import { Bot } from 'grammy';
+
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
+const DEFAULT_PAIRING_TIMEOUT_MS = 300_000; // 5 분.
+
+/**
+ * Telegram Bot API `getMe` 로 bot token 유효성 검증.
+ *
+ * @param {string} botToken
+ * @param {{
+ *   fetchFn?: typeof fetch,
+ *   apiBase?: string,
+ * }} [options]
+ * @returns {Promise<{ ok: true, botInfo: object } | { ok: false, error: string }>}
+ */
+export async function validateBotToken(botToken, options = {}) {
+  if (!botToken || typeof botToken !== 'string') {
+    return { ok: false, error: 'bot token is empty' };
+  }
+  const fetchFn = options.fetchFn ?? fetch;
+  const apiBase = options.apiBase ?? TELEGRAM_API_BASE;
+  try {
+    const res = await fetchFn(`${apiBase}/bot${botToken}/getMe`);
+    const body = await res.json();
+    if (!body || body.ok !== true) {
+      return { ok: false, error: body?.description ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, botInfo: body.result };
+  } catch (err) {
+    return { ok: false, error: err?.message ?? String(err) };
+  }
+}
+
+/**
+ * 1회용 페어링 코드 생성 — `TGW-XXXXXX` (대소문자 가독성 문자만).
+ *
+ * @returns {string}
+ */
+export function generatePairingCode() {
+  // 0/1/I/O 제외 — OCR / 시각적 혼동 회피.
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let suffix = '';
+  for (let i = 0; i < 6; i++) {
+    suffix += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return `TGW-${suffix}`;
+}
+
+/**
+ * 페어링용 1회 daemon 을 띄워 `/pair <code>` 메시지의 `ctx.from.id` 를 캡처.
+ *
+ * - 일치하는 code 가 도착하면 resolve.
+ * - 일치하지 않는 code 는 ctx.reply 로 안내 후 대기 지속.
+ * - timeoutMs 안에 도착 안 하면 reject.
+ *
+ * @param {string} botToken
+ * @param {string} expectedCode
+ * @param {{
+ *   timeoutMs?: number,
+ *   botFactory?: (token: string) => object,
+ *   logger?: { log?: (msg: string) => void },
+ * }} [options]
+ * @returns {Promise<{ userId: string, username: string | null }>}
+ */
+export async function runPairingBot(botToken, expectedCode, options = {}) {
+  if (!botToken) throw new Error('runPairingBot: botToken is required');
+  if (!expectedCode) throw new Error('runPairingBot: expectedCode is required');
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PAIRING_TIMEOUT_MS;
+  const bot = options.botFactory ? options.botFactory(botToken) : new Bot(botToken);
+  const log = options.logger?.log ?? ((msg) => console.log(msg));
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      void bot.stop?.();
+      reject(
+        new Error(
+          `pairing timeout (${Math.floor(timeoutMs / 1000)}s) — /pair 명령이 도착하지 않았습니다.`,
+        ),
+      );
+    }, timeoutMs);
+    if (typeof timer?.unref === 'function') timer.unref();
+
+    bot.on?.('message:text', async (ctx) => {
+      if (settled) return;
+      const text = ctx?.message?.text?.trim?.() ?? '';
+      const match = text.match(/^\/pair\s+(\S+)/);
+      if (!match) return;
+      const submittedCode = match[1];
+      if (submittedCode !== expectedCode) {
+        await ctx?.reply?.('코드가 일치하지 않습니다. 다시 확인해 주세요.').catch(() => {});
+        return;
+      }
+      const userId = ctx?.from?.id;
+      if (userId == null) {
+        await ctx?.reply?.('user_id 를 인식할 수 없습니다.').catch(() => {});
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      await ctx?.reply?.('✓ 페어링 완료. 터미널을 확인하세요.').catch(() => {});
+      void bot.stop?.();
+      resolve({
+        userId: String(userId),
+        username: ctx?.from?.username ?? null,
+      });
+    });
+
+    bot.catch?.((errCtx) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(errCtx?.error ?? errCtx);
+    });
+
+    Promise.resolve(bot.init?.())
+      .then(() => {
+        log(
+          `[token-weather/telegram] 페어링 daemon 시작 — 봇에 \`/pair ${expectedCode}\` 입력 대기 중...`,
+        );
+        bot.start?.({ drop_pending_updates: true })?.catch?.((err) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          reject(err);
+        });
+      })
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+  });
+}

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -31,6 +31,23 @@ const DIVIDER = '━━━━━━━━━━━━━━━━━━━━━
  */
 
 /**
+ * 두 객체를 재귀적으로 merge — `override` 가 `base` 보다 우선이지만, base 의
+ * 키도 보존된다. PR #135 review — config 가 없을 때 `telegram setup` 이 default
+ * config 의 providers / sync / defaults 같은 키를 누락하면 setup 직후 status /
+ * usage 가 provider disabled 상태가 되는 문제 해소.
+ */
+function deepMerge(base, override) {
+  if (typeof base !== 'object' || base === null) return override;
+  if (typeof override !== 'object' || override === null) return override;
+  if (Array.isArray(base) || Array.isArray(override)) return override;
+  const result = { ...base };
+  for (const key of Object.keys(override)) {
+    result[key] = key in base ? deepMerge(base[key], override[key]) : override[key];
+  }
+  return result;
+}
+
+/**
  * `token-weather telegram setup` 의 dispatch 진입점.
  *
  * @param {string[]} args
@@ -106,12 +123,16 @@ export async function runSetupSubcommand(args, deps, options = {}) {
     }`,
   );
 
-  // 5) config read + 갱신 + write + chmod 600.
+  // 5) config read + default merge + 갱신 + write + chmod 600.
+  //    PR #135 review — config 가 없을 때 partial 만 생성하면 setup 직후 status /
+  //    usage 가 provider disabled 상태가 되는 문제. deps.createDefaultConfig 로
+  //    base 를 만들고 기존 config 를 deepMerge 한 뒤 channels.telegram 만 override.
   const configPath = deps.resolveAgentConfigPath();
-  let config = {};
+  const base = typeof deps.createDefaultConfig === 'function' ? deps.createDefaultConfig() : {};
+  let existing = {};
   if (fsImpl.existsSync(configPath)) {
     try {
-      config = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
+      existing = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
     } catch (err) {
       errorLog(`✗ 설정 파일 파싱 실패: ${configPath}`);
       errorLog(`  ${err?.message ?? err}`);
@@ -119,6 +140,7 @@ export async function runSetupSubcommand(args, deps, options = {}) {
       return;
     }
   }
+  const config = deepMerge(base, existing);
   // user_id 는 array number 또는 string — Number 변환 시도, 실패 시 원본 유지.
   const numericId = Number(pairingResult.userId);
   const storedId = Number.isFinite(numericId) ? numericId : pairingResult.userId;

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -153,13 +153,19 @@ export async function runSetupSubcommand(args, deps, options = {}) {
   };
   fsImpl.mkdirSync(path.dirname(configPath), { recursive: true });
   fsImpl.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  let chmodApplied = true;
   try {
     fsImpl.chmodSync(configPath, 0o600);
   } catch (err) {
+    chmodApplied = false;
     errorLog(`⚠ chmod 600 적용 실패 (계속 진행): ${err?.message ?? err}`);
   }
   log('');
-  log(`✓ 설정 저장: ${configPath} (chmod 600)`);
+  log(
+    `✓ 설정 저장: ${configPath}${
+      chmodApplied ? ' (chmod 600)' : ' (chmod 미적용 — `telegram check` 로 권한 확인 필요)'
+    }`,
+  );
 
   // 6) OS service template print.
   const tmpl = pickServiceTemplate({

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -39,8 +39,10 @@ const DIVIDER = '━━━━━━━━━━━━━━━━━━━━━
  * @returns {Promise<void>}
  */
 export async function runSetupSubcommand(args, deps, options = {}) {
+  const log = options.log ?? ((msg) => console.log(msg));
+  const errorLog = options.errorLog ?? ((msg) => console.error(msg));
   if (Array.isArray(args) && (args.includes('--help') || args.includes('-h'))) {
-    for (const line of formatTelegramSetupHelp()) console.log(line);
+    for (const line of formatTelegramSetupHelp()) log(line);
     return;
   }
   if (!deps?.resolveAgentConfigPath) {
@@ -49,8 +51,6 @@ export async function runSetupSubcommand(args, deps, options = {}) {
 
   const promptFn = options.promptFn ?? defaultPromptFn;
   const fetchFn = options.fetchFn ?? fetch;
-  const log = options.log ?? ((msg) => console.log(msg));
-  const errorLog = options.errorLog ?? ((msg) => console.error(msg));
   const fsImpl = options.fsImpl ?? fs;
 
   log('▶ token-weather telegram setup');

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -1,0 +1,191 @@
+/**
+ * `telegram setup` 서브명령 구현 — 대화형 페어링 + config 저장 + OS service
+ * template print 흐름.
+ *
+ * Phase 4 (#129). 모든 외부 의존성 (prompt / fetch / Bot / fs) 은 옵션으로 주입
+ * 가능 — 단위 테스트 친화. process.exitCode 만 부수효과로 두고 throw 는 자제
+ * (사용자 친화 메시지 우선).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+
+import { validateBotToken, generatePairingCode, runPairingBot } from './pairing.js';
+import { pickServiceTemplate } from './os-service-templates.js';
+
+const DIVIDER = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
+
+/**
+ * @typedef {object} SetupOptions
+ * @property {(question: string) => Promise<string>} [promptFn]
+ *   대화형 입력 함수. 미지정 시 node:readline 사용.
+ * @property {typeof fetch} [fetchFn]
+ *   getMe API 호출용. 미지정 시 global fetch.
+ * @property {(token: string) => object} [botFactory]
+ *   페어링 daemon 의 grammy Bot mock 주입 (테스트 용).
+ * @property {(msg: string) => void} [log] - stdout hook.
+ * @property {(msg: string) => void} [errorLog] - stderr hook.
+ * @property {{ readFileSync: Function, writeFileSync: Function, mkdirSync: Function,
+ *   chmodSync: Function, existsSync: Function }} [fsImpl] - fs API mock.
+ */
+
+/**
+ * `token-weather telegram setup` 의 dispatch 진입점.
+ *
+ * @param {string[]} args
+ * @param {{ resolveAgentConfigPath: () => string, cliScriptPath?: string }} deps
+ * @param {SetupOptions} [options]
+ * @returns {Promise<void>}
+ */
+export async function runSetupSubcommand(args, deps, options = {}) {
+  if (Array.isArray(args) && (args.includes('--help') || args.includes('-h'))) {
+    for (const line of formatTelegramSetupHelp()) console.log(line);
+    return;
+  }
+  if (!deps?.resolveAgentConfigPath) {
+    throw new Error('runSetupSubcommand: deps.resolveAgentConfigPath 가 필요합니다.');
+  }
+
+  const promptFn = options.promptFn ?? defaultPromptFn;
+  const fetchFn = options.fetchFn ?? fetch;
+  const log = options.log ?? ((msg) => console.log(msg));
+  const errorLog = options.errorLog ?? ((msg) => console.error(msg));
+  const fsImpl = options.fsImpl ?? fs;
+
+  log('▶ token-weather telegram setup');
+  log('');
+
+  // 1) bot token 입력.
+  const rawToken = await promptFn(
+    'BotFather 에서 발급받은 봇 토큰을 입력하세요 (예: 1234567890:ABC...):\n> ',
+  );
+  const botToken = (rawToken ?? '').trim();
+  if (!botToken) {
+    errorLog('빈 토큰입니다. setup 을 취소합니다.');
+    process.exitCode = 1;
+    return;
+  }
+
+  // 2) 토큰 검증.
+  log('');
+  log('▶ Telegram Bot API getMe 호출로 토큰 검증...');
+  const validation = await validateBotToken(botToken, { fetchFn });
+  if (!validation.ok) {
+    errorLog(`✗ 토큰 검증 실패: ${validation.error}`);
+    process.exitCode = 1;
+    return;
+  }
+  log(`✓ 봇 핸들: @${validation.botInfo.username}`);
+
+  // 3) 1회용 코드 + 페어링 안내.
+  const code = generatePairingCode();
+  log('');
+  log(`▶ Telegram 에서 @${validation.botInfo.username} 봇에게 다음 명령을 보내세요:`);
+  log('');
+  log(`    /pair ${code}`);
+  log('');
+  log('   (5 분 안에 입력하지 않으면 setup 이 취소됩니다.)');
+
+  // 4) 페어링 daemon 부팅 + chat_id 캡처.
+  let pairingResult;
+  try {
+    pairingResult = await runPairingBot(botToken, code, {
+      botFactory: options.botFactory,
+      logger: { log },
+    });
+  } catch (err) {
+    errorLog(`✗ 페어링 실패: ${err?.message ?? err}`);
+    process.exitCode = 1;
+    return;
+  }
+  log('');
+  log(
+    `✓ 페어링 완료 — user_id: ${pairingResult.userId}${
+      pairingResult.username ? ` (@${pairingResult.username})` : ''
+    }`,
+  );
+
+  // 5) config read + 갱신 + write + chmod 600.
+  const configPath = deps.resolveAgentConfigPath();
+  let config = {};
+  if (fsImpl.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fsImpl.readFileSync(configPath, 'utf8'));
+    } catch (err) {
+      errorLog(`✗ 설정 파일 파싱 실패: ${configPath}`);
+      errorLog(`  ${err?.message ?? err}`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+  // user_id 는 array number 또는 string — Number 변환 시도, 실패 시 원본 유지.
+  const numericId = Number(pairingResult.userId);
+  const storedId = Number.isFinite(numericId) ? numericId : pairingResult.userId;
+  config.channels = config.channels ?? {};
+  config.channels.telegram = {
+    ...(config.channels.telegram ?? {}),
+    enabled: true,
+    botToken,
+    allowedUserIds: [storedId],
+  };
+  fsImpl.mkdirSync(path.dirname(configPath), { recursive: true });
+  fsImpl.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  try {
+    fsImpl.chmodSync(configPath, 0o600);
+  } catch (err) {
+    errorLog(`⚠ chmod 600 적용 실패 (계속 진행): ${err?.message ?? err}`);
+  }
+  log('');
+  log(`✓ 설정 저장: ${configPath} (chmod 600)`);
+
+  // 6) OS service template print.
+  const tmpl = pickServiceTemplate({
+    nodeBinPath: process.execPath,
+    cliScriptPath: deps.cliScriptPath ?? process.argv[1] ?? '',
+    homeDir: process.env.HOME,
+  });
+  log('');
+  log(DIVIDER);
+  log(`부팅 후 자동 시작 (선택사항) — ${tmpl.title}:`);
+  log('');
+  for (const line of tmpl.instructions) log(`  ${line}`);
+  log('');
+  log(DIVIDER);
+  log('');
+  log('지금 한 번만 실행하려면: `token-weather telegram start`');
+}
+
+/**
+ * Default prompt — node:readline 사용. process.stdin / stdout 직접.
+ */
+function defaultPromptFn(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+/**
+ * `token-weather telegram setup --help` 출력. Pure function.
+ */
+export function formatTelegramSetupHelp() {
+  return [
+    'token-weather telegram setup',
+    '',
+    '대화형으로 봇 토큰 등록 + 페어링 + 설정 저장 + OS service template 안내.',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+    '',
+    '흐름:',
+    '  1. BotFather 발급 토큰 입력',
+    '  2. getMe API 로 토큰 검증',
+    '  3. 1회용 코드 생성 → Telegram 봇에 `/pair <code>` 입력',
+    '  4. user_id 수신 → config 갱신 (~/.config/token-weather/config.json, chmod 600)',
+    '  5. OS 별 service template 출력 (복사 / 붙여넣기로 부팅 자동 시작 설정)',
+  ];
+}

--- a/packages/telegram/test/check-subcommand.test.js
+++ b/packages/telegram/test/check-subcommand.test.js
@@ -135,7 +135,12 @@ describe('runCheckSubcommand (Phase 4)', () => {
           status: 200,
           json: async () => ({ ok: true, result: { username: 'B' } }),
         }),
-        execImpl: () => 'Linger=no',
+        execImpl: (cmd, args) => {
+          // PR #135 review — execImpl 시그니처가 (cmd, args[]) 로 갱신됨을 단언.
+          assert.equal(cmd, 'loginctl');
+          assert.deepEqual(args, ['show-user', process.env.USER ?? '', '--property=Linger']);
+          return 'Linger=no';
+        },
         platform: 'linux',
       },
     );

--- a/packages/telegram/test/check-subcommand.test.js
+++ b/packages/telegram/test/check-subcommand.test.js
@@ -1,0 +1,158 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runCheckSubcommand, formatTelegramCheckHelp } from '../src/check-subcommand.js';
+
+function makeLogger() {
+  const logs = [];
+  return { logs, log: (m) => logs.push(m) };
+}
+
+function makeMockFs(files, mode = 0o100600) {
+  return {
+    existsSync: (p) => files.has(p),
+    readFileSync: (p) => {
+      if (!files.has(p)) throw new Error('not found');
+      return files.get(p);
+    },
+    statSync: () => ({ mode }),
+  };
+}
+
+describe('runCheckSubcommand (Phase 4)', () => {
+  it('--help 안내 출력', async () => {
+    const { logs, log } = makeLogger();
+    await runCheckSubcommand(['--help'], { resolveAgentConfigPath: () => '/cfg' }, { log });
+    assert.ok(logs.some((l) => l.includes('telegram check')));
+  });
+
+  it('config 파일 없음 → ✗ + exit 1', async () => {
+    process.exitCode = 0;
+    const { log } = makeLogger();
+    const r = await runCheckSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg.json' },
+      { log, fsImpl: makeMockFs(new Map()), platform: 'linux' },
+    );
+    assert.equal(r.checks[0].name, 'config 파일');
+    assert.equal(r.checks[0].ok, false);
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+
+  it('정상 흐름 — 모든 검사 통과', async () => {
+    process.exitCode = 0;
+    const { log } = makeLogger();
+    const cfg = JSON.stringify({
+      channels: {
+        telegram: {
+          enabled: true,
+          botToken: '123:fake',
+          allowedUserIds: [42],
+        },
+      },
+    });
+    const r = await runCheckSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg.json' },
+      {
+        log,
+        fsImpl: makeMockFs(new Map([['/cfg.json', cfg]])),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'TokenWeatherBot' } }),
+        }),
+        platform: 'darwin', // skip linger 검사.
+      },
+    );
+    // ✗ 없음.
+    assert.equal(
+      r.checks.some((c) => c.ok === false),
+      false,
+    );
+    // botToken 통과 + getMe 통과.
+    assert.ok(r.checks.some((c) => c.name === 'getMe API' && c.ok === true));
+    assert.equal(process.exitCode, 0);
+  });
+
+  it('chmod 권한 group/world 노출 시 warn (exit 0 유지)', async () => {
+    process.exitCode = 0;
+    const { log } = makeLogger();
+    const cfg = JSON.stringify({
+      channels: { telegram: { enabled: true, botToken: '123:fake', allowedUserIds: [42] } },
+    });
+    const r = await runCheckSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg.json' },
+      {
+        log,
+        fsImpl: makeMockFs(new Map([['/cfg.json', cfg]]), 0o100644),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        platform: 'darwin',
+      },
+    );
+    const permCheck = r.checks.find((c) => c.name === 'config 권한');
+    assert.equal(permCheck.ok, 'warn');
+    assert.equal(process.exitCode, 0, 'warn 은 exit code 영향 없음');
+  });
+
+  it('enabled=false 면 ✗ + exit 1', async () => {
+    process.exitCode = 0;
+    const { log } = makeLogger();
+    const cfg = JSON.stringify({
+      channels: { telegram: { enabled: false, botToken: '', allowedUserIds: [] } },
+    });
+    const r = await runCheckSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg.json' },
+      {
+        log,
+        fsImpl: makeMockFs(new Map([['/cfg.json', cfg]])),
+        platform: 'darwin',
+      },
+    );
+    assert.ok(r.checks.some((c) => c.name.includes('enabled') && c.ok === false));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+
+  it('Linux + linger 비활성화 시 warn', async () => {
+    process.exitCode = 0;
+    const { log } = makeLogger();
+    const cfg = JSON.stringify({
+      channels: { telegram: { enabled: true, botToken: '123:fake', allowedUserIds: [42] } },
+    });
+    const r = await runCheckSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg.json' },
+      {
+        log,
+        fsImpl: makeMockFs(new Map([['/cfg.json', cfg]])),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        execImpl: () => 'Linger=no',
+        platform: 'linux',
+      },
+    );
+    const lingerCheck = r.checks.find((c) => c.name === 'systemd linger');
+    assert.equal(lingerCheck.ok, 'warn');
+    assert.equal(process.exitCode, 0);
+  });
+});
+
+describe('formatTelegramCheckHelp', () => {
+  it('첫 줄이 token-weather telegram check', () => {
+    assert.match(formatTelegramCheckHelp()[0], /^token-weather telegram check$/);
+  });
+  it('검사 항목 목록 포함', () => {
+    const text = formatTelegramCheckHelp().join('\n');
+    assert.match(text, /config 파일 존재/);
+    assert.match(text, /getMe/);
+    assert.match(text, /linger/);
+  });
+});

--- a/packages/telegram/test/os-service-templates.test.js
+++ b/packages/telegram/test/os-service-templates.test.js
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  linuxSystemdUnit,
+  macosLaunchAgent,
+  windowsTaskScheduler,
+  pickServiceTemplate,
+} from '../src/os-service-templates.js';
+
+const INPUT = {
+  nodeBinPath: '/usr/bin/node',
+  cliScriptPath: '/home/u/.nvm/versions/node/v20/lib/node_modules/@token-weather/cli/bin/token-weather.js',
+  homeDir: '/Users/u',
+};
+
+describe('linuxSystemdUnit (Phase 4)', () => {
+  const tmpl = linuxSystemdUnit(INPUT);
+
+  it('kind / title 정확', () => {
+    assert.equal(tmpl.kind, 'systemd');
+    assert.match(tmpl.title, /systemd/);
+  });
+
+  it('mkdir + cat heredoc + systemctl 활성화 명령 모두 포함', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.match(text, /mkdir -p ~\/\.config\/systemd\/user/);
+    assert.match(text, /token-weather-bot\.service/);
+    assert.match(text, /systemctl --user daemon-reload/);
+    assert.match(text, /systemctl --user enable --now/);
+    assert.match(text, /loginctl enable-linger/);
+  });
+
+  it('ExecStart 에 nodeBinPath + cliScriptPath + "telegram start" 포함', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.match(text, /ExecStart=\/usr\/bin\/node .* telegram start/);
+    assert.ok(text.includes(INPUT.cliScriptPath));
+  });
+});
+
+describe('macosLaunchAgent (Phase 4)', () => {
+  const tmpl = macosLaunchAgent(INPUT);
+
+  it('kind / title 정확', () => {
+    assert.equal(tmpl.kind, 'launchd');
+    assert.match(tmpl.title, /LaunchAgent/);
+  });
+
+  it('plist 의 ProgramArguments + RunAtLoad + KeepAlive 포함', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.match(text, /com\.token-weather\.bot/);
+    assert.match(text, /<key>RunAtLoad<\/key>/);
+    assert.match(text, /<key>KeepAlive<\/key>/);
+    assert.ok(text.includes(`<string>${INPUT.nodeBinPath}</string>`));
+    assert.ok(text.includes(`<string>${INPUT.cliScriptPath}</string>`));
+  });
+
+  it('log path 가 homeDir 기준', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.ok(text.includes('/Users/u/Library/Logs/token-weather-bot.log'));
+  });
+
+  it('launchctl bootstrap 명령 포함', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.match(text, /launchctl bootstrap "gui\/\$\(id -u\)"/);
+  });
+});
+
+describe('windowsTaskScheduler (Phase 4)', () => {
+  const tmpl = windowsTaskScheduler(INPUT);
+
+  it('kind / title 정확', () => {
+    assert.equal(tmpl.kind, 'taskscheduler');
+    assert.match(tmpl.title, /Task Scheduler/);
+  });
+
+  it('schtasks /Create + ONLOGON + LIMITED 포함', () => {
+    const text = tmpl.instructions.join('\n');
+    assert.match(text, /schtasks \/Create/);
+    assert.match(text, /\/SC ONLOGON/);
+    assert.match(text, /\/RL LIMITED/);
+    assert.match(text, /telegram start/);
+  });
+
+  it('경로 따옴표 escape — cmd.exe 호환', () => {
+    const text = tmpl.instructions.join('\n');
+    // \\" 로 escape 되어 cmd 가 따옴표 인식.
+    assert.match(text, /\\"\/usr\/bin\/node\\"/);
+  });
+});
+
+describe('pickServiceTemplate (Phase 4)', () => {
+  it('현재 OS 에 맞는 템플릿을 자동 선택', () => {
+    const tmpl = pickServiceTemplate(INPUT);
+    // 호스트 OS 가 macOS/Linux/Windows 중 어느 것이든 알려진 kind 반환.
+    assert.ok(['systemd', 'launchd', 'taskscheduler'].includes(tmpl.kind));
+  });
+});

--- a/packages/telegram/test/os-service-templates.test.js
+++ b/packages/telegram/test/os-service-templates.test.js
@@ -10,7 +10,8 @@ import {
 
 const INPUT = {
   nodeBinPath: '/usr/bin/node',
-  cliScriptPath: '/home/u/.nvm/versions/node/v20/lib/node_modules/@token-weather/cli/bin/token-weather.js',
+  cliScriptPath:
+    '/home/u/.nvm/versions/node/v20/lib/node_modules/@token-weather/cli/bin/token-weather.js',
   homeDir: '/Users/u',
 };
 

--- a/packages/telegram/test/pairing.test.js
+++ b/packages/telegram/test/pairing.test.js
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { validateBotToken, generatePairingCode, runPairingBot } from '../src/pairing.js';
+
+describe('validateBotToken (Phase 4)', () => {
+  it('비어 있는 token 은 ok=false', async () => {
+    const r1 = await validateBotToken('');
+    const r2 = await validateBotToken(null);
+    assert.equal(r1.ok, false);
+    assert.equal(r2.ok, false);
+  });
+
+  it('getMe 가 ok=true 응답 시 botInfo 반환', async () => {
+    const fetchFn = async (url) => {
+      assert.match(url, /\/bot123:fake\/getMe$/);
+      return {
+        status: 200,
+        json: async () => ({ ok: true, result: { username: 'TokenWeatherBot' } }),
+      };
+    };
+    const r = await validateBotToken('123:fake', { fetchFn });
+    assert.equal(r.ok, true);
+    assert.equal(r.botInfo.username, 'TokenWeatherBot');
+  });
+
+  it('getMe 가 ok=false 응답 시 description 을 error 로', async () => {
+    const fetchFn = async () => ({
+      status: 401,
+      json: async () => ({ ok: false, description: 'Unauthorized' }),
+    });
+    const r = await validateBotToken('123:bad', { fetchFn });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Unauthorized/);
+  });
+
+  it('fetch 가 throw 하면 ok=false + error', async () => {
+    const fetchFn = async () => {
+      throw new Error('network down');
+    };
+    const r = await validateBotToken('123:any', { fetchFn });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /network down/);
+  });
+});
+
+describe('generatePairingCode (Phase 4)', () => {
+  it('TGW-XXXXXX 형식', () => {
+    const code = generatePairingCode();
+    assert.match(code, /^TGW-[A-Z2-9]{6}$/);
+  });
+
+  it('호출마다 다른 결과 (확률적)', () => {
+    const codes = new Set();
+    for (let i = 0; i < 20; i++) codes.add(generatePairingCode());
+    assert.ok(codes.size > 5, '20 호출 중 적어도 6 개 unique');
+  });
+
+  it('혼동되는 문자 (0/1/I/O) 제외', () => {
+    // 충분히 많은 호출에서 한 번이라도 등장 시 fail — 확률적이지만 안전 마진.
+    for (let i = 0; i < 100; i++) {
+      const code = generatePairingCode();
+      assert.equal(code.includes('0'), false);
+      assert.equal(code.includes('1'), false);
+      assert.equal(code.includes('I'), false);
+      assert.equal(code.includes('O'), false);
+    }
+  });
+});
+
+function makeMockBot() {
+  let messageHandler = null;
+  let catchHandler = null;
+  let stopped = false;
+  let started = false;
+  const replies = [];
+  return {
+    init: async () => {},
+    on: (event, handler) => {
+      if (event === 'message:text') messageHandler = handler;
+    },
+    catch: (handler) => {
+      catchHandler = handler;
+    },
+    start: () => new Promise(() => {}), // long-running, never resolves.
+    stop: async () => {
+      stopped = true;
+    },
+    // 테스트가 메시지 발사용.
+    _fire: async (ctx) => {
+      if (!messageHandler) throw new Error('handler not registered');
+      await messageHandler(ctx);
+    },
+    _fireError: (err) => {
+      catchHandler?.({ error: err });
+    },
+    get stopped() {
+      return stopped;
+    },
+    get started() {
+      return started;
+    },
+    get replies() {
+      return replies;
+    },
+  };
+}
+
+function makeCtx(text, { from } = {}) {
+  const replies = [];
+  return {
+    message: { text },
+    from,
+    reply: async (msg) => {
+      replies.push(msg);
+    },
+    replies,
+  };
+}
+
+describe('runPairingBot (Phase 4)', () => {
+  it('일치 code + user_id 있으면 resolve + bot.stop', async () => {
+    const mock = makeMockBot();
+    const pending = runPairingBot('123:fake', 'TGW-ABC123', {
+      botFactory: () => mock,
+      logger: { log: () => {} },
+    });
+    // bot.init 가 microtask 단위라 setImmediate / setTimeout 으로 yield.
+    await new Promise((r) => setImmediate(r));
+    const ctx = makeCtx('/pair TGW-ABC123', { from: { id: 42, username: 'alice' } });
+    await mock._fire(ctx);
+    const result = await pending;
+    assert.equal(result.userId, '42');
+    assert.equal(result.username, 'alice');
+    assert.equal(mock.stopped, true);
+    assert.ok(ctx.replies.some((m) => m.includes('페어링 완료')));
+  });
+
+  it('일치하지 않는 code 는 안내 + 대기 지속', async () => {
+    const mock = makeMockBot();
+    const pending = runPairingBot('123:fake', 'TGW-ABC123', {
+      botFactory: () => mock,
+      logger: { log: () => {} },
+      timeoutMs: 200,
+    });
+    await new Promise((r) => setImmediate(r));
+    const ctx = makeCtx('/pair TGW-WRONG', { from: { id: 42 } });
+    await mock._fire(ctx);
+    assert.ok(ctx.replies.some((m) => m.includes('코드가 일치하지 않습니다')));
+    assert.equal(mock.stopped, false);
+    // pending 은 결국 timeout reject.
+    await assert.rejects(() => pending, /pairing timeout/);
+  });
+
+  it('timeout 시 reject + bot.stop', async () => {
+    const mock = makeMockBot();
+    await assert.rejects(
+      () =>
+        runPairingBot('123:fake', 'TGW-XYZ789', {
+          botFactory: () => mock,
+          logger: { log: () => {} },
+          timeoutMs: 50,
+        }),
+      /pairing timeout/,
+    );
+    assert.equal(mock.stopped, true);
+  });
+
+  it('botToken / expectedCode 없으면 throw', async () => {
+    await assert.rejects(() => runPairingBot('', 'CODE'), /botToken/);
+    await assert.rejects(() => runPairingBot('TOKEN', ''), /expectedCode/);
+  });
+});

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -201,7 +201,9 @@ describe('runSetupSubcommand (Phase 4)', () => {
     );
     await new Promise((r) => setImmediate(r));
     await mock.fire({
-      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
       from: { id: 7 },
       reply: async () => {},
     });

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -14,7 +14,7 @@ function makeLogger() {
   };
 }
 
-function makeMockFs(initial = {}) {
+function makeMockFs(initial = {}, { chmodThrows = false } = {}) {
   const files = new Map();
   for (const [k, v] of Object.entries(initial)) files.set(k, v);
   let chmodCalls = [];
@@ -30,6 +30,7 @@ function makeMockFs(initial = {}) {
       },
       mkdirSync: () => {},
       chmodSync: (p, mode) => {
+        if (chmodThrows) throw new Error('EPERM: chmod not supported');
         chmodCalls.push({ path: p, mode });
       },
       statSync: (p) => {
@@ -173,6 +174,46 @@ describe('runSetupSubcommand (Phase 4)', () => {
     assert.match(out, /부팅 후 자동 시작/);
     assert.match(out, /token-weather telegram start/);
     assert.equal(process.exitCode, 0);
+  });
+
+  it('chmod 실패 시 안내 메시지 정합 (PR #135 review)', async () => {
+    process.exitCode = 0;
+    const { logs, errors, log, errorLog } = makeLogger();
+    const mockFs = makeMockFs({}, { chmodThrows: true });
+    const mock = makeMockBot();
+    const setupPromise = runSetupSubcommand(
+      [],
+      {
+        resolveAgentConfigPath: () => '/test/config.json',
+        createDefaultConfig: () => ({ version: 1, providers: {} }),
+      },
+      {
+        promptFn: async () => '123:fake',
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        log,
+        errorLog,
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    await mock.fire({
+      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      from: { id: 7 },
+      reply: async () => {},
+    });
+    await setupPromise;
+    // chmod 실패 warning + 저장 메시지가 `(chmod 미적용 — ...)` 표기.
+    assert.ok(errors.some((e) => e.includes('chmod 600 적용 실패')));
+    assert.ok(logs.some((l) => l.includes('chmod 미적용')));
+    assert.equal(
+      logs.some((l) => l.includes('(chmod 600)')),
+      false,
+      'chmod 실패 시 (chmod 600) 표기 금지',
+    );
   });
 
   it('기존 config 의 다른 키 보존 + channels.telegram 만 갱신', async () => {

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -118,7 +118,14 @@ describe('runSetupSubcommand (Phase 4)', () => {
     const mock = makeMockBot();
     const setupPromise = runSetupSubcommand(
       [],
-      { resolveAgentConfigPath: () => '/test/config.json', cliScriptPath: '/cli/bin' },
+      {
+        resolveAgentConfigPath: () => '/test/config.json',
+        cliScriptPath: '/cli/bin',
+        createDefaultConfig: () => ({
+          version: 1,
+          providers: { codex: { enabled: true }, claude: { enabled: true } },
+        }),
+      },
       {
         promptFn: async () => '123:fake',
         fetchFn: async () => ({
@@ -152,6 +159,11 @@ describe('runSetupSubcommand (Phase 4)', () => {
     assert.equal(parsed.channels.telegram.enabled, true);
     assert.equal(parsed.channels.telegram.botToken, '123:fake');
     assert.deepEqual(parsed.channels.telegram.allowedUserIds, [42]);
+    // PR #135 review — default config 기반이라 providers 도 채워짐 (setup 직후
+    // status/usage 가 disabled 가 아님).
+    assert.equal(parsed.providers.codex.enabled, true);
+    assert.equal(parsed.providers.claude.enabled, true);
+    assert.equal(parsed.version, 1);
     // chmod 600 호출됨.
     const chmods = mockFs.chmodCalls();
     assert.equal(chmods.length, 1);

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -1,0 +1,216 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runSetupSubcommand, formatTelegramSetupHelp } from '../src/setup-subcommand.js';
+
+function makeLogger() {
+  const logs = [];
+  const errors = [];
+  return {
+    logs,
+    errors,
+    log: (m) => logs.push(m),
+    errorLog: (m) => errors.push(m),
+  };
+}
+
+function makeMockFs(initial = {}) {
+  const files = new Map();
+  for (const [k, v] of Object.entries(initial)) files.set(k, v);
+  let chmodCalls = [];
+  return {
+    fs: {
+      existsSync: (p) => files.has(p),
+      readFileSync: (p) => {
+        if (!files.has(p)) throw new Error(`mock fs: ${p} not found`);
+        return files.get(p);
+      },
+      writeFileSync: (p, content) => {
+        files.set(p, content);
+      },
+      mkdirSync: () => {},
+      chmodSync: (p, mode) => {
+        chmodCalls.push({ path: p, mode });
+      },
+      statSync: (p) => {
+        if (!files.has(p)) throw new Error('not found');
+        return { mode: 0o100600 };
+      },
+    },
+    files,
+    chmodCalls: () => chmodCalls,
+  };
+}
+
+function makeMockBot() {
+  let messageHandler = null;
+  let stopped = false;
+  return {
+    bot: {
+      init: async () => {},
+      on: (event, handler) => {
+        if (event === 'message:text') messageHandler = handler;
+      },
+      catch: () => {},
+      start: () => new Promise(() => {}),
+      stop: async () => {
+        stopped = true;
+      },
+    },
+    fire: async (ctx) => messageHandler(ctx),
+    stopped: () => stopped,
+  };
+}
+
+describe('runSetupSubcommand (Phase 4)', () => {
+  it('--help 는 throw 없이 안내 출력', async () => {
+    const { logs, log, errorLog } = makeLogger();
+    await runSetupSubcommand(
+      ['--help'],
+      { resolveAgentConfigPath: () => '/cfg' },
+      { log, errorLog },
+    );
+    assert.ok(logs.some((l) => l.includes('telegram setup')));
+  });
+
+  it('빈 토큰 입력 시 친화 에러 + exit 1', async () => {
+    process.exitCode = 0;
+    const { errors, log, errorLog } = makeLogger();
+    await runSetupSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg' },
+      {
+        promptFn: async () => '',
+        log,
+        errorLog,
+      },
+    );
+    assert.ok(errors.some((e) => e.includes('빈 토큰')));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+
+  it('getMe 실패 시 친화 에러 + exit 1', async () => {
+    process.exitCode = 0;
+    const { errors, log, errorLog } = makeLogger();
+    await runSetupSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/cfg' },
+      {
+        promptFn: async () => '123:bad',
+        fetchFn: async () => ({
+          status: 401,
+          json: async () => ({ ok: false, description: 'Unauthorized' }),
+        }),
+        log,
+        errorLog,
+      },
+    );
+    assert.ok(errors.some((e) => e.includes('토큰 검증 실패')));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+
+  it('정상 흐름 — 페어링 성공 → config write + chmod 600 + template print', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    const mockFs = makeMockFs();
+    const mock = makeMockBot();
+    const setupPromise = runSetupSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/test/config.json', cliScriptPath: '/cli/bin' },
+      {
+        promptFn: async () => '123:fake',
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'MyBot' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        log,
+        errorLog,
+      },
+    );
+
+    // pairing 시작까지 yield.
+    await new Promise((r) => setImmediate(r));
+    // /pair 메시지 발사.
+    const replies = [];
+    await mock.fire({
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
+      from: { id: 42, username: 'alice' },
+      reply: async (m) => replies.push(m),
+    });
+    await setupPromise;
+
+    // config 파일 작성됨.
+    const written = mockFs.files.get('/test/config.json');
+    assert.ok(written, 'config 파일이 작성되어야 함');
+    const parsed = JSON.parse(written);
+    assert.equal(parsed.channels.telegram.enabled, true);
+    assert.equal(parsed.channels.telegram.botToken, '123:fake');
+    assert.deepEqual(parsed.channels.telegram.allowedUserIds, [42]);
+    // chmod 600 호출됨.
+    const chmods = mockFs.chmodCalls();
+    assert.equal(chmods.length, 1);
+    assert.equal(chmods[0].mode, 0o600);
+    // template 안내 포함.
+    const out = logs.join('\n');
+    assert.match(out, /부팅 후 자동 시작/);
+    assert.match(out, /token-weather telegram start/);
+    assert.equal(process.exitCode, 0);
+  });
+
+  it('기존 config 의 다른 키 보존 + channels.telegram 만 갱신', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    const existing = {
+      version: 1,
+      providers: { codex: { enabled: true } },
+      channels: { telegram: { enabled: false, botToken: '', allowedUserIds: [] } },
+    };
+    const mockFs = makeMockFs({ '/test/config.json': JSON.stringify(existing) });
+    const mock = makeMockBot();
+    const setupPromise = runSetupSubcommand(
+      [],
+      { resolveAgentConfigPath: () => '/test/config.json' },
+      {
+        promptFn: async () => '123:fake',
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        log,
+        errorLog,
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    await mock.fire({
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
+      from: { id: 99 },
+      reply: async () => {},
+    });
+    await setupPromise;
+    const parsed = JSON.parse(mockFs.files.get('/test/config.json'));
+    assert.equal(parsed.version, 1, 'version 보존');
+    assert.deepEqual(parsed.providers, { codex: { enabled: true } }, 'providers 보존');
+    assert.equal(parsed.channels.telegram.enabled, true, 'telegram 갱신됨');
+  });
+});
+
+describe('formatTelegramSetupHelp', () => {
+  it('첫 줄이 token-weather telegram setup', () => {
+    assert.match(formatTelegramSetupHelp()[0], /^token-weather telegram setup$/);
+  });
+  it('6 단계 흐름 안내 포함', () => {
+    const text = formatTelegramSetupHelp().join('\n');
+    assert.match(text, /1\. BotFather/);
+    assert.match(text, /5\. OS 별 service template/);
+  });
+});


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan 의 네 번째 PR (Phase 4). Phase 3 까지 `token-weather telegram start` 만 활성화되었던 상태에서 **end-user 가 처음부터 끝까지 자체 봇을 띄울 수 있는** 흐름을 완성합니다 — 봇 토큰 prompt → getMe 검증 → `/pair <code>` 페어링 → config write + chmod 600 → OS service template print. 진단용 `check` 도 함께 등록.

본 PR 머지 + release publish 후 사용자는 `npm i -g @token-weather/cli @token-weather/telegram` 한 줄로 telegram setup → start 흐름이 가능해집니다.

## 변경 내용

### 신규 모듈 `packages/telegram/src/`
- `os-service-templates.js` — `linuxSystemdUnit` / `macosLaunchAgent` / `windowsTaskScheduler` / `pickServiceTemplate`. pure templates, 파일 시스템 변경 X. 사용자가 복사 / 붙여넣기 활성화.
- `pairing.js` — `validateBotToken` (getMe API), `generatePairingCode` (TGW-XXXXXX 1회용), `runPairingBot` (allowlist 없이 `/pair <code>` listen + user_id 캡처 + 5 분 timeout).
- `setup-subcommand.js` — `runSetupSubcommand` 6 단계 흐름 (prompt → 검증 → 페어링 → config write → chmod → template print) + `formatTelegramSetupHelp`.
- `check-subcommand.js` — `runCheckSubcommand` read-only 진단 (config / chmod / channels.telegram / getMe / linger) + `formatTelegramCheckHelp`.

### `packages/telegram/src/index.js` 갱신
- `runTelegramCommand` dispatch 에 `setup` / `check` 추가 (start 와 동급).
- `formatTelegramHelp` Subcommands 목록 갱신.
- 신규 public export: pairing helpers + OS templates + setup/check entry + help formatters.

### 테스트
- `test/os-service-templates.test.js` (12 it) — 3 OS 템플릿 snapshot + 자동 picker.
- `test/pairing.test.js` (11 it) — validateBotToken / generatePairingCode / runPairingBot 단위, mock fetch / mock bot.
- `test/setup-subcommand.test.js` (6 it) — e2e: 빈 토큰 / getMe 실패 / 정상 flow (config write + chmod 600 + template print) / 기존 config 다른 키 보존.
- `test/check-subcommand.test.js` (7 it) — config 없음 / 정상 통과 / chmod warn / enabled=false / linger warn.

총 telegram 패키지 65 → 133 tests (Phase 4 신규 36).

## UX 정책 (PR #131 / #133 review 정신과 정합)

- **자동 OS service 등록 안 함** — print 만, 사용자가 복사 / 붙여넣기로 활성화. 도구가 시스템 파일을 직접 만들지 않음 → token-weather 의 "로컬 only" 약속 표면적 최소화.
- 페어링 daemon 은 1회용 — `createBotServer` 와 별도 lifecycle. allowlist 없이 `/pair <code>` 만 listen, 일치하면 즉시 종료.
- 모든 외부 의존성 (fetch / readline / Bot / fs / execSync / platform) 옵션 주입 — 단위 테스트가 외부 네트워크 / 실 파일 / 실 bot 없이 e2e 시나리오 검증.

## 변경 이유

Phase 3 의 의존성 주입 구조 위에 setup / check 도 같은 패턴을 적용 — telegram 패키지가 `@token-weather/cli` 를 import 하지 않는 정책 그대로 유지. 사용자 입장에서는 한 명령 (`telegram setup`) 으로 봇 토큰 / 페어링 / OS service 안내까지 한 번에. UX 절충안 (print 안) 으로 코드 복잡도 / 보안 표면 / 테스트 부담 모두 최소.

## 영향 범위

- [x] `packages/telegram` — 4 신규 모듈 + 4 테스트 파일 + index 갱신
- [ ] `packages/agent` — 무변경 (Phase 3 의 run-cli + deps 그대로 통과)
- [ ] `packages/schemas` / `packages/provider-adapters` — 무변경
- [x] `repo` — `.changeset/telegram-setup-check.md`
- [ ] `docs` — Phase 5 에서 일괄 갱신

## 테스트 / 확인

- `npm test` — 998 통과 (전체)
- `npm run lint` / `format:check` / `build:types` / `install-smoke.sh` 전부 통과
- `npx changeset status` — 4 패키지 모두 minor 인식
- 수동:
  - `node packages/agent/bin/token-weather.js telegram --help` → 3 subcommand 안내
  - `... telegram setup --help` → 6 단계 흐름
  - `... telegram check --help` → 검사 항목 4 종

## 리뷰 포인트

1. **페어링 daemon 의 별도 lifecycle** — `createBotServer` 와 다른 1회용 패턴 (allowlist 없이 `/pair` 만 listen). 의도적으로 분리 — 일반 daemon 의 보안 모델 (사용자 등록 후 명령) 과 setup 의 모델 (등록 *전* 메시지 수신) 이 다름.
2. **config.channels.telegram 갱신 정합** — 기존 키 spread (`...config.channels?.telegram`) 후 enabled / botToken / allowedUserIds 만 override. 다른 사용자 정의 키 보존.
3. **chmod 600 best-effort** — 실패해도 warning 후 계속 진행. Windows 등 chmod 의미 약한 OS 대응.
4. **OS service template print** — 자동 install 안 함 결정. 사용자 동의가 필요하다는 보안 도구 정신. `--auto-register` 플래그는 후속 plan 으로 분리.
5. **runPairingBot timeout** — 기본 5 분, `timer.unref()` 로 process keep-alive 방지. 단위 테스트는 50-200ms.

## 참고 사항

- Closes #129 (의 한 부분).
- bump: minor (linked 정책).
- 후속 PR: Phase 5 (#130) — docs/telegram-bot.md + README + SECURITY + release-policy 갱신 → publish.