### PR TITLE
[feat] telegram 페어링을 Telegram deep link 로 단순화 — 5 step → 2 step (issue #137)

### DIFF
--- a/.changeset/telegram-pairing-deeplink.md
+++ b/.changeset/telegram-pairing-deeplink.md
@@ -18,12 +18,15 @@ PR #136 review (메시지 #792) 에서 HetrixTools / UptimeRobot 류의 "공식 
 **신규 동작** (`@token-weather/telegram`):
 
 - `runPairingBot` 의 message:text 핸들러가 `/pair <code>` 외에 `/start <code>` 도
-  페어링 명령으로 인식 (regex `^\/(pair|start)\s+(\S+)`). Telegram deep link 클릭
-  시 자동 전송되는 `/start` 명령을 페어링 전용으로 해석. backward-compat — 기존
-  `/pair` 흐름 그대로.
+  페어링 명령으로 인식 (regex `^\/(pair|start)\s+(\S+)\s*$`, **strict matching** —
+  trailing arg 가 붙은 입력 silent ignore, PR #139 review). Telegram deep link
+  클릭 시 전달되는 `/start` 명령을 페어링 전용으로 해석. backward-compat —
+  기존 `/pair` 흐름 그대로.
 - `runSetupSubcommand` 의 페어링 안내 출력이 두 경로 모두 표시:
-  - (A) deep link URL — `https://t.me/${botInfo.username}?start=${code}`. 클릭 시
-    Telegram 앱 자동 열림 + `/start <code>` 자동 전송 → 페어링 완료.
+  - (A) deep link URL — `https://t.me/${botInfo.username}?start=${encodeURIComponent(code)}`
+    (PR #139 review — code 형식 후속 변경 방어). 클릭 시 Telegram 앱이 봇 대화
+    창으로 열림. 봇을 처음 여는 경우 "Start" 버튼 클릭 후 `/start <code>` 전달
+    → 페어링 완료.
   - (B) 수동 `/pair <code>` 명령 — 기존 흐름 (사용자가 봇 검색 + 수동 입력).
 - pairing daemon 시작 log 메시지도 두 경로 모두 안내.
 
@@ -53,4 +56,8 @@ PR #136 review (메시지 #792) 에서 HetrixTools / UptimeRobot 류의 "공식 
 
 **backward-compat 완전** — 기존 `/pair <code>` 사용자는 동작 무변경. config /
 public API contract 변경 없음 — `runSetupSubcommand` / `runPairingBot` 의 시그
-니처 그대로, 출력 내용만 확장.
+니처 그대로, 출력 내용 + regex 의 strict matching 만 확장.
+
+**Bump 의도** — `@token-weather/telegram` 의 동작 추가가 본질. linked 정책 (PR
+#131 review 결정, v0.x 단순성 우선) 으로 4 패키지 모두 minor 가 동시 누적. v0.5.0
+publish 전 follow-up 의 일관성 유지.

--- a/.changeset/telegram-pairing-deeplink.md
+++ b/.changeset/telegram-pairing-deeplink.md
@@ -1,0 +1,56 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): 페어링을 Telegram deep link 로 단순화 — 5 step → 2 step (issue #137).
+
+5-phase plan (#126~#130) 의 follow-up. Phase 4 (#129) 의 `telegram setup` 페어링은
+사용자가 봇을 직접 찾아 `/pair TGW-XXXXXX` 를 손으로 입력하는 5 단계 흐름이었다.
+
+PR #136 review (메시지 #792) 에서 HetrixTools / UptimeRobot 류의 "공식 봇 + 백엔드
+페어링" 패턴 (클릭 한 번) 과 비교되었고, token-weather 의 보안 모델 (로컬 only /
+공식 봇 없음) 위에서도 **Telegram deep link** (`t.me/<bot>?start=<code>`) 로 사용자
+단계를 1 클릭으로 줄일 수 있음을 검토 (메시지 #797). 본 release 가 도입.
+
+**신규 동작** (`@token-weather/telegram`):
+
+- `runPairingBot` 의 message:text 핸들러가 `/pair <code>` 외에 `/start <code>` 도
+  페어링 명령으로 인식 (regex `^\/(pair|start)\s+(\S+)`). Telegram deep link 클릭
+  시 자동 전송되는 `/start` 명령을 페어링 전용으로 해석. backward-compat — 기존
+  `/pair` 흐름 그대로.
+- `runSetupSubcommand` 의 페어링 안내 출력이 두 경로 모두 표시:
+  - (A) deep link URL — `https://t.me/${botInfo.username}?start=${code}`. 클릭 시
+    Telegram 앱 자동 열림 + `/start <code>` 자동 전송 → 페어링 완료.
+  - (B) 수동 `/pair <code>` 명령 — 기존 흐름 (사용자가 봇 검색 + 수동 입력).
+- pairing daemon 시작 log 메시지도 두 경로 모두 안내.
+
+**UX 비교**:
+
+| 기존 (#129)                       | deep link (#137)                                  |
+| --------------------------------- | ------------------------------------------------- |
+| 1. setup 출력의 `TGW-XXXXXX` 복사 | 1. setup 출력의 URL 클릭                          |
+| 2. Telegram 앱 열기               | 2. Telegram 앱 자동 열림 + `/start ...` 자동 전송 |
+| 3. 봇 검색 / 선택                 |                                                   |
+| 4. `/pair TGW-XXXXXX` 수동 입력   |                                                   |
+| 5. 전송                           |                                                   |
+
+**5 단계 → 2 단계**. BotFather 단계는 그대로 (자기 봇 모델의 본질).
+
+**문서**:
+
+- `docs/telegram-bot.md` — 빠른 시작 / 명령 표 / 봇 채팅 명령 표 모두 두 경로
+  안내. `/start <code>` / `/pair <code>` 두 페어링 전용 명령을 봇 명령 표에 추가.
+
+**테스트**:
+
+- `pairing.test.js` — `/start <code>` 정상 페어링 + `/start <wrong-code>` mismatch
+  대응 2 케이스.
+- `setup-subcommand.test.js` — deep link URL log 출력 + 기존 `/pair` 안내 보존
+  단언.
+
+**backward-compat 완전** — 기존 `/pair <code>` 사용자는 동작 무변경. config /
+public API contract 변경 없음 — `runSetupSubcommand` / `runPairingBot` 의 시그
+니처 그대로, 출력 내용만 확장.

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -16,6 +16,7 @@ npm install -g @token-weather/cli @token-weather/telegram
 
 # 3) 봇 토큰 + chat 페어링 + config 저장 + OS service 안내까지 한 명령으로
 token-weather telegram setup
+#    토큰 prompt → getMe 검증 → 출력의 deep link 클릭 (또는 /pair 수동 입력) → 자동 페어링
 
 # 4) (선택) OS service 등록 — setup 끝에서 안내한 블록을 복사 / 붙여넣기
 
@@ -30,7 +31,7 @@ token-weather telegram start
 
 | 명령                                                 | 설명                                                                                                      |
 | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → `/pair <code>` 페어링 → config 저장 (chmod 600) → OS service template print |
+| `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → **deep link 클릭** 또는 `/pair <code>` 수동 입력으로 페어링 → config 저장 (chmod 600) → OS service template print |
 | `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                             |
 | `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                       |
 | `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                       |
@@ -45,6 +46,8 @@ token-weather telegram start
 | `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")  |
 | `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단        |
 | `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션          |
+| `/start <code>`  | 페어링 전용 (setup 시점에만 의미). Telegram deep link 클릭 시 자동 전송 |
+| `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback     |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -16,7 +16,7 @@ npm install -g @token-weather/cli @token-weather/telegram
 
 # 3) 봇 토큰 + chat 페어링 + config 저장 + OS service 안내까지 한 명령으로
 token-weather telegram setup
-#    토큰 prompt → getMe 검증 → 출력의 deep link 클릭 (또는 /pair 수동 입력) → 자동 페어링
+#    토큰 prompt → getMe 검증 → 출력의 deep link 클릭 (또는 /pair 수동 입력) → 봇 대화창 열림 → (필요 시 Start 버튼 클릭) → 페어링 완료
 
 # 4) (선택) OS service 등록 — setup 끝에서 안내한 블록을 복사 / 붙여넣기
 
@@ -38,16 +38,16 @@ token-weather telegram start
 
 ## 봇이 받는 채팅 명령
 
-| Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                                    |
-| ---------------- | ----------------------------------------------------------------------- |
-| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                                    |
-| `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status")                |
-| `/usage`         | status alias — 평문                                                     |
-| `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")                 |
-| `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단                       |
-| `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션                         |
-| `/start <code>`  | 페어링 전용 (setup 시점에만 의미). Telegram deep link 클릭 시 자동 전송 |
-| `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback                   |
+| Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                                                                                  |
+| `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status")                                                              |
+| `/usage`         | status alias — 평문                                                                                                   |
+| `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")                                                               |
+| `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단                                                                     |
+| `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션                                                                       |
+| `/start <code>`  | 페어링 전용 (setup 시점에만 의미). Telegram deep link 클릭 → 봇 대화창 → (처음이면 Start 버튼) → `/start <code>` 전달 |
+| `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback                                                                 |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -29,25 +29,25 @@ token-weather telegram start
 
 ## 명령
 
-| 명령                                                 | 설명                                                                                                      |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| 명령                                                 | 설명                                                                                                                                            |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → **deep link 클릭** 또는 `/pair <code>` 수동 입력으로 페어링 → config 저장 (chmod 600) → OS service template print |
-| `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                             |
-| `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                       |
-| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                       |
+| `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                                                                   |
+| `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                                                             |
+| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                                                             |
 
 ## 봇이 받는 채팅 명령
 
-| Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                     |
-| ---------------- | -------------------------------------------------------- |
-| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                     |
-| `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status") |
-| `/usage`         | status alias — 평문                                      |
-| `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")  |
-| `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단        |
-| `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션          |
+| Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                                    |
+| ---------------- | ----------------------------------------------------------------------- |
+| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                                    |
+| `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status")                |
+| `/usage`         | status alias — 평문                                                     |
+| `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")                 |
+| `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단                       |
+| `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션                         |
 | `/start <code>`  | 페어링 전용 (setup 시점에만 의미). Telegram deep link 클릭 시 자동 전송 |
-| `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback     |
+| `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback                   |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
 

--- a/packages/telegram/src/pairing.js
+++ b/packages/telegram/src/pairing.js
@@ -107,9 +107,13 @@ export async function runPairingBot(botToken, expectedCode, options = {}) {
       if (settled) return;
       const text = ctx?.message?.text?.trim?.() ?? '';
       // `/pair <code>` 와 `/start <code>` 둘 다 페어링 명령으로 인식 (issue #137).
-      // `/start` 는 Telegram deep link (`t.me/<bot>?start=<code>`) 클릭 시 자동
-      // 전송되는 명령이라 페어링 UX 단순화 (5 step → 2 step) 의 핵심.
-      const match = text.match(/^\/(pair|start)\s+(\S+)/);
+      // `/start` 는 Telegram deep link (`t.me/<bot>?start=<code>`) 클릭 시
+      // 전달되는 명령이라 페어링 UX 단순화 (5 step → 2 step) 의 핵심.
+      //
+      // strict matching — payload 가 정확히 한 토큰. `/pair <code> extra` 같이
+      // trailing arg 가 붙은 입력은 거부 (PR #139 review). 페어링 코드는
+      // authorization token 성격이라 입력 검증 엄격.
+      const match = text.match(/^\/(pair|start)\s+(\S+)\s*$/);
       if (!match) return;
       const submittedCode = match[2];
       if (submittedCode !== expectedCode) {

--- a/packages/telegram/src/pairing.js
+++ b/packages/telegram/src/pairing.js
@@ -106,9 +106,12 @@ export async function runPairingBot(botToken, expectedCode, options = {}) {
     bot.on?.('message:text', async (ctx) => {
       if (settled) return;
       const text = ctx?.message?.text?.trim?.() ?? '';
-      const match = text.match(/^\/pair\s+(\S+)/);
+      // `/pair <code>` 와 `/start <code>` 둘 다 페어링 명령으로 인식 (issue #137).
+      // `/start` 는 Telegram deep link (`t.me/<bot>?start=<code>`) 클릭 시 자동
+      // 전송되는 명령이라 페어링 UX 단순화 (5 step → 2 step) 의 핵심.
+      const match = text.match(/^\/(pair|start)\s+(\S+)/);
       if (!match) return;
-      const submittedCode = match[1];
+      const submittedCode = match[2];
       if (submittedCode !== expectedCode) {
         await ctx?.reply?.('코드가 일치하지 않습니다. 다시 확인해 주세요.').catch(() => {});
         return;
@@ -138,7 +141,7 @@ export async function runPairingBot(botToken, expectedCode, options = {}) {
     Promise.resolve(bot.init?.())
       .then(() => {
         log(
-          `[token-weather/telegram] 페어링 daemon 시작 — 봇에 \`/pair ${expectedCode}\` 입력 대기 중...`,
+          `[token-weather/telegram] 페어링 daemon 시작 — \`/pair ${expectedCode}\` 입력 또는 deep link 클릭 대기 중...`,
         );
         bot.start?.({ drop_pending_updates: true })?.catch?.((err) => {
           if (settled) return;

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -106,8 +106,9 @@ export async function runSetupSubcommand(args, deps, options = {}) {
   log('');
   log('▶ 다음 중 하나로 페어링하세요:');
   log('');
-  log('  (A) 아래 링크를 클릭하면 Telegram 앱이 자동으로 열리며 페어링됩니다:');
+  log('  (A) 아래 링크를 클릭하면 Telegram 앱이 봇 대화창으로 열립니다:');
   log(`      ${deepLink}`);
+  log('      봇을 처음 여는 경우 "Start" 버튼이 보이면 한 번 누르세요 (페어링 코드는 자동 전달).');
   log('');
   log(`  (B) Telegram 앱에서 @${validation.botInfo.username} 봇에게 다음 명령을 직접 입력:`);
   log(`      /pair ${code}`);

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -98,7 +98,11 @@ export async function runSetupSubcommand(args, deps, options = {}) {
   // 3) 1회용 코드 + 페어링 안내. deep link / 수동 명령 두 경로 모두 안내 (issue
   //    #137 — Telegram deep link 클릭 한 번으로 /start <code> 자동 전송 가능).
   const code = generatePairingCode();
-  const deepLink = `https://t.me/${validation.botInfo.username}?start=${code}`;
+  // deep link URL — code 를 encodeURIComponent 로 감싸 방어 (PR #139 review).
+  // 현재 generatePairingCode 가 URL-safe (`TGW-XXXXXX`) 라 사실상 영향 없지만,
+  // code 형식이 후속에 바뀌어도 안전. Telegram username 규칙은 URL path 안전이라
+  // 별도 encoding 불필요.
+  const deepLink = `https://t.me/${validation.botInfo.username}?start=${encodeURIComponent(code)}`;
   log('');
   log('▶ 다음 중 하나로 페어링하세요:');
   log('');

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -95,14 +95,20 @@ export async function runSetupSubcommand(args, deps, options = {}) {
   }
   log(`✓ 봇 핸들: @${validation.botInfo.username}`);
 
-  // 3) 1회용 코드 + 페어링 안내.
+  // 3) 1회용 코드 + 페어링 안내. deep link / 수동 명령 두 경로 모두 안내 (issue
+  //    #137 — Telegram deep link 클릭 한 번으로 /start <code> 자동 전송 가능).
   const code = generatePairingCode();
+  const deepLink = `https://t.me/${validation.botInfo.username}?start=${code}`;
   log('');
-  log(`▶ Telegram 에서 @${validation.botInfo.username} 봇에게 다음 명령을 보내세요:`);
+  log('▶ 다음 중 하나로 페어링하세요:');
   log('');
-  log(`    /pair ${code}`);
+  log('  (A) 아래 링크를 클릭하면 Telegram 앱이 자동으로 열리며 페어링됩니다:');
+  log(`      ${deepLink}`);
   log('');
-  log('   (5 분 안에 입력하지 않으면 setup 이 취소됩니다.)');
+  log(`  (B) Telegram 앱에서 @${validation.botInfo.username} 봇에게 다음 명령을 직접 입력:`);
+  log(`      /pair ${code}`);
+  log('');
+  log('   (5 분 안에 진행하지 않으면 setup 이 취소됩니다.)');
 
   // 4) 페어링 daemon 부팅 + chat_id 캡처.
   let pairingResult;

--- a/packages/telegram/test/pairing.test.js
+++ b/packages/telegram/test/pairing.test.js
@@ -154,6 +154,23 @@ describe('runPairingBot (Phase 4)', () => {
     assert.ok(ctx.replies.some((m) => m.includes('페어링 완료')));
   });
 
+  it('/pair <code> <extra> 같이 trailing arg 가 붙은 입력은 거부 (PR #139 review)', async () => {
+    const mock = makeMockBot();
+    const pending = runPairingBot('123:fake', 'TGW-ABC123', {
+      botFactory: () => mock,
+      logger: { log: () => {} },
+      timeoutMs: 200,
+    });
+    await new Promise((r) => setImmediate(r));
+    // trailing arg 가 붙으면 strict regex 가 fail — 핸들러는 silent ignore (return)
+    // → reply / settle 없이 timeout 까지 대기.
+    const ctx = makeCtx('/pair TGW-ABC123 extra', { from: { id: 42 } });
+    await mock._fire(ctx);
+    assert.equal(ctx.replies.length, 0, 'trailing arg 입력은 silent — reply 없음');
+    assert.equal(mock.stopped, false);
+    await assert.rejects(() => pending, /pairing timeout/);
+  });
+
   it('/start <wrong-code> 도 mismatch 응답 (대기 지속)', async () => {
     const mock = makeMockBot();
     const pending = runPairingBot('123:fake', 'TGW-ABC123', {

--- a/packages/telegram/test/pairing.test.js
+++ b/packages/telegram/test/pairing.test.js
@@ -136,6 +136,39 @@ describe('runPairingBot (Phase 4)', () => {
     assert.ok(ctx.replies.some((m) => m.includes('페어링 완료')));
   });
 
+  it('/start <code> 도 페어링 명령으로 인식 — deep link 동치 (issue #137)', async () => {
+    const mock = makeMockBot();
+    const pending = runPairingBot('123:fake', 'TGW-ABC123', {
+      botFactory: () => mock,
+      logger: { log: () => {} },
+    });
+    await new Promise((r) => setImmediate(r));
+    // `/start <code>` 가 Telegram deep link 클릭 시 자동 전송되는 명령. `/pair`
+    // 와 동치로 페어링이 완료되어야 한다.
+    const ctx = makeCtx('/start TGW-ABC123', { from: { id: 99, username: 'bob' } });
+    await mock._fire(ctx);
+    const result = await pending;
+    assert.equal(result.userId, '99');
+    assert.equal(result.username, 'bob');
+    assert.equal(mock.stopped, true);
+    assert.ok(ctx.replies.some((m) => m.includes('페어링 완료')));
+  });
+
+  it('/start <wrong-code> 도 mismatch 응답 (대기 지속)', async () => {
+    const mock = makeMockBot();
+    const pending = runPairingBot('123:fake', 'TGW-ABC123', {
+      botFactory: () => mock,
+      logger: { log: () => {} },
+      timeoutMs: 200,
+    });
+    await new Promise((r) => setImmediate(r));
+    const ctx = makeCtx('/start TGW-WRONG', { from: { id: 42 } });
+    await mock._fire(ctx);
+    assert.ok(ctx.replies.some((m) => m.includes('코드가 일치하지 않습니다')));
+    assert.equal(mock.stopped, false);
+    await assert.rejects(() => pending, /pairing timeout/);
+  });
+
   it('일치하지 않는 code 는 안내 + 대기 지속', async () => {
     const mock = makeMockBot();
     const pending = runPairingBot('123:fake', 'TGW-ABC123', {

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -173,6 +173,10 @@ describe('runSetupSubcommand (Phase 4)', () => {
     const out = logs.join('\n');
     assert.match(out, /부팅 후 자동 시작/);
     assert.match(out, /token-weather telegram start/);
+    // deep link URL 안내 포함 (issue #137) — t.me/<botUsername>?start=<code> 패턴.
+    assert.match(out, /https:\/\/t\.me\/MyBot\?start=TGW-/);
+    // 기존 수동 /pair <code> 안내도 보존 (backward-compat).
+    assert.match(out, /\/pair TGW-/);
     assert.equal(process.exitCode, 0);
   });
 


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan (#126~#130) 의 follow-up. Phase 4 (#129) 의 페어링이 사용자가 봇을 직접 찾아 `/pair TGW-XXXXXX` 를 손으로 입력하는 5 단계 흐름이었던 것을 **Telegram deep link** (`t.me/<bot>?start=<code>`) 로 1 클릭 흐름으로 단순화합니다.

PR #136 review 의 메시지 #792 (HetrixTools / UptimeRobot 류 비교) → #797 (검토) → #800 (사용자 진행 결정) 후속.

## 변경 내용

### `packages/telegram/src/pairing.js`
- message:text 핸들러 regex: `^\/pair\s+(\S+)` → `^\/(pair|start)\s+(\S+)`. `match[2]` 가 code.
- daemon 시작 log 갱신 — "`/pair <code>` 입력 또는 deep link 클릭 대기 중...".

### `packages/telegram/src/setup-subcommand.js`
- 페어링 안내 출력 재구성:
  - (A) deep link URL — `https://t.me/${botInfo.username}?start=${code}`.
  - (B) 수동 `/pair <code>` 명령 — backward-compat.
- 사용자가 환경 / 선호에 따라 선택.

### 테스트
- `pairing.test.js` (2 신규): `/start <code>` 정상 페어링 + `/start <wrong-code>` mismatch 대응.
- `setup-subcommand.test.js`: deep link URL log + 기존 `/pair` 안내 보존 단언.

### 문서
- `docs/telegram-bot.md` — 빠른 시작 의 setup 단계 / 명령 표 의 setup 행 / 봇 채팅 명령 표 (`/start <code>` + `/pair <code>` 페어링 전용 명령 추가).

### Changeset
- `.changeset/telegram-pairing-deeplink.md` — 4 패키지 모두 minor (linked).

## UX 비교

| 기존 (#129) | deep link (본 PR) |
|---|---|
| 1. setup 출력의 `TGW-XXXXXX` 복사 | 1. setup 출력의 URL 클릭 |
| 2. Telegram 앱 열기 | 2. Telegram 앱 자동 열림 + `/start ...` 자동 전송 |
| 3. 봇 검색 / 선택 | |
| 4. `/pair TGW-XXXXXX` 수동 입력 | |
| 5. 전송 | |

**5 단계 → 2 단계**.

## 변경 이유

token-weather 의 보안 모델 (로컬 only / 공식 봇 없음) 을 유지하면서 HetrixTools 류의 "클릭 한 번 페어링" UX 를 달성. BotFather 단계는 그대로 유지 (자기 봇 모델의 본질).

## 영향 범위

- [x] `packages/telegram` — pairing.js regex + setup-subcommand.js 안내 + 2 테스트 파일
- [ ] `packages/agent` / `schemas` / `provider-adapters` — 무변경
- [x] `docs` — `docs/telegram-bot.md` 의 페어링 흐름 안내
- [x] `repo` — `.changeset/telegram-pairing-deeplink.md`

## 테스트 / 확인

- `npm test` — 1001 통과 (직전 999 + 신규 2)
- `npm run lint` / `format:check` / `build:types` / `install-smoke.sh` 모두 통과
- `npx changeset status` — 4 패키지 모두 minor 인식

## 리뷰 포인트

1. **regex 통합** vs 별도 분기 — `^\/(pair|start)\s+(\S+)` 한 줄 변경으로 두 명령 동치 처리. 명시성보다 단순성 선택.
2. **두 경로 모두 안내** — deep link 만 vs 둘 다. fallback 보장 (deep link 가 안 열리는 환경 / 사용자가 봇 검색 선호) 위해 둘 다 채택.
3. **backward-compat** — 기존 `/pair <code>` 사용자 동작 무변경. 모든 기존 테스트 (Phase 4 의 11 케이스) 그대로 통과.
4. **`/start` 의 다른 용도와 충돌** — Telegram 봇의 `/start` 는 일반적으로 환영 메시지. 본 봇은 페어링 전용 봇이라 `/start` 가 페어링 외 용도로 쓰일 일 없음.

## 후속

본 PR 완료 후 issue #138 (OS service 자동 등록) 진입 가능.

## 참고

- Closes #137.
- bump: minor (`runPairingBot` 의 message 인식 contract 확장 — 동작 추가).
- 5-phase Telegram 봇 통합 plan: #126 / #127 / #128 / #129 / #130 모두 완료.
- 검토 thread: PR #136 의 메시지 #792 → #797 → #800.