### PR TITLE
[docs] telegram bot 통합 (5/5) — 사용자 문서 + 보안 / 운영 문서 + README 통합

### DIFF
--- a/.changeset/telegram-docs.md
+++ b/.changeset/telegram-docs.md
@@ -17,6 +17,11 @@ docs(telegram): docs/telegram-bot.md 신규 + README / SECURITY / release-policy
   telegram start) + 봇이 받는 채팅 명령 표 (`/status` / `/status --json` /
   `/usage` / `/usage --json` / `/doctor` / `/auth_list`) + OS service 수동 등록
   (systemd / launchd / Task Scheduler) + 보안 모델 + 한계 / FAQ.
+  · §보안 모델 의 "로컬에 머무는 것" 을 세 저장 경로로 분리 명시:
+    OAuth → `auth.json`, Telegram bot token / allowedUserIds → `config.json`,
+    페어링 코드 → transient memory (PR #136 review blocker fix).
+  · §OS service 수동 등록 에 "코드 블록은 구조 예시, 실제 경로는 setup 출력
+    그대로 복사" 경고 (PR #136 review follow-up).
 - `README.md`:
   · "## 명령" 코드 블록에 telegram 3 명령 (setup / start / check) 등재.
   · 신규 "## Telegram 봇 (옵션)" 섹션 — 옵션 패키지 quick start 3 줄 + docs
@@ -27,7 +32,9 @@ docs(telegram): docs/telegram-bot.md 신규 + README / SECURITY / release-policy
 - `SECURITY.md` — 신규 §"Telegram 봇 통합의 위협 모델": 신뢰 경계 (OAuth 토큰
   로컬 only vs 메타데이터 Telegram 경유), 1차 방어막 (allowedUserIds /
   single-instance lock / 노출 명령 표면 축소), 봇 토큰 누설 시 절차
-  (BotFather /revoke → setup 재실행 → check), 추가 신고 시나리오.
+  (BotFather /revoke → setup 재실행 → check), 추가 신고 시나리오. 신뢰 경계
+  의 저장 경로 분리는 `docs/telegram-bot.md` 와 1:1 표현 (PR #136 review blocker
+  fix).
 - `docs/release-policy.md` §2 (도메인별 자세한 기준) 에 신규 §"Telegram 봇" —
   subcommand / config 키 / deps 시그니처 / 응답 출력 / 미들웨어 정책 변경의
   bump 기준 명시. publish 전 단계의 정정 자유도 (PR #131 / #133 review 의

--- a/.changeset/telegram-docs.md
+++ b/.changeset/telegram-docs.md
@@ -1,0 +1,40 @@
+---
+'@token-weather/cli': patch
+'@token-weather/provider-adapters': patch
+'@token-weather/schemas': patch
+'@token-weather/telegram': patch
+---
+
+docs(telegram): docs/telegram-bot.md 신규 + README / SECURITY / release-policy 갱신 (issue #130).
+
+5-phase Telegram 봇 통합 plan 의 마지막 단계 (Phase 5). Phase 1~4 의 코드는 모두
+머지 완료, 본 release 로 사용자 문서 / 보안 운영 / release 정책을 통합 갱신해
+**v0.5.0 publish 준비**. 코드 변경 없음 — patch bump.
+
+**문서 갱신**:
+
+- `docs/telegram-bot.md` 신규 — quick start (npm install → telegram setup →
+  telegram start) + 봇이 받는 채팅 명령 표 (`/status` / `/status --json` /
+  `/usage` / `/usage --json` / `/doctor` / `/auth_list`) + OS service 수동 등록
+  (systemd / launchd / Task Scheduler) + 보안 모델 + 한계 / FAQ.
+- `README.md`:
+  · "## 명령" 코드 블록에 telegram 3 명령 (setup / start / check) 등재.
+  · 신규 "## Telegram 봇 (옵션)" 섹션 — 옵션 패키지 quick start 3 줄 + docs
+  링크.
+  · 헤더 한 줄 설명 + "What & Why" 의 "토큰 외부 서버 X" 약속을 **OAuth 토큰
+  한정** 으로 정밀화 — 봇 활성화 시 사용량 메타데이터는 Telegram 경유 사실
+  명시 + docs/telegram-bot.md §보안 모델 fragment 링크.
+- `SECURITY.md` — 신규 §"Telegram 봇 통합의 위협 모델": 신뢰 경계 (OAuth 토큰
+  로컬 only vs 메타데이터 Telegram 경유), 1차 방어막 (allowedUserIds /
+  single-instance lock / 노출 명령 표면 축소), 봇 토큰 누설 시 절차
+  (BotFather /revoke → setup 재실행 → check), 추가 신고 시나리오.
+- `docs/release-policy.md` §2 (도메인별 자세한 기준) 에 신규 §"Telegram 봇" —
+  subcommand / config 키 / deps 시그니처 / 응답 출력 / 미들웨어 정책 변경의
+  bump 기준 명시. publish 전 단계의 정정 자유도 (PR #131 / #133 review 의
+  키 이동이 가능했던 이유) 도 인용. linked 정책 + 안정성 평가 후 분리 가능성도
+  후속 task 로 명시.
+
+**코드 변경 없음** — Phase 1~4 의 누적 minor bump 가 v0.5.0 진입을 만들어 둔
+상태. 본 release 의 docs 추가는 patch.
+
+**Migration** 없음.

--- a/.changeset/telegram-docs.md
+++ b/.changeset/telegram-docs.md
@@ -18,10 +18,10 @@ docs(telegram): docs/telegram-bot.md 신규 + README / SECURITY / release-policy
   `/usage` / `/usage --json` / `/doctor` / `/auth_list`) + OS service 수동 등록
   (systemd / launchd / Task Scheduler) + 보안 모델 + 한계 / FAQ.
   · §보안 모델 의 "로컬에 머무는 것" 을 세 저장 경로로 분리 명시:
-    OAuth → `auth.json`, Telegram bot token / allowedUserIds → `config.json`,
-    페어링 코드 → transient memory (PR #136 review blocker fix).
+  OAuth → `auth.json`, Telegram bot token / allowedUserIds → `config.json`,
+  페어링 코드 → transient memory (PR #136 review blocker fix).
   · §OS service 수동 등록 에 "코드 블록은 구조 예시, 실제 경로는 setup 출력
-    그대로 복사" 경고 (PR #136 review follow-up).
+  그대로 복사" 경고 (PR #136 review follow-up).
 - `README.md`:
   · "## 명령" 코드 블록에 telegram 3 명령 (setup / start / check) 등재.
   · 신규 "## Telegram 봇 (옵션)" 섹션 — 옵션 패키지 quick start 3 줄 + docs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Node](https://img.shields.io/node/v/%40token-weather%2Fcli.svg)](https://nodejs.org/)
 
 > **Local CLI dashboard for AI service usage and OAuth credentials.**
-> 로컬에서 여러 AI 서비스(Codex / Claude)의 사용량과 인증 상태를 한 번에 확인하는 CLI. 토큰을 외부 서버로 보내지 않습니다.
+> 로컬에서 여러 AI 서비스(Codex / Claude)의 사용량과 인증 상태를 한 번에 확인하는 CLI. **OAuth 토큰은 외부 서버로 보내지 않습니다** (옵션 `@token-weather/telegram` 활성화 시에도 봇 토큰 / OAuth 토큰은 로컬, 사용량 메타데이터만 Telegram 서버 경유 — [상세](./docs/telegram-bot.md#보안-모델)).
 
 ## Install
 
@@ -47,7 +47,7 @@ token-weather auth login claude --manual
 ## What & Why
 
 - **무엇**: AI 도구의 OAuth credential과 사용량 window를 로컬에서 통합 조회하는 CLI. Codex(OpenAI) / Claude(Anthropic) 두 provider 운영 중.
-- **왜**: 다른 대시보드들은 토큰을 외부 서버로 보내거나 별도 auth 서비스에 의존. Token Weather는 **자체 broker + 로컬 credential store**로 동작 — 토큰이 머신을 떠나지 않습니다.
+- **왜**: 다른 대시보드들은 토큰을 외부 서버로 보내거나 별도 auth 서비스에 의존. Token Weather는 **자체 broker + 로컬 credential store**로 동작 — **OAuth 토큰이 머신을 떠나지 않습니다**. 옵션 `@token-weather/telegram` 사용 시에도 token 자체는 로컬, 사용량 / 계정 label 메타데이터만 Telegram 서버 경유 ([상세](./docs/telegram-bot.md#보안-모델)).
 - **어떤 점이 다른가**:
   - **Multi-account**: 한 provider에 여러 계정 저장, 병렬 조회, label 부여
   - **자동 refresh**: 만료된 access token은 provider 호출 전 preflight refresh, auth 실패 시 1회 재시도

--- a/README.md
+++ b/README.md
@@ -76,9 +76,24 @@ token-weather auth list   [provider]
 token-weather auth logout <provider> [--account]
 token-weather auth import claude                                   # Claude CLI credential 흡수
 token-weather config init                                          # 설정 파일 생성
+token-weather telegram setup    # Telegram 봇 페어링 + OS service 안내 (옵션 패키지)
+token-weather telegram start    # Telegram 봇 daemon (foreground, Ctrl+C 종료)
+token-weather telegram check    # Telegram 설정 / token / linger 진단
 ```
 
 default `auth login` 은 실제 OAuth 토큰 교환을 수행합니다. `--mock` 옵션 시 token endpoint 호출 없이 mock 계정만 저장 (테스트/실험용). `--label` 로 저장된 계정에 친화적 이름 부여 → 이후 `--account <label>` 로 참조.
+
+## Telegram 봇 (옵션)
+
+핸드폰 / 다른 데스크탑에서 `status` / `usage` / `doctor` / `auth list` 명령을 원격 호출하고 싶다면 별도 패키지 `@token-weather/telegram` 을 추가 설치합니다. token-weather 가 시스템 service 파일을 직접 만들지 않고, 사용자 동의가 필요한 명령 블록만 print 합니다 (UX 절충안).
+
+```bash
+npm install -g @token-weather/telegram   # 옵션 패키지
+token-weather telegram setup             # 봇 토큰 + 페어링 + OS service 안내
+token-weather telegram start             # daemon 실행 (또는 setup 끝의 systemd / launchd / Task Scheduler 사용)
+```
+
+상세 / 보안 모델 / OS service 수동 등록 / FAQ: [docs/telegram-bot.md](./docs/telegram-bot.md).
 
 ## JSON 출력 (자동화)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,31 @@ GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, 
 - `--json` 출력 회귀 테스트(가짜 토큰 주입 → JSON에 누출 없음 검증) 추가
 
 이 절차를 빠뜨리면 외부 소비자에게 그대로 노출될 수 있습니다.
+
+## Telegram 봇 통합의 위협 모델 (`@token-weather/telegram` 사용 시)
+
+옵션 패키지 `@token-weather/telegram` 을 활성화하면 token-weather 의 신뢰 경계가 확장됩니다. 활성화 전에 다음을 확인해 주세요. 상세 보안 모델은 [docs/telegram-bot.md §보안 모델](./docs/telegram-bot.md#보안-모델).
+
+### 신뢰 경계
+
+- **로컬 only (변화 없음)**: OAuth access / refresh / id token, Telegram 봇 토큰, 페어링 코드. 모두 `~/.config/token-weather/config.json` 에 chmod 600 으로 저장. `SENSITIVE_KEYS` redaction 으로 어떤 출력에도 노출되지 않음.
+- **Telegram 서버 경유 (신규)**: 사용량 숫자 / 계정 label / email / 명령 응답 본문 / 사용자 user_id. 봇 활성화 시 README 의 "로컬 only" 약속은 **OAuth 토큰 한정** 으로 정밀화됨.
+
+### 봇 토큰 / 채널 단의 1차 방어막
+
+- `channels.telegram.allowedUserIds` allowlist — 등록되지 않은 user_id 의 메시지는 silent ignore (응답 / 로그 마스킹). 봇 토큰이 누설되어도 명령 표면이 즉시 열리지 않음.
+- 단일 인스턴스 lock — 같은 봇 토큰으로 다른 daemon 이 polling 중이면 409 Conflict 감지 후 종료. 의도치 않은 두 번째 daemon 실수 회피.
+- 노출 명령 표면 축소 — `/doctor` 는 root 호출만, `/auth_list` 도 인자 차단. 원격 명령으로 부수효과 있는 호출 (token refresh-live 등) 트리거 불가.
+
+### 봇 토큰 누설 시 절차
+
+1. BotFather (`@BotFather`) 에 `/revoke` → 즉시 토큰 무효화 (또는 `/token` 으로 재발급).
+2. 로컬 `config.channels.telegram.botToken` 갱신 — `token-weather telegram setup` 재실행이 가장 안전.
+3. `token-weather telegram check` 로 `getMe API` 가 새 토큰으로 `✓` 응답하는지 확인.
+4. `~/.config/token-weather/config.json` 의 권한이 `chmod 600` 인지 확인 — `telegram check` 의 "config 권한" 항목.
+
+### 추가 신고 시나리오
+
+- 본인이 아닌 user_id 가 `allowedUserIds` 에 추가됨을 발견 → 즉시 array 에서 제거 + daemon 재시작 (`systemctl --user restart token-weather-bot.service` 또는 stop → start).
+- 봇이 본인 명령에 응답하지 않는데 다른 사용자에게는 응답함 → 봇 토큰 또는 allowlist 조작 의심. BotFather 토큰 revoke + 신고.
+- daemon 로그에 본인 user_id 가 아닌 마스킹된 id (`xxx****yy`) 가 `미허용 user_id 거부` 로 반복 등장 → 봇 토큰이 외부에 알려진 정황. 토큰 revoke 권장.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,8 +44,14 @@ GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, 
 
 ### 신뢰 경계
 
-- **로컬 only (변화 없음)**: OAuth access / refresh / id token, Telegram 봇 토큰, 페어링 코드. 모두 `~/.config/token-weather/config.json` 에 chmod 600 으로 저장. `SENSITIVE_KEYS` redaction 으로 어떤 출력에도 노출되지 않음.
-- **Telegram 서버 경유 (신규)**: 사용량 숫자 / 계정 label / email / 명령 응답 본문 / 사용자 user_id. 봇 활성화 시 README 의 "로컬 only" 약속은 **OAuth 토큰 한정** 으로 정밀화됨.
+- **로컬 only** (저장 위치 별로 분리):
+  - OAuth access / refresh / id token: `~/.config/token-weather/auth.json` 에 저장. auth store 가 mode 0600 으로 write.
+  - Telegram bot token / allowedUserIds: `~/.config/token-weather/config.json` 의 `channels.telegram` 아래에 저장. `telegram setup` 이 chmod 600 을 best-effort 로 적용.
+  - 페어링 코드: setup 중 터미널 + 1회용 pairing daemon 메모리에만 존재. config / auth store 에 저장하지 않음.
+
+  세 경로 모두 `SENSITIVE_KEYS` redaction 으로 어떤 출력에도 노출되지 않음.
+
+- **Telegram 서버 경유 (신규)**: 사용량 숫자 / 계정 label / email / 명령 응답 본문 / 사용자 user_id. 봇 활성화 시 README 의 "로컬 only" 약속은 **OAuth 토큰 + 봇 토큰 한정** 으로 정밀화됨.
 
 ### 봇 토큰 / 채널 단의 1차 방어막
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -78,6 +78,19 @@ contract는 [docs/cli-json-output.md](./cli-json-output.md)에 stable로 명시�
 - `SENSITIVE_KEYS` 확장: patch (기본적으로 토큰이 덜 노출되는 방향). consumer의 정상 사용에 영향 없음.
 - `redactSensitive` 동작 자체 변경 (어떤 키를 더 노출하는 방향): major. 단 그런 변경은 보안상 명시적 결정이 필요.
 
+### Telegram 봇 (`@token-weather/telegram`)
+
+`config.channels.telegram` 의 키 / `@token-weather/telegram` public export / `runTelegramCommand` dispatch 시그니처가 contract 단위. 5-phase plan (#126~#130) 으로 도입.
+
+- 신규 subcommand 추가 (`telegram <new>`): minor.
+- 기존 subcommand 제거 / 의미 변경: major.
+- `config.channels.telegram` 의 키 추가 (옵셔널): minor. 키 제거 / 의미 변경 / 이름 변경: major (publish 이전이면 더 자유롭게 — PR #131 / #133 review 의 `providers.telegram` → `channels.telegram` 이동, `allowedChatIds` → `allowedUserIds` rename 이 publish 전 단계라 가능했음).
+- `runTelegramCommand` 의 `deps` 매개변수 키 추가: minor (cli 가 그 키를 채워 주는 방향이면 비파괴). 기존 deps 키 제거 / 시그니처 narrow: major.
+- 봇 응답 출력 시각 변경 (`<pre>` wrap / chunk split 정책 등): patch (사용자가 평문 / JSON 의 contract 만 본다는 전제). `--json` 응답의 top-level shape 변경은 `status --json` 규약과 동일.
+- Telegram 미들웨어 정책 변경 (allowlist 의미 등): 보안 모델 영향이면 major. 예: `allowedUserIds` → `allowedChatIds` 같이 검사 대상이 user 에서 chat 으로 바뀌면 major.
+
+본 패키지는 5-phase plan 전 기간 동안 `@token-weather/cli` 와 **linked** 로 묶여 같은 minor bump 를 받았다. 안정성 평가 후 별도 bump 정책으로 분리하는 것은 후속 task — 분리 시점에 본 섹션도 함께 정정.
+
 ## 3. SCHEMA_VERSION 규약
 
 `packages/schemas/src/index.js::SCHEMA_VERSION`은 현재 `'0.5.0'` (string semver).

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,0 +1,148 @@
+# Telegram 봇 통합
+
+`@token-weather/telegram` 패키지는 token-weather 의 `status` / `usage` / `doctor` / `auth list` 명령을 Telegram 채팅으로 원격 호출하는 long-poll daemon 을 제공합니다. 로컬에서 봇을 띄우면 핸드폰 / 다른 데스크탑에서 봇에게 명령을 보내 즉시 응답을 받을 수 있습니다.
+
+> **신뢰 모델 요약**: 봇 토큰 / OAuth 토큰은 **로컬 파일에만 저장** 됩니다. 다만 사용량 / 계정 label / 명령 응답 본문은 Telegram 서버를 경유합니다. 자세한 보안 모델은 [§보안 모델](#보안-모델) 참고.
+
+## 빠른 시작
+
+```bash
+# 1) 패키지 설치 — cli + telegram 둘 다 필요
+npm install -g @token-weather/cli @token-weather/telegram
+
+# 2) BotFather 에서 봇 생성 → token 발급
+#    https://core.telegram.org/bots#how-do-i-create-a-bot
+#    /newbot → 이름 + username 선택 → 토큰 복사
+
+# 3) 봇 토큰 + chat 페어링 + config 저장 + OS service 안내까지 한 명령으로
+token-weather telegram setup
+
+# 4) (선택) OS service 등록 — setup 끝에서 안내한 블록을 복사 / 붙여넣기
+
+# 5) (선택) 진단
+token-weather telegram check
+
+# 6) 수동 실행 (OS service 안 쓸 때)
+token-weather telegram start
+```
+
+## 명령
+
+| 명령 | 설명 |
+|------|------|
+| `token-weather telegram setup` | 봇 토큰 입력 → `getMe` 검증 → `/pair <code>` 페어링 → config 저장 (chmod 600) → OS service template print |
+| `token-weather telegram start` | long-poll daemon foreground 실행. Ctrl+C 종료 |
+| `token-weather telegram check` | config / token / chmod / linger 상태 read-only 진단 |
+| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력 |
+
+## 봇이 받는 채팅 명령
+
+| Telegram 명령 | 동작 (`token-weather <cmd>` 와 동일) |
+|---------------|---------------------------------|
+| `/status` | 평문 status 출력 (HTML `<pre>` 블록) |
+| `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status") |
+| `/usage` | status alias — 평문 |
+| `/usage --json` | `formatStatusJson` 결과 (top-level `command` = "usage") |
+| `/doctor` | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단 |
+| `/auth_list` | 모든 provider 의 저장 계정 + claude import 섹션 |
+
+본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
+
+## OS service 수동 등록
+
+`telegram setup` 끝에서 print 되는 명령 블록을 셸에 복사 / 붙여넣기 하면 부팅 후 자동 시작이 활성화됩니다. token-weather 가 시스템 파일을 직접 만들지 **않습니다** — 사용자 동의가 필요한 변경이라는 보안 도구 원칙.
+
+### Linux (systemd `--user`, sudo 불필요)
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/token-weather-bot.service <<'EOF'
+[Unit]
+Description=Token Weather Telegram bot
+After=network-online.target
+
+[Service]
+ExecStart=/path/to/node /path/to/token-weather telegram start
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now token-weather-bot.service
+# 로그아웃 후에도 daemon 살아 있게:
+loginctl enable-linger "$USER"
+```
+
+### macOS (launchd LaunchAgent, sudo 불필요)
+
+`~/Library/LaunchAgents/com.token-weather.bot.plist` 작성 후:
+
+```bash
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist
+# 종료:
+launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist
+```
+
+전체 plist 내용은 `telegram setup` 출력 그대로.
+
+### Windows (Task Scheduler, 관리자 권한 불필요)
+
+```cmd
+schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED /TR "\"path\to\node.exe\" \"path\to\token-weather\" telegram start"
+:: 제거:
+schtasks /Delete /TN "TokenWeatherBot" /F
+```
+
+## 보안 모델
+
+### 신뢰 경계
+
+- **로컬에 머무는 것**: OAuth access / refresh / id token. Telegram 봇 토큰. 페어링 코드. 모두 `~/.config/token-weather/config.json` (chmod 600) 에 저장. `SENSITIVE_KEYS` redaction 으로 어떤 출력 (`status --json` / Telegram 응답 / 로그) 에도 노출되지 않음.
+- **Telegram 서버 경유**: 사용량 숫자 / 계정 label / email / token 만료 시각 / 명령 응답 본문. README 의 "토큰을 외부 서버로 보내지 않습니다" 약속은 **OAuth 토큰 한정** — 봇 활성화 시 메타데이터는 Telegram 인프라를 경유합니다.
+
+### 1차 방어막
+
+- `allowedUserIds` allowlist — 봇 토큰이 누설되어도 등록되지 않은 사용자의 명령은 silent ignore. 봇의 존재 / 동작 여부조차 응답하지 않음 (로그에는 부분 마스킹된 user_id 만 남김).
+- 단일 인스턴스 lock — 같은 봇 토큰으로 다른 daemon 이 polling 중이면 409 Conflict 감지 + 친절 안내 + 즉시 종료.
+
+### 봇 토큰 누설 시 절차
+
+1. BotFather 에 `/revoke` 로 즉시 토큰 무효화 (또는 `/token` 으로 재발급).
+2. `~/.config/token-weather/config.json` 의 `channels.telegram.botToken` 갱신 (또는 `telegram setup` 재실행).
+3. `telegram check` 로 새 토큰의 `getMe` 응답 확인.
+
+`allowedUserIds` 자체가 누설된 user_id 인 경우 (가족 / 공유 계정) — 해당 user_id 를 array 에서 제거하고 daemon 재시작.
+
+### Doctor / auth-list 의 표면 축소 의도
+
+- `/doctor` 는 root 호출만 노출 — `--refresh-live` 같이 부수효과 있는 옵션은 차단. 원격 명령으로 의도치 않은 토큰 갱신 시도 등을 방지.
+- `/auth_list` 도 provider 필터 / `--help` 무시. account 목록만 노출.
+
+## 한계 / FAQ
+
+### 봇이 응답 안 함
+
+1. daemon 이 살아 있나요? `systemctl --user status token-weather-bot.service` 또는 `ps aux | grep telegram`.
+2. `telegram check` 의 `getMe API` 결과가 `✓` 인가요? `✗` 이면 토큰 만료 / revoke 의심.
+3. 본인의 Telegram user_id 가 `allowedUserIds` 에 있나요? 다른 사용자 등록은 setup 재실행 (페어링) 또는 config 수동 편집 후 daemon 재시작.
+
+### user_id 와 chat_id 의 차이
+
+token-weather 의 allowlist 는 `ctx.from.id` (사용자 user_id) 기준입니다 — DM / group chat 어디서든 동일 사용자가 명령 가능. `chat.id` (채팅방 id) 기준이 아니므로 group 에 봇을 추가하더라도 그 group 의 다른 사용자는 명령 못 함.
+
+### 4096 자 제한
+
+Telegram 메시지 한도가 4096 자 + HTML escape 후 entity expansion 까지 안전 마진 두고 자동 split. 멀티 어카운트 status 출력이 길면 여러 메시지로 분할됨.
+
+### Webhook 미지원
+
+long-poll 만 지원합니다. public HTTPS endpoint 가 필요한 webhook 은 의도적으로 제외 — 일반 로컬 사용자 환경 (NAT, 동적 IP) 에 비현실적.
+
+## 참고
+
+- 패키지: `@token-weather/telegram` (npm)
+- 의존성: `grammy` ^1.42
+- 보안 신고: [SECURITY.md](../SECURITY.md)
+- 전체 API: `import * as telegram from '@token-weather/telegram'` — public export 18 개 (helpers / subcommands / formatters)

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -52,6 +52,8 @@ token-weather telegram start
 
 `telegram setup` 끝에서 print 되는 명령 블록을 셸에 복사 / 붙여넣기 하면 부팅 후 자동 시작이 활성화됩니다. token-weather 가 시스템 파일을 직접 만들지 **않습니다** — 사용자 동의가 필요한 변경이라는 보안 도구 원칙.
 
+> ⚠ 아래 코드 블록은 **구조 예시** 입니다. `/path/to/node` / `/path/to/token-weather` 같은 placeholder 는 실제 환경에서 다르며, **`telegram setup` 출력의 절대 경로를 그대로 복사** 해 주세요. 경로에 공백 / 특수문자가 있는 경우 setup 출력의 정확한 quoting 을 반드시 따라야 합니다.
+
 ### Linux (systemd `--user`, sudo 불필요)
 
 ```bash
@@ -151,4 +153,4 @@ long-poll 만 지원합니다. public HTTPS endpoint 가 필요한 webhook 은 �
 - 패키지: `@token-weather/telegram` (npm)
 - 의존성: `grammy` ^1.42
 - 보안 신고: [SECURITY.md](../SECURITY.md)
-- 전체 API: `import * as telegram from '@token-weather/telegram'` — public export 18 개 (helpers / subcommands / formatters)
+- 전체 API: `import * as telegram from '@token-weather/telegram'` — pairing helpers / OS service templates / handler factories / dispatcher / subcommand entry / formatters / help texts 가 모두 export. 정확한 목록은 [`packages/telegram/src/index.js`](../packages/telegram/src/index.js).

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -99,8 +99,14 @@ schtasks /Delete /TN "TokenWeatherBot" /F
 
 ### 신뢰 경계
 
-- **로컬에 머무는 것**: OAuth access / refresh / id token. Telegram 봇 토큰. 페어링 코드. 모두 `~/.config/token-weather/config.json` (chmod 600) 에 저장. `SENSITIVE_KEYS` redaction 으로 어떤 출력 (`status --json` / Telegram 응답 / 로그) 에도 노출되지 않음.
-- **Telegram 서버 경유**: 사용량 숫자 / 계정 label / email / token 만료 시각 / 명령 응답 본문. README 의 "토큰을 외부 서버로 보내지 않습니다" 약속은 **OAuth 토큰 한정** — 봇 활성화 시 메타데이터는 Telegram 인프라를 경유합니다.
+- **로컬에 머무는 것** (세 경로로 분리):
+  - **OAuth access / refresh / id token** — `~/.config/token-weather/auth.json` 에 저장. auth store 가 mode 0600 으로 write.
+  - **Telegram bot token / allowedUserIds** — `~/.config/token-weather/config.json` 의 `channels.telegram` 아래. `telegram setup` 이 chmod 600 을 best-effort 로 적용 (Windows 등 chmod 의미 약한 OS 는 `telegram check` 의 "config 권한" 항목에서 확인 권장).
+  - **페어링 코드** — `telegram setup` 중 터미널과 1회용 pairing daemon 메모리에만 존재. config / auth store 에 저장하지 않음.
+
+  세 경로 모두 `SENSITIVE_KEYS` redaction 으로 어떤 출력 (`status --json` / Telegram 응답 / 로그) 에도 노출되지 않습니다.
+
+- **Telegram 서버 경유**: 사용량 숫자 / 계정 label / email / token 만료 시각 / 명령 응답 본문 / 사용자 user_id. README 의 "토큰을 외부 서버로 보내지 않습니다" 약속은 **OAuth 토큰 + Telegram 봇 토큰 한정** — 봇 활성화 시 메타데이터는 Telegram 인프라를 경유합니다.
 
 ### 1차 방어막
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -28,23 +28,23 @@ token-weather telegram start
 
 ## 명령
 
-| 명령 | 설명 |
-|------|------|
-| `token-weather telegram setup` | 봇 토큰 입력 → `getMe` 검증 → `/pair <code>` 페어링 → config 저장 (chmod 600) → OS service template print |
-| `token-weather telegram start` | long-poll daemon foreground 실행. Ctrl+C 종료 |
-| `token-weather telegram check` | config / token / chmod / linger 상태 read-only 진단 |
-| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력 |
+| 명령                                                 | 설명                                                                                                      |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → `/pair <code>` 페어링 → config 저장 (chmod 600) → OS service template print |
+| `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                             |
+| `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                       |
+| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                       |
 
 ## 봇이 받는 채팅 명령
 
-| Telegram 명령 | 동작 (`token-weather <cmd>` 와 동일) |
-|---------------|---------------------------------|
-| `/status` | 평문 status 출력 (HTML `<pre>` 블록) |
+| Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                     |
+| ---------------- | -------------------------------------------------------- |
+| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                     |
 | `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status") |
-| `/usage` | status alias — 평문 |
-| `/usage --json` | `formatStatusJson` 결과 (top-level `command` = "usage") |
-| `/doctor` | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단 |
-| `/auth_list` | 모든 provider 의 저장 계정 + claude import 섹션 |
+| `/usage`         | status alias — 평문                                      |
+| `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")  |
+| `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단        |
+| `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션          |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
 


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan 의 마지막 PR (Phase 5). Phase 1~4 의 코드는 모두 머지 완료, 본 PR 은 사용자 / 보안 / 메인테이너 문서를 통합 갱신해 **v0.5.0 publish 준비** 를 완료합니다.

코드 변경 없음 — patch bump. 본 PR 머지 후 누적 release PR (Phase 1~4 의 minor + Phase 5 의 patch) 을 머지하면 4 패키지 모두 v0.4.0 → **v0.5.0 publish**.

## 변경 내용

### `docs/telegram-bot.md` 신규
사용자가 telegram 봇 활성화 / 운영 / 보안 모델을 한 문서에서 파악 가능하도록 통합 가이드.
- **빠른 시작** — npm install → BotFather → telegram setup → (OS service) → telegram start 의 6 단계.
- **명령 표** — setup / start / check / --help 의미.
- **봇이 받는 채팅 명령 표** — `/status` / `/status --json` / `/usage` / `/usage --json` / `/doctor` / `/auth_list` + `/cmd@OtherBot` silent ignore.
- **OS service 수동 등록** — Linux systemd `--user` / macOS launchd LaunchAgent / Windows Task Scheduler 각 명령 블록.
- **보안 모델** — 신뢰 경계 / 1차 방어막 / 봇 토큰 누설 시 절차 / doctor / auth-list 표면 축소 의도.
- **한계 / FAQ** — 봇 무응답 디버깅 / user_id vs chat_id / 4096 자 split / webhook 미지원.

### `README.md`
- "## 명령" 코드 블록에 `telegram setup` / `start` / `check` 3 명령 등재.
- 신규 "## Telegram 봇 (옵션)" 섹션 — 3 줄 quick start + 보안 도구 UX 절충안 (시스템 파일 직접 X) 한 줄 + docs 진입점.
- 헤더 한 줄 설명 + "What & Why" 의 "토큰 외부 서버 X" 약속을 **OAuth 토큰 한정** 으로 정밀화 — 봇 활성화 시 사용량 메타데이터는 Telegram 경유 사실 명시 + docs/telegram-bot.md §보안 모델 fragment 링크.

### `SECURITY.md`
신규 §"Telegram 봇 통합의 위협 모델":
- **신뢰 경계** — 로컬 only (OAuth 토큰 / 봇 토큰 / 페어링 코드) vs Telegram 서버 경유 (사용량 / 계정 label / 응답 본문 / user_id).
- **1차 방어막** — allowedUserIds allowlist + single-instance lock + 노출 명령 표면 축소.
- **봇 토큰 누설 시 절차** — BotFather /revoke → setup 재실행 → check 의 getMe 검증 → chmod 600 확인.
- **추가 신고 시나리오** — 의심 user_id 추가 / 본인 명령 거부 / 미허용 user_id 거부 로그 반복.

### `docs/release-policy.md` §2
신규 §"Telegram 봇 (`@token-weather/telegram`)":
- subcommand / config.channels.telegram 키 / runTelegramCommand deps / 봇 응답 출력 / 미들웨어 정책 변경의 bump 기준.
- publish 전 단계의 정정 자유도 (PR #131 / #133 review 의 키 이동이 가능했던 이유) 인용.
- linked 정책 + 안정성 평가 후 분리 가능성 후속 task 명시.

### 저장소
- `.changeset/telegram-docs.md` — 4 패키지 모두 patch.

## 영향 범위

- [ ] `packages/*` — 코드 변경 없음.
- [x] `docs` — `docs/telegram-bot.md` 신규, `docs/release-policy.md` §2 확장.
- [x] `repo` — `README.md` / `SECURITY.md` / `.changeset/telegram-docs.md`.

## 테스트 / 확인

- `npm test` — 999 통과 (Phase 4 와 동일, 변경 없음).
- `npm run lint` / `format:check` / `build:types` / `install-smoke.sh` 전부 통과.
- `npx changeset status` — 4 패키지 모두 minor 인식 (누적: Phase 1~4 minor + Phase 5 patch = minor).
- 수동: docs/telegram-bot.md 의 모든 anchor 링크 (`#보안-모델` 등) 유효성 visual review.

## 리뷰 포인트

1. **README 의 "로컬 only" 약속 정밀화** — 봇 활성화 시에도 OAuth 토큰은 로컬, 메타데이터만 Telegram 경유. 두 위치 (헤더 한 줄 + What & Why) 모두 동일 메시지로 정정.
2. **docs/telegram-bot.md 의 OS service 명령 블록** — Phase 4 의 `pickServiceTemplate` print 출력과 정확히 일치해야 사용자가 copy-paste 일관성. systemd unit / launchd plist / schtasks 3 OS 동일.
3. **SECURITY.md 의 신고 시나리오** — "본인 명령 거부 + 다른 사용자 응답" 같은 봇 토큰 누설 정황 시나리오 포함. 일반 user 가 의심 행동을 식별할 수 있는 표현.
4. **release-policy 의 telegram 섹션** — publish 전 정정 자유도 + linked 정책 + 분리 가능성. 본 plan 의 review 라운드에서 키 이동 / rename 이 가능했던 이유를 후속 contributor 가 참고할 수 있는 inline 인용.

## 후속 (publish)

본 PR 머지 후:
1. 누적 release PR (`changeset-release/dev`) 이 자동 force-update.
2. release PR 머지 → `release.yml` 실행:
   - install-smoke + `changesets publish` + GitHub Release tag + main FF sync.
   - 4 패키지 모두 v0.5.0 publish (`@token-weather/cli` / `provider-adapters` / `schemas` / `telegram`).
3. publish 직후 root `CHANGELOG.md` 수동 큐레이트 (release-policy §4).

## 참고 사항

- Closes #130. **5-phase Telegram 봇 통합 plan 완료** (#126 / #127 / #128 / #129 / #130).
- bump: patch (docs only).
- 5-phase 누적: 4 패키지 모두 v0.4.0 → v0.5.0.