### PR TITLE
[feat] telegram setup 의 OS service 자동 등록 옵션 — 5+ 줄 셸 명령 → Enter 한 번 (issue #138)

### DIFF
--- a/.changeset/telegram-os-service-installer.md
+++ b/.changeset/telegram-os-service-installer.md
@@ -1,0 +1,86 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): OS service 자동 등록 옵션 — 5+ 줄 셸 명령 → Enter 한 번 (issue #138).
+
+5-phase plan (#126~#130) 의 후속 follow-up. Phase 4 (#129) 의 `telegram setup` 은
+OS service template 를 **print 만** 했는데, 본 release 부터 동의 기반 자동 등록을
+지원한다. 보안 도구 원칙 유지 — Y default 프롬프트 + 사용자 명시 n / detect skip
+시 기존 수동 안내 fallback.
+
+PR #136 review (메시지 #796) 의 오픈클로 게이트웨이 비교에서 출발 → 메시지 #798
+의 사용자 결정 사양 (Y default / skip+안내 / service+linger 까지만 uninstall) →
+본 release 가 구현.
+
+**신규 동작**:
+
+- `telegram setup` 의 마지막 단계가 `자동으로 설치하시겠습니까? [Y/n]` 프롬프트를
+  표시:
+  - **Y (default)**: token-weather 가 직접 systemd unit / launchd plist / Task
+    Scheduler 항목을 작성 + 활성화 (`systemctl --user enable --now` /
+    `launchctl bootstrap` / `schtasks /Create`). Linux 는 `loginctl enable-linger`
+    까지 자동 (best-effort).
+  - **n**: 자동 등록 건너뜀 → 기존 수동 안내 블록 출력 (Phase 4 와 동일).
+  - **systemd / launchctl / schtasks 미감지** (WSL / Docker / Alpine OpenRC 등):
+    자동 skip + 수동 안내 fallback. install 실패하지 않음.
+- 신규 서브명령 `telegram uninstall-service`:
+  - 작성된 service 항목을 confirm (default Y) 후 제거.
+  - 책임 범위: service 파일 + Linux linger 까지. **config / auth.json 은 건드리지
+    않음** — 봇 설정 자체를 지우려면 사용자가 명시적으로 config 편집.
+
+**신규 public export** (`@token-weather/telegram`):
+
+- `installOsService(input, options)` / `uninstallOsService(options)` — OS detect →
+  분기. 미지원 platform 은 `{ status: 'skipped' }`.
+- `installSystemdUnit` / `uninstallSystemdUnit` / `installLaunchAgent` /
+  `uninstallLaunchAgent` / `installTaskScheduler` / `uninstallTaskScheduler` —
+  OS 별 install / uninstall 실 구현.
+- `runUninstallServiceSubcommand(args, deps, options?)` —
+  `telegram uninstall-service` 의 진입점.
+- `formatTelegramUninstallServiceHelp()` — `--help` 안내.
+- `parseYesNo(answer, defaultYes)` — Y/N 응답 파싱 helper.
+
+**부수 변경** (`@token-weather/telegram` 의 `os-service-templates.js`):
+
+- `linuxSystemdUnit` / `macosLaunchAgent` 의 반환 객체에 `content` / `serviceFilename`
+  키 추가 — installer 가 직접 fs.writeFile 로 작성할 raw unit content. 기존
+  `instructions` (manual heredoc) 은 그대로 보존, backward-compat 완전.
+
+**UX 비교**:
+
+| 기존 (#129)                            | 자동 등록 (본 issue)                     |
+| -------------------------------------- | ---------------------------------------- |
+| 1. setup 끝의 template 블록 보기       | 1. setup 끝의 `자동 설치 [Y/n]` 프롬프트 |
+| 2. 5+ 줄 셸 명령 셸에 복사 / 붙여넣기  | 2. Enter → 자동 등록 완료                |
+| 3. 무시하고 `telegram start` 수동 실행 | 3. 거부 시 기존 수동 안내 fallback       |
+
+5+ 줄 셸 명령 → Enter 한 번. 보안 원칙 (동의 필요) 유지.
+
+**위험 / Fallback**:
+
+- WSL / Docker container / Alpine OpenRC: `systemctl --version` 등 사전 detect →
+  skip + 수동 안내. install 실패 X.
+- nvm / fnm path stale: install 완료 메시지에 "Node 버전 매니저 변경 시
+  `telegram setup` 재실행 권장" 안내.
+- 기존 service 파일 충돌: hash 비교 → 다르면 confirm (default n) → 사용자 명시
+  y 시만 덮어쓰기.
+- install 중간 실패: try / catch + cleanup (작성한 파일 unlink) + status 'failed'
+  → 수동 안내 fallback.
+- uninstall 의 linger 비활성화: 다른 user-level service 도 영향 가능 — 안내
+  텍스트에 명시.
+
+**config / public API contract** 변경 없음 — `runSetupSubcommand` / `runTelegramCommand`
+의 시그니처 그대로, 동작 추가 + 신규 export 만.
+
+**Bump 의도** — `@token-weather/telegram` 의 동작 추가가 본질. linked 정책
+(release-policy §1, v0.x 단순성 우선) 으로 4 패키지 모두 minor 가 동시 누적.
+
+**문서**:
+
+- `docs/telegram-bot.md` — §빠른 시작 / §명령 표 / §OS service 등록 모두 갱신.
+  자동 등록 / fallback / uninstall-service 흐름 안내. 기존 수동 등록 안내는
+  fallback section 으로 보존.

--- a/.changeset/telegram-os-service-installer.md
+++ b/.changeset/telegram-os-service-installer.md
@@ -67,9 +67,18 @@ PR #136 review (메시지 #796) 의 오픈클로 게이트웨이 비교에서 �
 - nvm / fnm path stale: install 완료 메시지에 "Node 버전 매니저 변경 시
   `telegram setup` 재실행 권장" 안내.
 - 기존 service 파일 충돌: hash 비교 → 다르면 confirm (default n) → 사용자 명시
-  y 시만 덮어쓰기.
-- install 중간 실패: try / catch + cleanup (작성한 파일 unlink) + status 'failed'
-  → 수동 안내 fallback.
+  y 시만 덮어쓰기. Windows 도 동일 정책 — `schtasks /Query` 사전 검사 (PR #140
+  review blocker 2).
+- 충돌 시 confirm 의 실 동작 정합 (PR #140 review blocker 1) — setup 경로에서
+  `options.confirmFn` 미주입 시 자동으로 `promptFn` 기반 adapter build, 실제
+  프롬프트로 사용자 결정 받음.
+- install 중간 실패: try / catch + **backup / restore** (PR #140 review). 기존
+  파일이 있었으면 cleanup 시 unlink 대신 restore — 사용자 파일 손실 회피.
+- HOME / USER 환경변수 누락 (PR #140 review): HOME 없으면 status 'skipped' + manual
+  fallback. USER 없으면 linger 단계만 skip + log 안내.
+- 경로 공백 / XML 특수문자 (PR #140 review): 사전 검사 (`hasUnsafePathChars`) →
+  발견 시 즉시 status 'skipped' + manual 안내. 정확한 escaping helper 는 별도
+  follow-up.
 - uninstall 의 linger 비활성화: 다른 user-level service 도 영향 가능 — 안내
   텍스트에 명시.
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -61,6 +61,7 @@ token-weather telegram uninstall-service
 - **Enter / y** (default): token-weather 가 직접 systemd unit / launchd plist / Task Scheduler 항목을 작성 + 활성화 (`systemctl --user enable --now` / `launchctl bootstrap` / `schtasks /Create`). Linux 는 `loginctl enable-linger` 까지 자동 (best-effort).
 - **n**: 자동 등록 건너뜀 → 아래 수동 안내 블록을 사용자가 복사 / 붙여넣기.
 - **systemd / launchctl / schtasks 미감지** (WSL / Docker container / Alpine OpenRC 등): 자동 skip + 동일한 수동 안내 출력.
+- **경로에 공백 / 특수문자 (예: Windows 의 `C:\Program Files\nodejs\node.exe`)**: 자동 skip + 수동 안내 fallback. systemd unit / launchd plist (XML) / cmd.exe quoting 의 escape 규칙과 충돌 위험을 사전 차단. Windows 표준 Node 설치 환경은 보통 이 경로에 해당 — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장 (정확한 escaping helper 도입은 follow-up issue).
 
 자동 등록을 나중에 해제하려면 `token-weather telegram uninstall-service`. 책임 범위는 service / linger 까지 (config / auth.json 은 그대로 유지).
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -14,27 +14,30 @@ npm install -g @token-weather/cli @token-weather/telegram
 #    https://core.telegram.org/bots#how-do-i-create-a-bot
 #    /newbot → 이름 + username 선택 → 토큰 복사
 
-# 3) 봇 토큰 + chat 페어링 + config 저장 + OS service 안내까지 한 명령으로
+# 3) 봇 토큰 + chat 페어링 + config 저장 + OS service 자동 등록 / 안내까지 한 명령으로
 token-weather telegram setup
-#    토큰 prompt → getMe 검증 → 출력의 deep link 클릭 (또는 /pair 수동 입력) → 봇 대화창 열림 → (필요 시 Start 버튼 클릭) → 페어링 완료
+#    토큰 prompt → getMe 검증 → 출력의 deep link 클릭 → (Start 버튼) → 페어링 완료
+#    → "자동으로 설치하시겠습니까? [Y/n]" → Enter → systemd / launchd / Task Scheduler 자동 등록
 
-# 4) (선택) OS service 등록 — setup 끝에서 안내한 블록을 복사 / 붙여넣기
-
-# 5) (선택) 진단
+# 4) (선택) 진단
 token-weather telegram check
 
-# 6) 수동 실행 (OS service 안 쓸 때)
+# 5) 수동 실행 (OS service 안 쓸 때)
 token-weather telegram start
+
+# 6) 제거 (자동 등록 해제)
+token-weather telegram uninstall-service
 ```
 
 ## 명령
 
-| 명령                                                 | 설명                                                                                                                                            |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → **deep link 클릭** 또는 `/pair <code>` 수동 입력으로 페어링 → config 저장 (chmod 600) → OS service template print |
-| `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                                                                   |
-| `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                                                             |
-| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                                                             |
+| 명령                                                 | 설명                                                                                                                                                                   |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `token-weather telegram setup`                       | 봇 토큰 입력 → `getMe` 검증 → **deep link 클릭** 또는 `/pair <code>` 수동 입력 → config 저장 (chmod 600) → **OS service 자동 등록 [Y/n]** (거부 시 수동 안내 fallback) |
+| `token-weather telegram start`                       | long-poll daemon foreground 실행. Ctrl+C 종료                                                                                                                          |
+| `token-weather telegram check`                       | config / token / chmod / linger 상태 read-only 진단                                                                                                                    |
+| `token-weather telegram uninstall-service`           | `setup` 으로 등록된 OS service 제거 (config / auth.json 은 유지)                                                                                                       |
+| `... telegram --help`<br>`... telegram <sub> --help` | 각 명령의 안내 출력                                                                                                                                                    |
 
 ## 봇이 받는 채팅 명령
 
@@ -51,9 +54,17 @@ token-weather telegram start
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
 
-## OS service 수동 등록
+## OS service 등록
 
-`telegram setup` 끝에서 print 되는 명령 블록을 셸에 복사 / 붙여넣기 하면 부팅 후 자동 시작이 활성화됩니다. token-weather 가 시스템 파일을 직접 만들지 **않습니다** — 사용자 동의가 필요한 변경이라는 보안 도구 원칙.
+`telegram setup` 의 마지막 단계가 **`자동으로 설치하시겠습니까? [Y/n]`** 프롬프트를 표시합니다:
+
+- **Enter / y** (default): token-weather 가 직접 systemd unit / launchd plist / Task Scheduler 항목을 작성 + 활성화 (`systemctl --user enable --now` / `launchctl bootstrap` / `schtasks /Create`). Linux 는 `loginctl enable-linger` 까지 자동 (best-effort).
+- **n**: 자동 등록 건너뜀 → 아래 수동 안내 블록을 사용자가 복사 / 붙여넣기.
+- **systemd / launchctl / schtasks 미감지** (WSL / Docker container / Alpine OpenRC 등): 자동 skip + 동일한 수동 안내 출력.
+
+자동 등록을 나중에 해제하려면 `token-weather telegram uninstall-service`. 책임 범위는 service / linger 까지 (config / auth.json 은 그대로 유지).
+
+### 수동 등록 (자동 등록 거부 / skip 시)
 
 > ⚠ 아래 코드 블록은 **구조 예시** 입니다. `/path/to/node` / `/path/to/token-weather` 같은 placeholder 는 실제 환경에서 다르며, **`telegram setup` 출력의 절대 경로를 그대로 복사** 해 주세요. 경로에 공백 / 특수문자가 있는 경우 setup 출력의 정확한 quoting 을 반드시 따라야 합니다.
 

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -17,6 +17,7 @@ import { createBotServer } from './bot-server.js';
 import { buildDispatcher } from './dispatcher.js';
 import { runSetupSubcommand } from './setup-subcommand.js';
 import { runCheckSubcommand } from './check-subcommand.js';
+import { runUninstallServiceSubcommand } from './uninstall-service-subcommand.js';
 
 export { createBotServer, handleTextMessage } from './bot-server.js';
 export { buildDispatcher } from './dispatcher.js';
@@ -38,6 +39,21 @@ export {
 } from './os-service-templates.js';
 export { runSetupSubcommand, formatTelegramSetupHelp } from './setup-subcommand.js';
 export { runCheckSubcommand, formatTelegramCheckHelp } from './check-subcommand.js';
+export {
+  runUninstallServiceSubcommand,
+  formatTelegramUninstallServiceHelp,
+} from './uninstall-service-subcommand.js';
+export {
+  installOsService,
+  uninstallOsService,
+  installSystemdUnit,
+  uninstallSystemdUnit,
+  installLaunchAgent,
+  uninstallLaunchAgent,
+  installTaskScheduler,
+  uninstallTaskScheduler,
+  parseYesNo,
+} from './os-service-installer.js';
 
 let _activeServer = null;
 
@@ -95,6 +111,10 @@ export async function runTelegramCommand(argv, deps) {
     await runCheckSubcommand(rest, deps);
     return;
   }
+  if (subcommand === 'uninstall-service') {
+    await runUninstallServiceSubcommand(rest, deps);
+    return;
+  }
   console.error(`알 수 없는 telegram 서브명령: ${subcommand}`);
   for (const line of formatTelegramHelp()) console.error(line);
   process.exitCode = 1;
@@ -110,9 +130,10 @@ export function formatTelegramHelp() {
     'Telegram 봇 daemon 으로 status / usage / doctor / auth list 명령을 원격 호출.',
     '',
     'Subcommands:',
-    '  setup    대화형 봇 토큰 등록 + 페어링 + OS service template 안내',
-    '  start    Telegram 봇 long-poll daemon 시작 (foreground, Ctrl+C 종료)',
-    '  check    설정 / token / linger 상태 read-only 진단',
+    '  setup              대화형 봇 토큰 등록 + 페어링 + OS service 자동 등록 / template 안내',
+    '  start              Telegram 봇 long-poll daemon 시작 (foreground, Ctrl+C 종료)',
+    '  check              설정 / token / linger 상태 read-only 진단',
+    '  uninstall-service  setup 으로 등록된 OS service 제거 (config 는 유지)',
     '',
     'Options:',
     '  -h, --help   이 도움말 출력',

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -112,7 +112,9 @@ export async function installSystemdUnit(input, options = {}) {
   const serviceDir = path.join(home, SYSTEMD_USER_DIR);
   const servicePath = path.join(serviceDir, tmpl.serviceFilename);
 
-  // 2) 기존 파일 충돌 검사.
+  // 2) 기존 파일 충돌 검사. 충돌 시 backup 으로 보존 — install 실패 시 restore
+  //    (PR #140 review). 기존 사용자 파일 손실 회피.
+  let backup = null;
   if (fsImpl.existsSync(servicePath)) {
     const existing = fsImpl.readFileSync(servicePath, 'utf8');
     if (existing.trim() !== tmpl.content.trim()) {
@@ -126,6 +128,7 @@ export async function installSystemdUnit(input, options = {}) {
           message: `사용자가 덮어쓰기 거부 — ${servicePath} 보존`,
         };
       }
+      backup = existing;
     }
   }
 
@@ -153,13 +156,16 @@ export async function installSystemdUnit(input, options = {}) {
       steps,
     };
   } catch (err) {
-    // cleanup — 작성한 파일 삭제 + disable 시도.
-    if (fsImpl.existsSync(servicePath)) {
-      try {
+    // cleanup — backup 이 있으면 restore, 없으면 새로 쓴 파일 unlink (PR #140 review).
+    try {
+      if (backup !== null) {
+        fsImpl.writeFileSync(servicePath, backup);
+        log(`ℹ install 실패 — 기존 service 파일 restore: ${servicePath}`);
+      } else if (fsImpl.existsSync(servicePath)) {
         fsImpl.unlinkSync(servicePath);
-      } catch {
-        // ignore
       }
+    } catch {
+      // ignore — restore / unlink 실패는 사용자에게 안내만.
     }
     return {
       status: 'failed',
@@ -240,6 +246,8 @@ export async function installLaunchAgent(input, options = {}) {
   const agentsDir = path.join(home, LAUNCH_AGENTS_DIR);
   const plistPath = path.join(agentsDir, tmpl.serviceFilename);
 
+  // 충돌 검사 + backup (PR #140 review — overwrite 후 실패 시 restore).
+  let backup = null;
   if (fsImpl.existsSync(plistPath)) {
     const existing = fsImpl.readFileSync(plistPath, 'utf8');
     if (existing.trim() !== tmpl.content.trim()) {
@@ -250,9 +258,11 @@ export async function installLaunchAgent(input, options = {}) {
       if (!overwrite) {
         return { status: 'skipped', message: `사용자가 덮어쓰기 거부 — ${plistPath} 보존` };
       }
+      backup = existing;
     }
   }
 
+  const log = options.log ?? ((msg) => console.log(msg));
   const steps = [];
   try {
     fsImpl.mkdirSync(agentsDir, { recursive: true });
@@ -268,12 +278,15 @@ export async function installLaunchAgent(input, options = {}) {
       steps,
     };
   } catch (err) {
-    if (fsImpl.existsSync(plistPath)) {
-      try {
+    try {
+      if (backup !== null) {
+        fsImpl.writeFileSync(plistPath, backup);
+        log(`ℹ install 실패 — 기존 plist restore: ${plistPath}`);
+      } else if (fsImpl.existsSync(plistPath)) {
         fsImpl.unlinkSync(plistPath);
-      } catch {
-        // ignore
       }
+    } catch {
+      // ignore
     }
     return {
       status: 'failed',

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -329,6 +329,7 @@ export async function uninstallLaunchAgent(options = {}) {
 
 export async function installTaskScheduler(input, options = {}) {
   const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
 
   try {
     execImpl('schtasks', ['/?']);
@@ -337,6 +338,28 @@ export async function installTaskScheduler(input, options = {}) {
       status: 'skipped',
       message: `schtasks 미감지 (${err?.message ?? '실행 실패'}) — 수동 등록 안내로 fallback`,
     };
+  }
+
+  // 기존 task 충돌 검사 — `/Query` 성공 시 동일 이름 task 존재 (PR #140 review
+  // blocker 2). systemd / launchd 와 일관된 사용자 파일 보호 정책.
+  let existing = false;
+  try {
+    execImpl('schtasks', ['/Query', '/TN', 'TokenWeatherBot']);
+    existing = true;
+  } catch {
+    // task 없음 — 정상 진행.
+  }
+  if (existing) {
+    const overwrite = await confirmFn(
+      '기존 Task Scheduler 항목 `TokenWeatherBot` 가 존재합니다. 덮어쓸까요?',
+      false,
+    );
+    if (!overwrite) {
+      return {
+        status: 'skipped',
+        message: '사용자가 덮어쓰기 거부 — 기존 TokenWeatherBot task 보존',
+      };
+    }
   }
 
   const steps = [];

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -1,0 +1,423 @@
+/**
+ * OS service 자동 등록 / 해제 — `telegram setup` 의 동의 프롬프트 + 별도
+ * `telegram uninstall-service` 명령이 호출.
+ *
+ * Phase 4 (#129) 의 OS service template print only 정책을 동의 기반 자동 등록
+ * 으로 확장 (issue #138). 보안 도구 원칙 유지 — 동의 프롬프트 default Y 지만
+ * 사용자가 명시 n 시 즉시 skip + 수동 안내 fallback.
+ *
+ * 모든 외부 의존성 (fs / exec / confirm / log / env / platform) 주입 가능 —
+ * 단위 테스트 친화.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { linuxSystemdUnit, macosLaunchAgent } from './os-service-templates.js';
+// Windows installer 는 schtasks 명령을 직접 박으므로 windowsTaskScheduler template
+// 이 필요 없음 (template 의 instructions 는 manual fallback 용도로 setup-
+// subcommand 가 사용).
+
+const SYSTEMD_USER_DIR = '.config/systemd/user';
+const LAUNCH_AGENTS_DIR = 'Library/LaunchAgents';
+
+/**
+ * @typedef {object} InstallerInput
+ * @property {string} nodeBinPath
+ * @property {string} cliScriptPath
+ * @property {string} [homeDir]
+ */
+
+/**
+ * @typedef {object} InstallerOptions
+ * @property {{ existsSync: Function, readFileSync: Function, writeFileSync: Function,
+ *   mkdirSync: Function, unlinkSync: Function }} [fsImpl]
+ * @property {(cmd: string, args: string[]) => string} [execImpl]
+ * @property {(question: string, defaultYes?: boolean) => Promise<boolean>} [confirmFn]
+ * @property {(msg: string) => void} [log]
+ * @property {(msg: string) => void} [errorLog]
+ * @property {{ HOME?: string, USER?: string }} [env]
+ * @property {NodeJS.Platform} [platform]
+ */
+
+/**
+ * @typedef {object} InstallResult
+ * @property {'installed' | 'skipped' | 'failed'} status
+ * @property {string} message
+ * @property {string[]} [steps]
+ * @property {string} [error]
+ */
+
+/**
+ * OS detect 후 적절한 installer 호출. 지원하지 않는 platform 은 skipped.
+ *
+ * @param {InstallerInput} input
+ * @param {InstallerOptions} [options]
+ * @returns {Promise<InstallResult>}
+ */
+export async function installOsService(input, options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform === 'linux') return installSystemdUnit(input, options);
+  if (platform === 'darwin') return installLaunchAgent(input, options);
+  if (platform === 'win32') return installTaskScheduler(input, options);
+  return {
+    status: 'skipped',
+    message: `지원하지 않는 platform (${platform}) — 수동 등록만 가능`,
+  };
+}
+
+/**
+ * OS detect 후 적절한 uninstaller 호출.
+ *
+ * @param {InstallerOptions} [options]
+ * @returns {Promise<InstallResult>}
+ */
+export async function uninstallOsService(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform === 'linux') return uninstallSystemdUnit(options);
+  if (platform === 'darwin') return uninstallLaunchAgent(options);
+  if (platform === 'win32') return uninstallTaskScheduler(options);
+  return {
+    status: 'skipped',
+    message: `지원하지 않는 platform (${platform}) — 수동 제거만 가능`,
+  };
+}
+
+// ─── Linux systemd ──────────────────────────────────────────────────────────
+
+export async function installSystemdUnit(input, options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
+  const log = options.log ?? ((msg) => console.log(msg));
+  const env = options.env ?? process.env;
+  const home = input.homeDir ?? env.HOME;
+  const user = env.USER ?? '';
+
+  // 1) systemd 존재 검사.
+  try {
+    execImpl('systemctl', ['--version']);
+  } catch (err) {
+    return {
+      status: 'skipped',
+      message: `systemd 미감지 (${err?.message ?? 'systemctl 실행 실패'}) — 수동 등록 안내로 fallback`,
+    };
+  }
+
+  const tmpl = linuxSystemdUnit({
+    nodeBinPath: input.nodeBinPath,
+    cliScriptPath: input.cliScriptPath,
+  });
+  const serviceDir = path.join(home, SYSTEMD_USER_DIR);
+  const servicePath = path.join(serviceDir, tmpl.serviceFilename);
+
+  // 2) 기존 파일 충돌 검사.
+  if (fsImpl.existsSync(servicePath)) {
+    const existing = fsImpl.readFileSync(servicePath, 'utf8');
+    if (existing.trim() !== tmpl.content.trim()) {
+      const overwrite = await confirmFn(
+        `기존 service 파일과 내용이 다릅니다: ${servicePath}\n덮어쓸까요?`,
+        false,
+      );
+      if (!overwrite) {
+        return {
+          status: 'skipped',
+          message: `사용자가 덮어쓰기 거부 — ${servicePath} 보존`,
+        };
+      }
+    }
+  }
+
+  // 3) install 시퀀스.
+  const steps = [];
+  try {
+    fsImpl.mkdirSync(serviceDir, { recursive: true });
+    steps.push(`mkdir -p ${serviceDir}`);
+    fsImpl.writeFileSync(servicePath, `${tmpl.content}\n`);
+    steps.push(`write ${servicePath}`);
+    execImpl('systemctl', ['--user', 'daemon-reload']);
+    steps.push('systemctl --user daemon-reload');
+    execImpl('systemctl', ['--user', 'enable', '--now', tmpl.serviceFilename]);
+    steps.push(`systemctl --user enable --now ${tmpl.serviceFilename}`);
+    // linger — 실패해도 warning + 계속 (loginctl 부재 가능 환경).
+    try {
+      execImpl('loginctl', ['enable-linger', user]);
+      steps.push(`loginctl enable-linger ${user}`);
+    } catch (err) {
+      log(`⚠ loginctl enable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+    }
+    return {
+      status: 'installed',
+      message: `systemd --user service 등록 완료. Node 버전 매니저 변경 시 \`telegram setup\` 재실행 권장.`,
+      steps,
+    };
+  } catch (err) {
+    // cleanup — 작성한 파일 삭제 + disable 시도.
+    if (fsImpl.existsSync(servicePath)) {
+      try {
+        fsImpl.unlinkSync(servicePath);
+      } catch {
+        // ignore
+      }
+    }
+    return {
+      status: 'failed',
+      message: `systemd install 실패 (cleanup 후) — 수동 등록 안내로 fallback`,
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+export async function uninstallSystemdUnit(options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
+  const log = options.log ?? ((msg) => console.log(msg));
+  const env = options.env ?? process.env;
+  const home = env.HOME ?? '';
+  const user = env.USER ?? '';
+
+  const serviceFilename = 'token-weather-bot.service';
+  const servicePath = path.join(home, SYSTEMD_USER_DIR, serviceFilename);
+
+  if (!fsImpl.existsSync(servicePath)) {
+    return {
+      status: 'skipped',
+      message: `service 파일 없음: ${servicePath} — 이미 제거되었거나 자동 설치된 적 없음`,
+    };
+  }
+
+  const ok = await confirmFn(
+    `다음을 제거합니다:\n  - ${servicePath}\n  - systemctl --user disable --now ${serviceFilename}\n  - loginctl disable-linger ${user} (다른 user-level service 도 영향)\n계속?`,
+    true,
+  );
+  if (!ok) return { status: 'skipped', message: '사용자가 제거 거부' };
+
+  const steps = [];
+  try {
+    execImpl('systemctl', ['--user', 'disable', '--now', serviceFilename]);
+    steps.push(`systemctl --user disable --now ${serviceFilename}`);
+    fsImpl.unlinkSync(servicePath);
+    steps.push(`unlink ${servicePath}`);
+    try {
+      execImpl('loginctl', ['disable-linger', user]);
+      steps.push(`loginctl disable-linger ${user}`);
+    } catch (err) {
+      log(`⚠ loginctl disable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+    }
+    return { status: 'installed', message: 'systemd service 제거 완료', steps };
+  } catch (err) {
+    return {
+      status: 'failed',
+      message: '제거 중 일부 단계 실패',
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+// ─── macOS launchd ──────────────────────────────────────────────────────────
+
+export async function installLaunchAgent(input, options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
+  const env = options.env ?? process.env;
+  const home = input.homeDir ?? env.HOME;
+
+  try {
+    execImpl('launchctl', ['version']);
+  } catch (err) {
+    return {
+      status: 'skipped',
+      message: `launchctl 미감지 (${err?.message ?? '실행 실패'}) — 수동 등록 안내로 fallback`,
+    };
+  }
+
+  const tmpl = macosLaunchAgent({ ...input, homeDir: home });
+  const agentsDir = path.join(home, LAUNCH_AGENTS_DIR);
+  const plistPath = path.join(agentsDir, tmpl.serviceFilename);
+
+  if (fsImpl.existsSync(plistPath)) {
+    const existing = fsImpl.readFileSync(plistPath, 'utf8');
+    if (existing.trim() !== tmpl.content.trim()) {
+      const overwrite = await confirmFn(
+        `기존 LaunchAgent plist 와 내용이 다릅니다: ${plistPath}\n덮어쓸까요?`,
+        false,
+      );
+      if (!overwrite) {
+        return { status: 'skipped', message: `사용자가 덮어쓰기 거부 — ${plistPath} 보존` };
+      }
+    }
+  }
+
+  const steps = [];
+  try {
+    fsImpl.mkdirSync(agentsDir, { recursive: true });
+    steps.push(`mkdir -p ${agentsDir}`);
+    fsImpl.writeFileSync(plistPath, `${tmpl.content}\n`);
+    steps.push(`write ${plistPath}`);
+    const uid = execImpl('id', ['-u']).trim();
+    execImpl('launchctl', ['bootstrap', `gui/${uid}`, plistPath]);
+    steps.push(`launchctl bootstrap gui/${uid} ${plistPath}`);
+    return {
+      status: 'installed',
+      message: 'LaunchAgent 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
+      steps,
+    };
+  } catch (err) {
+    if (fsImpl.existsSync(plistPath)) {
+      try {
+        fsImpl.unlinkSync(plistPath);
+      } catch {
+        // ignore
+      }
+    }
+    return {
+      status: 'failed',
+      message: 'launchd install 실패 (cleanup 후) — 수동 등록 안내로 fallback',
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+export async function uninstallLaunchAgent(options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
+  const env = options.env ?? process.env;
+  const home = env.HOME ?? '';
+
+  const serviceFilename = 'com.token-weather.bot.plist';
+  const plistPath = path.join(home, LAUNCH_AGENTS_DIR, serviceFilename);
+
+  if (!fsImpl.existsSync(plistPath)) {
+    return {
+      status: 'skipped',
+      message: `plist 파일 없음: ${plistPath} — 이미 제거되었거나 자동 설치된 적 없음`,
+    };
+  }
+
+  const ok = await confirmFn(
+    `다음을 제거합니다:\n  - launchctl bootout gui/$(id -u) ${plistPath}\n  - unlink ${plistPath}\n계속?`,
+    true,
+  );
+  if (!ok) return { status: 'skipped', message: '사용자가 제거 거부' };
+
+  const steps = [];
+  try {
+    const uid = execImpl('id', ['-u']).trim();
+    execImpl('launchctl', ['bootout', `gui/${uid}`, plistPath]);
+    steps.push(`launchctl bootout gui/${uid} ${plistPath}`);
+    fsImpl.unlinkSync(plistPath);
+    steps.push(`unlink ${plistPath}`);
+    return { status: 'installed', message: 'LaunchAgent 제거 완료', steps };
+  } catch (err) {
+    return {
+      status: 'failed',
+      message: '제거 중 일부 단계 실패',
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+// ─── Windows Task Scheduler ─────────────────────────────────────────────────
+
+export async function installTaskScheduler(input, options = {}) {
+  const execImpl = options.execImpl ?? defaultExecImpl;
+
+  try {
+    execImpl('schtasks', ['/?']);
+  } catch (err) {
+    return {
+      status: 'skipped',
+      message: `schtasks 미감지 (${err?.message ?? '실행 실패'}) — 수동 등록 안내로 fallback`,
+    };
+  }
+
+  const steps = [];
+  try {
+    const taskRun = `"${input.nodeBinPath}" "${input.cliScriptPath}" telegram start`;
+    execImpl('schtasks', [
+      '/Create',
+      '/TN',
+      'TokenWeatherBot',
+      '/SC',
+      'ONLOGON',
+      '/RL',
+      'LIMITED',
+      '/TR',
+      taskRun,
+      '/F',
+    ]);
+    steps.push('schtasks /Create /TN TokenWeatherBot ...');
+    return {
+      status: 'installed',
+      message: 'Windows Task Scheduler 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
+      steps,
+    };
+  } catch (err) {
+    return {
+      status: 'failed',
+      message: 'taskscheduler install 실패 — 수동 등록 안내로 fallback',
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+export async function uninstallTaskScheduler(options = {}) {
+  const execImpl = options.execImpl ?? defaultExecImpl;
+  const confirmFn = options.confirmFn ?? defaultConfirmFn;
+
+  const ok = await confirmFn(
+    `다음을 제거합니다:\n  - schtasks /Delete /TN TokenWeatherBot /F\n계속?`,
+    true,
+  );
+  if (!ok) return { status: 'skipped', message: '사용자가 제거 거부' };
+
+  const steps = [];
+  try {
+    execImpl('schtasks', ['/Delete', '/TN', 'TokenWeatherBot', '/F']);
+    steps.push('schtasks /Delete /TN TokenWeatherBot /F');
+    return { status: 'installed', message: 'Task Scheduler 항목 제거 완료', steps };
+  } catch (err) {
+    return {
+      status: 'failed',
+      message: '제거 실패 (이미 없거나 권한 문제)',
+      error: err?.message ?? String(err),
+      steps,
+    };
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function defaultExecImpl(cmd, args) {
+  return execFileSync(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+}
+
+async function defaultConfirmFn(_question, defaultYes) {
+  // 기본 구현은 default 값 반환 — 실제 prompt 가 필요하면 호출자가 옵션 주입.
+  return Boolean(defaultYes);
+}
+
+/**
+ * Y/N 응답 파싱 — 빈 입력 시 default 적용. setup / uninstall-service 의 공통
+ * helper.
+ *
+ * @param {string} answer
+ * @param {boolean} defaultYes
+ * @returns {boolean}
+ */
+export function parseYesNo(answer, defaultYes) {
+  const trimmed = (answer ?? '').trim().toLowerCase();
+  if (trimmed === '') return defaultYes;
+  if (/^y(es)?$/.test(trimmed)) return true;
+  if (/^n(o)?$/.test(trimmed)) return false;
+  return defaultYes;
+}

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -357,7 +357,8 @@ export async function installTaskScheduler(input, options = {}) {
     steps.push('schtasks /Create /TN TokenWeatherBot ...');
     return {
       status: 'installed',
-      message: 'Windows Task Scheduler 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
+      message:
+        'Windows Task Scheduler 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
       steps,
     };
   } catch (err) {

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -95,6 +95,14 @@ export async function installSystemdUnit(input, options = {}) {
   const home = input.homeDir ?? env.HOME;
   const user = env.USER ?? '';
 
+  // HOME 누락 시 path.join throw 회피 — 수동 안내로 fallback (PR #140 review).
+  if (!home) {
+    return {
+      status: 'skipped',
+      message: 'HOME 환경변수가 비어 있어 service 파일 경로를 결정할 수 없음 — 수동 등록 안내로 fallback',
+    };
+  }
+
   // 1) systemd 존재 검사.
   try {
     execImpl('systemctl', ['--version']);
@@ -143,12 +151,17 @@ export async function installSystemdUnit(input, options = {}) {
     steps.push('systemctl --user daemon-reload');
     execImpl('systemctl', ['--user', 'enable', '--now', tmpl.serviceFilename]);
     steps.push(`systemctl --user enable --now ${tmpl.serviceFilename}`);
-    // linger — 실패해도 warning + 계속 (loginctl 부재 가능 환경).
-    try {
-      execImpl('loginctl', ['enable-linger', user]);
-      steps.push(`loginctl enable-linger ${user}`);
-    } catch (err) {
-      log(`⚠ loginctl enable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+    // linger — 실패해도 warning + 계속 (loginctl 부재 가능 환경). USER 비어
+    // 있으면 단계 자체 skip (PR #140 review — 빈 user 로 loginctl 호출 회피).
+    if (!user) {
+      log('ℹ USER 환경변수가 비어 있어 loginctl enable-linger 단계 skip');
+    } else {
+      try {
+        execImpl('loginctl', ['enable-linger', user]);
+        steps.push(`loginctl enable-linger ${user}`);
+      } catch (err) {
+        log(`⚠ loginctl enable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+      }
     }
     return {
       status: 'installed',
@@ -185,6 +198,13 @@ export async function uninstallSystemdUnit(options = {}) {
   const home = env.HOME ?? '';
   const user = env.USER ?? '';
 
+  if (!home) {
+    return {
+      status: 'skipped',
+      message: 'HOME 환경변수가 비어 있어 service 파일 경로를 결정할 수 없음',
+    };
+  }
+
   const serviceFilename = 'token-weather-bot.service';
   const servicePath = path.join(home, SYSTEMD_USER_DIR, serviceFilename);
 
@@ -207,11 +227,15 @@ export async function uninstallSystemdUnit(options = {}) {
     steps.push(`systemctl --user disable --now ${serviceFilename}`);
     fsImpl.unlinkSync(servicePath);
     steps.push(`unlink ${servicePath}`);
-    try {
-      execImpl('loginctl', ['disable-linger', user]);
-      steps.push(`loginctl disable-linger ${user}`);
-    } catch (err) {
-      log(`⚠ loginctl disable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+    if (!user) {
+      log('ℹ USER 환경변수가 비어 있어 loginctl disable-linger 단계 skip');
+    } else {
+      try {
+        execImpl('loginctl', ['disable-linger', user]);
+        steps.push(`loginctl disable-linger ${user}`);
+      } catch (err) {
+        log(`⚠ loginctl disable-linger 실패 (계속 진행): ${err?.message ?? err}`);
+      }
     }
     return { status: 'installed', message: 'systemd service 제거 완료', steps };
   } catch (err) {
@@ -232,6 +256,13 @@ export async function installLaunchAgent(input, options = {}) {
   const confirmFn = options.confirmFn ?? defaultConfirmFn;
   const env = options.env ?? process.env;
   const home = input.homeDir ?? env.HOME;
+
+  if (!home) {
+    return {
+      status: 'skipped',
+      message: 'HOME 환경변수가 비어 있어 plist 경로를 결정할 수 없음 — 수동 등록 안내로 fallback',
+    };
+  }
 
   try {
     execImpl('launchctl', ['version']);
@@ -303,6 +334,13 @@ export async function uninstallLaunchAgent(options = {}) {
   const confirmFn = options.confirmFn ?? defaultConfirmFn;
   const env = options.env ?? process.env;
   const home = env.HOME ?? '';
+
+  if (!home) {
+    return {
+      status: 'skipped',
+      message: 'HOME 환경변수가 비어 있어 plist 경로를 결정할 수 없음',
+    };
+  }
 
   const serviceFilename = 'com.token-weather.bot.plist';
   const plistPath = path.join(home, LAUNCH_AGENTS_DIR, serviceFilename);

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -23,6 +23,19 @@ const SYSTEMD_USER_DIR = '.config/systemd/user';
 const LAUNCH_AGENTS_DIR = 'Library/LaunchAgents';
 
 /**
+ * 자동 등록 가능 여부의 사전 검사 — 경로의 공백 / XML 특수문자 / 따옴표 등이
+ * systemd unit / launchd plist / Task Scheduler 의 quoting 규칙과 충돌할 수
+ * 있어, 안전을 위해 자동 등록을 skip 하고 manual fallback 으로 안내 (PR #140
+ * review). 정확한 escaping helper 는 별도 follow-up.
+ *
+ * @param {string} p
+ * @returns {boolean}
+ */
+function hasUnsafePathChars(p) {
+  return /[\s<>&"'`]/.test(p);
+}
+
+/**
  * @typedef {object} InstallerInput
  * @property {string} nodeBinPath
  * @property {string} cliScriptPath
@@ -99,7 +112,18 @@ export async function installSystemdUnit(input, options = {}) {
   if (!home) {
     return {
       status: 'skipped',
-      message: 'HOME 환경변수가 비어 있어 service 파일 경로를 결정할 수 없음 — 수동 등록 안내로 fallback',
+      message:
+        'HOME 환경변수가 비어 있어 service 파일 경로를 결정할 수 없음 — 수동 등록 안내로 fallback',
+    };
+  }
+
+  // 경로 안전성 사전 검사 — 공백 / 특수문자가 있으면 systemd unit 의 ExecStart=
+  // 인자 구분과 충돌. manual fallback 으로 안내 (PR #140 review).
+  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
+    return {
+      status: 'skipped',
+      message:
+        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
     };
   }
 
@@ -264,6 +288,16 @@ export async function installLaunchAgent(input, options = {}) {
     };
   }
 
+  // 경로 안전성 사전 검사 — launchd plist 는 XML 이라 `<`, `>`, `&` 등이 escape
+  // 되지 않으면 깨짐 (PR #140 review).
+  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
+    return {
+      status: 'skipped',
+      message:
+        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
+    };
+  }
+
   try {
     execImpl('launchctl', ['version']);
   } catch (err) {
@@ -381,6 +415,15 @@ export async function uninstallLaunchAgent(options = {}) {
 export async function installTaskScheduler(input, options = {}) {
   const execImpl = options.execImpl ?? defaultExecImpl;
   const confirmFn = options.confirmFn ?? defaultConfirmFn;
+
+  // 경로 안전성 사전 검사 — Windows 의 cmd.exe 따옴표 escaping (PR #140 review).
+  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
+    return {
+      status: 'skipped',
+      message:
+        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
+    };
+  }
 
   try {
     execImpl('schtasks', ['/?']);

--- a/packages/telegram/src/os-service-templates.js
+++ b/packages/telegram/src/os-service-templates.js
@@ -52,6 +52,10 @@ export function linuxSystemdUnit({ nodeBinPath, cliScriptPath }) {
   return {
     kind: 'systemd',
     title: 'Linux systemd --user unit (user-level, sudo 불필요)',
+    // installer 가 직접 fs.writeFile 로 작성할 raw unit content + 대상 경로
+    // (issue #138). instructions 의 heredoc 안 본문과 동일.
+    content: unitContent,
+    serviceFilename: 'token-weather-bot.service',
     instructions: [
       'mkdir -p ~/.config/systemd/user',
       "cat > ~/.config/systemd/user/token-weather-bot.service <<'EOF'",
@@ -102,6 +106,8 @@ export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
   return {
     kind: 'launchd',
     title: 'macOS LaunchAgent (user-level, sudo 불필요)',
+    content: plistContent,
+    serviceFilename: 'com.token-weather.bot.plist',
     instructions: [
       'mkdir -p ~/Library/LaunchAgents',
       "cat > ~/Library/LaunchAgents/com.token-weather.bot.plist <<'EOF'",

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -13,6 +13,7 @@ import { createInterface } from 'node:readline';
 
 import { validateBotToken, generatePairingCode, runPairingBot } from './pairing.js';
 import { pickServiceTemplate } from './os-service-templates.js';
+import { installOsService, parseYesNo } from './os-service-installer.js';
 
 const DIVIDER = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
 
@@ -178,17 +179,52 @@ export async function runSetupSubcommand(args, deps, options = {}) {
     }`,
   );
 
-  // 6) OS service template print.
-  const tmpl = pickServiceTemplate({
+  // 6) OS service 자동 등록 동의 프롬프트 (issue #138) — Y default. 거부 / skip /
+  //    실패 시 수동 등록 안내 fallback.
+  const installerInput = {
     nodeBinPath: process.execPath,
     cliScriptPath: deps.cliScriptPath ?? process.argv[1] ?? '',
     homeDir: process.env.HOME,
-  });
+  };
+  const tmpl = pickServiceTemplate(installerInput);
+  const installer = options.installer ?? installOsService;
+
   log('');
   log(DIVIDER);
-  log(`부팅 후 자동 시작 (선택사항) — ${tmpl.title}:`);
+  log(`부팅 후 자동 시작 (선택사항) — ${tmpl.title}`);
   log('');
-  for (const line of tmpl.instructions) log(`  ${line}`);
+  const consentRaw = await promptFn('자동으로 설치하시겠습니까? [Y/n] ');
+  const consent = parseYesNo(consentRaw, true);
+  log('');
+
+  if (consent) {
+    const result = await installer(installerInput, {
+      fsImpl,
+      execImpl: options.execImpl,
+      confirmFn: options.confirmFn,
+      log,
+      errorLog,
+      env: options.env ?? process.env,
+      platform: options.platform,
+    });
+    if (result.status === 'installed') {
+      log(`✓ ${result.message}`);
+      for (const step of result.steps ?? []) log(`  · ${step}`);
+    } else if (result.status === 'skipped') {
+      log(`ℹ ${result.message}`);
+      log('');
+      log('수동 등록 안내:');
+      for (const line of tmpl.instructions) log(`  ${line}`);
+    } else {
+      errorLog(`✗ 자동 설치 실패: ${result.error ?? result.message}`);
+      log('');
+      log('수동 등록 안내:');
+      for (const line of tmpl.instructions) log(`  ${line}`);
+    }
+  } else {
+    log('자동 설치 건너뜀 — 수동 등록 안내:');
+    for (const line of tmpl.instructions) log(`  ${line}`);
+  }
   log('');
   log(DIVIDER);
   log('');

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -198,10 +198,22 @@ export async function runSetupSubcommand(args, deps, options = {}) {
   log('');
 
   if (consent) {
+    // promptFn 기반 confirm adapter (PR #140 review blocker 1) — installer 가
+    // 기존 service 파일 충돌 같은 사용자 결정이 필요한 시점에 실제 프롬프트를
+    // 띄우도록. options.confirmFn 미주입 시 default 가 prompt 없이 boolean 만
+    // 반환하는 문제 해소.
+    const confirmFn =
+      options.confirmFn ??
+      (async (question, defaultYes) => {
+        const suffix = defaultYes ? ' [Y/n] ' : ' [y/N] ';
+        const answer = await promptFn(`${question}${suffix}`);
+        return parseYesNo(answer, Boolean(defaultYes));
+      });
+
     const result = await installer(installerInput, {
       fsImpl,
       execImpl: options.execImpl,
-      confirmFn: options.confirmFn,
+      confirmFn,
       log,
       errorLog,
       env: options.env ?? process.env,

--- a/packages/telegram/src/uninstall-service-subcommand.js
+++ b/packages/telegram/src/uninstall-service-subcommand.js
@@ -1,0 +1,113 @@
+/**
+ * `telegram uninstall-service` 서브명령 — OS service 자동 등록 (issue #138) 의
+ * 대칭 명령. setup 의 자동 등록으로 작성된 systemd unit / launchd plist / Task
+ * Scheduler 항목을 confirm 후 제거.
+ *
+ * 책임 범위 (issue #138 결정): service 파일 + linger 까지만. config / auth.json
+ * 은 건드리지 않음 — 봇 설정 자체를 지우려면 사용자가 명시적으로 config 편집.
+ */
+
+import { createInterface } from 'node:readline';
+
+import { uninstallOsService, parseYesNo } from './os-service-installer.js';
+
+/**
+ * @typedef {object} UninstallOptions
+ * @property {(question: string, defaultYes?: boolean) => Promise<boolean>} [confirmFn]
+ * @property {(question: string) => Promise<string>} [promptFn]
+ * @property {(cmd: string, args: string[]) => string} [execImpl]
+ * @property {object} [fsImpl]
+ * @property {{ HOME?: string, USER?: string }} [env]
+ * @property {NodeJS.Platform} [platform]
+ * @property {(msg: string) => void} [log]
+ * @property {(msg: string) => void} [errorLog]
+ * @property {(opts: object) => Promise<object>} [uninstaller]  - 테스트 mock.
+ */
+
+/**
+ * @param {string[]} args
+ * @param {object} _deps  - 현재 사용 안 함 (대칭성을 위해 유지).
+ * @param {UninstallOptions} [options]
+ */
+export async function runUninstallServiceSubcommand(args, _deps, options = {}) {
+  const log = options.log ?? ((msg) => console.log(msg));
+  const errorLog = options.errorLog ?? ((msg) => console.error(msg));
+  if (Array.isArray(args) && (args.includes('--help') || args.includes('-h'))) {
+    for (const line of formatTelegramUninstallServiceHelp()) log(line);
+    return;
+  }
+
+  const uninstaller = options.uninstaller ?? uninstallOsService;
+  // confirmFn 미주입 시 readline 기반 default (Y default — uninstall-service 명령
+  // 입력 시점에 의도 명확).
+  const confirmFn = options.confirmFn ?? createReadlineConfirm(options.promptFn);
+
+  log('▶ token-weather telegram uninstall-service');
+  log('');
+
+  const result = await uninstaller({
+    fsImpl: options.fsImpl,
+    execImpl: options.execImpl,
+    confirmFn,
+    log,
+    errorLog,
+    env: options.env ?? process.env,
+    platform: options.platform,
+  });
+
+  if (result.status === 'installed') {
+    // uninstaller 의 'installed' 는 "정상 완료" 의미 (시퀀스 성공).
+    log(`✓ ${result.message}`);
+    for (const step of result.steps ?? []) log(`  · ${step}`);
+  } else if (result.status === 'skipped') {
+    log(`ℹ ${result.message}`);
+  } else {
+    errorLog(`✗ ${result.message}`);
+    if (result.error) errorLog(`  ${result.error}`);
+    process.exitCode = 1;
+  }
+}
+
+function createReadlineConfirm(promptFn) {
+  const prompt = promptFn ?? defaultPromptFn;
+  return async (question, defaultYes) => {
+    const suffix = defaultYes ? ' [Y/n] ' : ' [y/N] ';
+    const answer = await prompt(`${question}${suffix}`);
+    return parseYesNo(answer, Boolean(defaultYes));
+  };
+}
+
+function defaultPromptFn(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+/**
+ * `--help` 출력.
+ */
+export function formatTelegramUninstallServiceHelp() {
+  return [
+    'token-weather telegram uninstall-service',
+    '',
+    '`telegram setup` 의 자동 등록으로 작성된 OS service 항목을 제거합니다.',
+    '',
+    'Options:',
+    '  -h, --help   이 도움말 출력',
+    '',
+    '제거 대상 (issue #138):',
+    '  - Linux:   ~/.config/systemd/user/token-weather-bot.service + linger 해제',
+    '  - macOS:   ~/Library/LaunchAgents/com.token-weather.bot.plist',
+    '  - Windows: schtasks /TN TokenWeatherBot',
+    '',
+    '주의:',
+    '  - config / auth.json 은 건드리지 않습니다. 봇 설정 자체를 지우려면',
+    '    `~/.config/token-weather/config.json` 의 channels.telegram 을 수동 편집.',
+    '  - Linux 의 linger 해제는 동일 사용자의 다른 user-level service 에도 영향',
+    '    이 있을 수 있습니다.',
+  ];
+}

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -152,15 +152,11 @@ describe('installSystemdUnit (issue #138)', () => {
 
   it('중간 단계 실패 시 cleanup (write 한 파일 unlink) + status failed', async () => {
     const mockFs = makeMockFs();
-    const mockExec = makeMockExec({
-      throwOn: { systemctl: '' }, // 'systemctl' 명령에서 throw — 첫 호출은 --version, 그건 ok ... mock 단순화.
-    });
-    // throwOn 키 매칭 단순화 — 우선 첫 systemctl 도 fail 하면 skipped 경로라 cleanup 안 함.
-    // 더 정밀한 케이스: --version 만 ok 후 daemon-reload 에서 fail.
+    // systemctl --version (첫 호출) 은 ok, 그 다음 daemon-reload 에서 fail.
     const callCounts = { systemctl: 0 };
     const r = await installSystemdUnit(INPUT, {
       fsImpl: mockFs.fs,
-      execImpl: (cmd, args) => {
+      execImpl: (cmd) => {
         if (cmd === 'systemctl') {
           callCounts.systemctl += 1;
           if (callCounts.systemctl === 1) return ''; // --version ok

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -244,6 +244,40 @@ describe('installTaskScheduler (issue #138)', () => {
     assert.equal(r.status, 'skipped');
     assert.match(r.message, /schtasks 미감지/);
   });
+
+  it('기존 task 존재 + confirm n → status skipped (PR #140 review blocker 2)', async () => {
+    // schtasks /? 와 /Query 둘 다 성공 (task 존재 의미).
+    let confirmAsked = false;
+    const r = await installTaskScheduler(INPUT, {
+      execImpl: () => '', // 모든 호출 ok — /? 통과 + /Query 통과 = 기존 task 존재.
+      confirmFn: async (_q, _default) => {
+        confirmAsked = true;
+        return false; // n.
+      },
+    });
+    assert.equal(confirmAsked, true);
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /덮어쓰기 거부/);
+  });
+
+  it('기존 task 없음 (/Query fail) → 정상 install 진행', async () => {
+    const calls = [];
+    let queryCalled = 0;
+    const r = await installTaskScheduler(INPUT, {
+      execImpl: (cmd, args) => {
+        calls.push({ cmd, args });
+        if (cmd === 'schtasks' && args[0] === '/Query') {
+          queryCalled += 1;
+          throw new Error('task not found');
+        }
+        return '';
+      },
+    });
+    assert.equal(queryCalled, 1);
+    assert.equal(r.status, 'installed');
+    // /Create 호출 단언.
+    assert.ok(calls.some((c) => c.cmd === 'schtasks' && c.args.includes('/Create')));
+  });
 });
 
 // ─── uninstallLaunchAgent / uninstallTaskScheduler ──────────────────────────

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -130,7 +130,10 @@ describe('installSystemdUnit (issue #138)', () => {
     assert.equal(r.status, 'skipped');
     assert.match(r.message, /덮어쓰기 거부/);
     // write / mkdir 안 일어남.
-    assert.equal(mockFs.calls.some((c) => c.op === 'write'), false);
+    assert.equal(
+      mockFs.calls.some((c) => c.op === 'write'),
+      false,
+    );
   });
 
   it('linger 실패는 warning + 계속 (status 는 여전히 installed)', async () => {
@@ -199,7 +202,10 @@ describe('uninstallSystemdUnit (issue #138)', () => {
       env: { HOME: '/home/test', USER: 'test' },
     });
     assert.equal(r.status, 'skipped');
-    assert.equal(mockFs.calls.some((c) => c.op === 'unlink'), false);
+    assert.equal(
+      mockFs.calls.some((c) => c.op === 'unlink'),
+      false,
+    );
   });
 
   it('정상 uninstall — disable + unlink + linger 해제', async () => {

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -1,0 +1,297 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  installSystemdUnit,
+  uninstallSystemdUnit,
+  installLaunchAgent,
+  uninstallLaunchAgent,
+  installTaskScheduler,
+  uninstallTaskScheduler,
+  installOsService,
+  uninstallOsService,
+  parseYesNo,
+} from '../src/os-service-installer.js';
+
+const INPUT = {
+  nodeBinPath: '/usr/bin/node',
+  cliScriptPath: '/cli/bin/token-weather.js',
+  homeDir: '/home/test',
+};
+
+function makeMockFs({ files = new Map() } = {}) {
+  const calls = [];
+  return {
+    fs: {
+      existsSync: (p) => files.has(p),
+      readFileSync: (p) => files.get(p) ?? '',
+      writeFileSync: (p, c) => {
+        files.set(p, c);
+        calls.push({ op: 'write', path: p });
+      },
+      mkdirSync: (p) => {
+        calls.push({ op: 'mkdir', path: p });
+      },
+      unlinkSync: (p) => {
+        files.delete(p);
+        calls.push({ op: 'unlink', path: p });
+      },
+    },
+    files,
+    calls,
+  };
+}
+
+function makeMockExec({ throwOn = {}, returnFor = {} } = {}) {
+  const calls = [];
+  return {
+    impl: (cmd, args) => {
+      const key = `${cmd} ${args.join(' ')}`;
+      calls.push({ cmd, args });
+      if (throwOn[cmd]) throw new Error(throwOn[cmd]);
+      return returnFor[key] ?? '';
+    },
+    calls,
+  };
+}
+
+// ─── parseYesNo ─────────────────────────────────────────────────────────────
+
+describe('parseYesNo', () => {
+  it('빈 입력은 default 반환', () => {
+    assert.equal(parseYesNo('', true), true);
+    assert.equal(parseYesNo('', false), false);
+    assert.equal(parseYesNo('  ', true), true);
+  });
+  it('y / yes 는 true', () => {
+    assert.equal(parseYesNo('y', false), true);
+    assert.equal(parseYesNo('Y', false), true);
+    assert.equal(parseYesNo('yes', false), true);
+    assert.equal(parseYesNo('YES', false), true);
+  });
+  it('n / no 는 false', () => {
+    assert.equal(parseYesNo('n', true), false);
+    assert.equal(parseYesNo('NO', true), false);
+  });
+  it('알 수 없는 입력은 default 반환', () => {
+    assert.equal(parseYesNo('maybe', true), true);
+    assert.equal(parseYesNo('123', false), false);
+  });
+});
+
+// ─── installSystemdUnit ─────────────────────────────────────────────────────
+
+describe('installSystemdUnit (issue #138)', () => {
+  it('systemd 부재 (systemctl 실행 실패) → status skipped', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec({ throwOn: { systemctl: 'command not found' } });
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /systemd 미감지/);
+  });
+
+  it('정상 install 시퀀스 — mkdir / write / daemon-reload / enable / linger', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec();
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'installed');
+    assert.ok(mockFs.calls.some((c) => c.op === 'mkdir'));
+    assert.ok(mockFs.calls.some((c) => c.op === 'write'));
+    const cmds = mockExec.calls.map((c) => `${c.cmd} ${c.args.join(' ')}`);
+    assert.ok(cmds.some((c) => c.includes('systemctl --version')));
+    assert.ok(cmds.some((c) => c.includes('systemctl --user daemon-reload')));
+    assert.ok(cmds.some((c) => c.includes('systemctl --user enable --now')));
+    assert.ok(cmds.some((c) => c.includes('loginctl enable-linger test')));
+  });
+
+  it('기존 service 파일 + 내용 다름 + confirm n → status skipped', async () => {
+    const servicePath = '/home/test/.config/systemd/user/token-weather-bot.service';
+    const mockFs = makeMockFs({ files: new Map([[servicePath, 'old content']]) });
+    const mockExec = makeMockExec();
+    let confirmAsked = false;
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      confirmFn: async (_q, _d) => {
+        confirmAsked = true;
+        return false; // n
+      },
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(confirmAsked, true);
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /덮어쓰기 거부/);
+    // write / mkdir 안 일어남.
+    assert.equal(mockFs.calls.some((c) => c.op === 'write'), false);
+  });
+
+  it('linger 실패는 warning + 계속 (status 는 여전히 installed)', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec({ throwOn: { loginctl: 'permission denied' } });
+    const logs = [];
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      log: (m) => logs.push(m),
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'installed');
+    assert.ok(logs.some((l) => l.includes('loginctl enable-linger 실패')));
+  });
+
+  it('중간 단계 실패 시 cleanup (write 한 파일 unlink) + status failed', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec({
+      throwOn: { systemctl: '' }, // 'systemctl' 명령에서 throw — 첫 호출은 --version, 그건 ok ... mock 단순화.
+    });
+    // throwOn 키 매칭 단순화 — 우선 첫 systemctl 도 fail 하면 skipped 경로라 cleanup 안 함.
+    // 더 정밀한 케이스: --version 만 ok 후 daemon-reload 에서 fail.
+    const callCounts = { systemctl: 0 };
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: (cmd, args) => {
+        if (cmd === 'systemctl') {
+          callCounts.systemctl += 1;
+          if (callCounts.systemctl === 1) return ''; // --version ok
+          throw new Error('daemon-reload failed');
+        }
+        return '';
+      },
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'failed');
+    // cleanup — write 했던 파일이 unlink 됨.
+    assert.ok(mockFs.calls.some((c) => c.op === 'unlink'));
+  });
+});
+
+// ─── uninstallSystemdUnit ──────────────────────────────────────────────────
+
+describe('uninstallSystemdUnit (issue #138)', () => {
+  it('service 파일 없음 → status skipped', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec();
+    const r = await uninstallSystemdUnit({
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /service 파일 없음/);
+  });
+
+  it('confirm 거부 → status skipped', async () => {
+    const servicePath = '/home/test/.config/systemd/user/token-weather-bot.service';
+    const mockFs = makeMockFs({ files: new Map([[servicePath, 'existing']]) });
+    const mockExec = makeMockExec();
+    const r = await uninstallSystemdUnit({
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      confirmFn: async () => false,
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'skipped');
+    assert.equal(mockFs.calls.some((c) => c.op === 'unlink'), false);
+  });
+
+  it('정상 uninstall — disable + unlink + linger 해제', async () => {
+    const servicePath = '/home/test/.config/systemd/user/token-weather-bot.service';
+    const mockFs = makeMockFs({ files: new Map([[servicePath, 'existing']]) });
+    const mockExec = makeMockExec();
+    const r = await uninstallSystemdUnit({
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      confirmFn: async () => true,
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'installed');
+    const cmds = mockExec.calls.map((c) => `${c.cmd} ${c.args.join(' ')}`);
+    assert.ok(cmds.some((c) => c.includes('systemctl --user disable --now')));
+    assert.ok(cmds.some((c) => c.includes('loginctl disable-linger test')));
+    assert.ok(mockFs.calls.some((c) => c.op === 'unlink' && c.path === servicePath));
+  });
+});
+
+// ─── installLaunchAgent / installTaskScheduler skip detect ──────────────────
+
+describe('installLaunchAgent (issue #138)', () => {
+  it('launchctl 미감지 → status skipped', async () => {
+    const r = await installLaunchAgent(INPUT, {
+      fsImpl: makeMockFs().fs,
+      execImpl: makeMockExec({ throwOn: { launchctl: 'not found' } }).impl,
+      env: { HOME: '/home/test' },
+    });
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /launchctl 미감지/);
+  });
+});
+
+describe('installTaskScheduler (issue #138)', () => {
+  it('schtasks 미감지 → status skipped', async () => {
+    const r = await installTaskScheduler(INPUT, {
+      execImpl: makeMockExec({ throwOn: { schtasks: 'not found' } }).impl,
+    });
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /schtasks 미감지/);
+  });
+});
+
+// ─── uninstallLaunchAgent / uninstallTaskScheduler ──────────────────────────
+
+describe('uninstallLaunchAgent (issue #138)', () => {
+  it('plist 부재 → status skipped', async () => {
+    const r = await uninstallLaunchAgent({
+      fsImpl: makeMockFs().fs,
+      execImpl: makeMockExec().impl,
+      env: { HOME: '/home/test' },
+    });
+    assert.equal(r.status, 'skipped');
+  });
+});
+
+describe('uninstallTaskScheduler (issue #138)', () => {
+  it('confirm 거부 → status skipped', async () => {
+    const r = await uninstallTaskScheduler({
+      execImpl: makeMockExec().impl,
+      confirmFn: async () => false,
+    });
+    assert.equal(r.status, 'skipped');
+  });
+});
+
+// ─── installOsService / uninstallOsService — platform dispatch ──────────────
+
+describe('installOsService / uninstallOsService platform dispatch', () => {
+  it('지원하지 않는 platform → status skipped', async () => {
+    const r = await installOsService(INPUT, {
+      platform: 'aix',
+      fsImpl: makeMockFs().fs,
+      execImpl: makeMockExec().impl,
+    });
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /지원하지 않는 platform/);
+  });
+
+  it('uninstall 도 지원 외 platform skip', async () => {
+    const r = await uninstallOsService({ platform: 'aix' });
+    assert.equal(r.status, 'skipped');
+  });
+
+  it('linux platform → systemd 분기 (systemctl 부재 skip 으로 확인)', async () => {
+    const r = await installOsService(INPUT, {
+      platform: 'linux',
+      fsImpl: makeMockFs().fs,
+      execImpl: makeMockExec({ throwOn: { systemctl: 'not found' } }).impl,
+      env: { HOME: '/home/test' },
+    });
+    assert.match(r.message, /systemd 미감지/);
+  });
+});

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -172,6 +172,83 @@ describe('installSystemdUnit (issue #138)', () => {
   });
 });
 
+// ─── installSystemdUnit — review 2 follow-up: guard 보강 ────────────────────
+
+describe('installSystemdUnit guard 보강 (PR #140 review 2)', () => {
+  it('HOME 없음 → status skipped (path.join throw 회피)', async () => {
+    // INPUT.homeDir 도 비워서 input.homeDir ?? env.HOME 둘 다 falsy 만들기.
+    const r = await installSystemdUnit(
+      { nodeBinPath: '/usr/bin/node', cliScriptPath: '/cli.js' },
+      {
+        fsImpl: makeMockFs().fs,
+        execImpl: makeMockExec().impl,
+        env: {}, // HOME 부재.
+      },
+    );
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /HOME 환경변수/);
+  });
+
+  it('USER 없음 → install 성공 + loginctl 단계만 skip + 안내 log', async () => {
+    const mockFs = makeMockFs();
+    const mockExec = makeMockExec();
+    const logs = [];
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: mockExec.impl,
+      env: { HOME: '/home/test' }, // USER 부재.
+      log: (m) => logs.push(m),
+    });
+    assert.equal(r.status, 'installed');
+    // loginctl 호출 부재.
+    assert.equal(
+      mockExec.calls.some((c) => c.cmd === 'loginctl'),
+      false,
+    );
+    assert.ok(logs.some((l) => l.includes('USER 환경변수가 비어 있어')));
+  });
+
+  it('nodeBinPath 공백 포함 → status skipped + manual fallback 안내', async () => {
+    const r = await installSystemdUnit(
+      { ...INPUT, nodeBinPath: '/path with space/node' },
+      { fsImpl: makeMockFs().fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
+    );
+    assert.equal(r.status, 'skipped');
+    assert.match(r.message, /공백 또는 특수문자/);
+  });
+
+  it('cliScriptPath XML 특수문자 포함 → status skipped', async () => {
+    const r = await installSystemdUnit(
+      { ...INPUT, cliScriptPath: '/cli/<bin>/token-weather.js' },
+      { fsImpl: makeMockFs().fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
+    );
+    assert.equal(r.status, 'skipped');
+  });
+
+  it('overwrite 동의 + daemon-reload 실패 → 기존 content 가 restore (PR #140 review 3)', async () => {
+    const servicePath = '/home/test/.config/systemd/user/token-weather-bot.service';
+    const originalContent = '[Unit]\nDescription=user-original\n';
+    const mockFs = makeMockFs({ files: new Map([[servicePath, originalContent]]) });
+    const callCounts = { systemctl: 0 };
+    const r = await installSystemdUnit(INPUT, {
+      fsImpl: mockFs.fs,
+      execImpl: (cmd) => {
+        if (cmd === 'systemctl') {
+          callCounts.systemctl += 1;
+          if (callCounts.systemctl === 1) return ''; // --version ok
+          throw new Error('daemon-reload failed'); // 그 다음 명령 fail.
+        }
+        return '';
+      },
+      confirmFn: async () => true, // 사용자가 overwrite 허용.
+      env: { HOME: '/home/test', USER: 'test' },
+    });
+    assert.equal(r.status, 'failed');
+    // restore 단언 — 파일이 원본 content 로 복원.
+    assert.equal(mockFs.files.get(servicePath), originalContent);
+  });
+});
+
 // ─── uninstallSystemdUnit ──────────────────────────────────────────────────
 
 describe('uninstallSystemdUnit (issue #138)', () => {

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -117,6 +117,8 @@ describe('runSetupSubcommand (Phase 4)', () => {
     const { logs, log, errorLog } = makeLogger();
     const mockFs = makeMockFs();
     const mock = makeMockBot();
+    // installer mock — 실 systemctl / launchctl / schtasks 호출 차단 (issue #138).
+    const installerCalls = [];
     const setupPromise = runSetupSubcommand(
       [],
       {
@@ -135,6 +137,10 @@ describe('runSetupSubcommand (Phase 4)', () => {
         }),
         botFactory: () => mock.bot,
         fsImpl: mockFs.fs,
+        installer: async (input, opts) => {
+          installerCalls.push({ input, opts });
+          return { status: 'skipped', message: 'mock — 수동 안내 fallback' };
+        },
         log,
         errorLog,
       },
@@ -199,6 +205,7 @@ describe('runSetupSubcommand (Phase 4)', () => {
         }),
         botFactory: () => mock.bot,
         fsImpl: mockFs.fs,
+        installer: async () => ({ status: 'skipped', message: 'mock' }),
         log,
         errorLog,
       },
@@ -222,6 +229,108 @@ describe('runSetupSubcommand (Phase 4)', () => {
     );
   });
 
+  it('자동 등록 동의 Y default — installer 호출 + installed 결과 출력 (issue #138)', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    const mockFs = makeMockFs();
+    const mock = makeMockBot();
+    let installerCalled = 0;
+    const setupPromise = runSetupSubcommand(
+      [],
+      {
+        resolveAgentConfigPath: () => '/test/config.json',
+        createDefaultConfig: () => ({ version: 1, providers: {} }),
+      },
+      {
+        // promptFn 은 첫 두 호출 (token / 페어링 안내는 prompt 없음) 후 consent
+        // 차례 — '' 반환 시 parseYesNo default true 로 Y.
+        promptFn: (() => {
+          let n = 0;
+          return async () => {
+            n += 1;
+            if (n === 1) return '123:fake'; // token
+            return ''; // consent — default Y
+          };
+        })(),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        installer: async () => {
+          installerCalled += 1;
+          return {
+            status: 'installed',
+            message: 'systemd service 등록 완료',
+            steps: ['mkdir', 'write', 'enable'],
+          };
+        },
+        log,
+        errorLog,
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    await mock.fire({
+      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      from: { id: 7 },
+      reply: async () => {},
+    });
+    await setupPromise;
+    assert.equal(installerCalled, 1);
+    const out = logs.join('\n');
+    assert.match(out, /✓ systemd service 등록 완료/);
+    assert.match(out, /· mkdir/);
+  });
+
+  it('자동 등록 거부 n → installer 호출 0 + 수동 안내 출력 (issue #138)', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    const mockFs = makeMockFs();
+    const mock = makeMockBot();
+    let installerCalled = 0;
+    const setupPromise = runSetupSubcommand(
+      [],
+      {
+        resolveAgentConfigPath: () => '/test/config.json',
+        createDefaultConfig: () => ({ version: 1, providers: {} }),
+      },
+      {
+        promptFn: (() => {
+          let n = 0;
+          return async () => {
+            n += 1;
+            if (n === 1) return '123:fake';
+            return 'n'; // consent — 거부.
+          };
+        })(),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        installer: async () => {
+          installerCalled += 1;
+          return { status: 'installed', message: 'should not be called' };
+        },
+        log,
+        errorLog,
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    await mock.fire({
+      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      from: { id: 7 },
+      reply: async () => {},
+    });
+    await setupPromise;
+    assert.equal(installerCalled, 0, 'consent n 시 installer 호출 안 됨');
+    const out = logs.join('\n');
+    assert.match(out, /자동 설치 건너뜀/);
+    assert.match(out, /수동 등록 안내/);
+  });
+
   it('기존 config 의 다른 키 보존 + channels.telegram 만 갱신', async () => {
     process.exitCode = 0;
     const { logs, log, errorLog } = makeLogger();
@@ -243,6 +352,7 @@ describe('runSetupSubcommand (Phase 4)', () => {
         }),
         botFactory: () => mock.bot,
         fsImpl: mockFs.fs,
+        installer: async () => ({ status: 'skipped', message: 'mock' }),
         log,
         errorLog,
       },

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -317,7 +317,10 @@ describe('runSetupSubcommand (Phase 4)', () => {
         fsImpl: mockFs.fs,
         installer: async (_input, opts) => {
           // installer 가 confirmFn 을 받고 호출. mock 으로 그 호출을 시뮬.
-          const overwrite = await opts.confirmFn('기존 service 파일과 내용이 다릅니다. 덮어쓸까요?', false);
+          const overwrite = await opts.confirmFn(
+            '기존 service 파일과 내용이 다릅니다. 덮어쓸까요?',
+            false,
+          );
           return overwrite
             ? { status: 'installed', message: 'overwrote' }
             : { status: 'skipped', message: '사용자가 덮어쓰기 거부' };
@@ -328,7 +331,9 @@ describe('runSetupSubcommand (Phase 4)', () => {
     );
     await new Promise((r) => setImmediate(r));
     await mock.fire({
-      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
       from: { id: 7 },
       reply: async () => {},
     });

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -272,7 +272,9 @@ describe('runSetupSubcommand (Phase 4)', () => {
     );
     await new Promise((r) => setImmediate(r));
     await mock.fire({
-      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
       from: { id: 7 },
       reply: async () => {},
     });
@@ -320,7 +322,9 @@ describe('runSetupSubcommand (Phase 4)', () => {
     );
     await new Promise((r) => setImmediate(r));
     await mock.fire({
-      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      message: {
+        text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}`,
+      },
       from: { id: 7 },
       reply: async () => {},
     });

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -285,6 +285,59 @@ describe('runSetupSubcommand (Phase 4)', () => {
     assert.match(out, /· mkdir/);
   });
 
+  it('installer 의 confirmFn 이 promptFn 기반 adapter — 기존 파일 충돌 시 사용자 프롬프트 동작 (PR #140 review)', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    const mockFs = makeMockFs();
+    const mock = makeMockBot();
+    let confirmQuestionAsked = null;
+    const setupPromise = runSetupSubcommand(
+      [],
+      {
+        resolveAgentConfigPath: () => '/test/config.json',
+        createDefaultConfig: () => ({ version: 1, providers: {} }),
+      },
+      {
+        promptFn: (() => {
+          let n = 0;
+          return async (question) => {
+            n += 1;
+            if (n === 1) return '123:fake'; // token
+            if (n === 2) return ''; // consent — default Y
+            // 3 번째 호출 = installer 의 confirmFn adapter 가 호출 — 충돌 시.
+            confirmQuestionAsked = question;
+            return 'n'; // 덮어쓰지 않음.
+          };
+        })(),
+        fetchFn: async () => ({
+          status: 200,
+          json: async () => ({ ok: true, result: { username: 'B' } }),
+        }),
+        botFactory: () => mock.bot,
+        fsImpl: mockFs.fs,
+        installer: async (_input, opts) => {
+          // installer 가 confirmFn 을 받고 호출. mock 으로 그 호출을 시뮬.
+          const overwrite = await opts.confirmFn('기존 service 파일과 내용이 다릅니다. 덮어쓸까요?', false);
+          return overwrite
+            ? { status: 'installed', message: 'overwrote' }
+            : { status: 'skipped', message: '사용자가 덮어쓰기 거부' };
+        },
+        log,
+        errorLog,
+      },
+    );
+    await new Promise((r) => setImmediate(r));
+    await mock.fire({
+      message: { text: `/pair ${logs.find((l) => l.includes('/pair'))?.match(/\/pair (\S+)/)?.[1]}` },
+      from: { id: 7 },
+      reply: async () => {},
+    });
+    await setupPromise;
+    assert.ok(confirmQuestionAsked, 'installer 의 confirmFn 이 promptFn 으로 질문해야 함');
+    assert.match(confirmQuestionAsked, /\[y\/N\]/, 'default false 면 [y/N] suffix');
+    assert.ok(logs.some((l) => l.includes('덮어쓰기 거부')));
+  });
+
   it('자동 등록 거부 n → installer 호출 0 + 수동 안내 출력 (issue #138)', async () => {
     process.exitCode = 0;
     const { logs, log, errorLog } = makeLogger();

--- a/packages/telegram/test/uninstall-service-subcommand.test.js
+++ b/packages/telegram/test/uninstall-service-subcommand.test.js
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  runUninstallServiceSubcommand,
+  formatTelegramUninstallServiceHelp,
+} from '../src/uninstall-service-subcommand.js';
+
+function makeLogger() {
+  const logs = [];
+  const errors = [];
+  return {
+    logs,
+    errors,
+    log: (m) => logs.push(m),
+    errorLog: (m) => errors.push(m),
+  };
+}
+
+describe('runUninstallServiceSubcommand (issue #138)', () => {
+  it('--help 안내 출력', async () => {
+    const { logs, log } = makeLogger();
+    await runUninstallServiceSubcommand(['--help'], null, { log });
+    assert.ok(logs.some((l) => l.includes('telegram uninstall-service')));
+  });
+
+  it('-h 도 동일 안내', async () => {
+    const { logs, log } = makeLogger();
+    await runUninstallServiceSubcommand(['-h'], null, { log });
+    assert.ok(logs.some((l) => l.includes('제거 대상')));
+  });
+
+  it('uninstaller status installed → ✓ 출력 + exit 0', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    await runUninstallServiceSubcommand([], null, {
+      log,
+      errorLog,
+      uninstaller: async () => ({
+        status: 'installed',
+        message: 'systemd service 제거 완료',
+        steps: ['systemctl --user disable', 'unlink ...'],
+      }),
+    });
+    assert.ok(logs.some((l) => l.startsWith('✓')));
+    assert.ok(logs.some((l) => l.includes('systemctl --user disable')));
+    assert.equal(process.exitCode, 0);
+  });
+
+  it('uninstaller status skipped → ℹ 출력 + exit 0', async () => {
+    process.exitCode = 0;
+    const { logs, log, errorLog } = makeLogger();
+    await runUninstallServiceSubcommand([], null, {
+      log,
+      errorLog,
+      uninstaller: async () => ({ status: 'skipped', message: 'service 파일 없음' }),
+    });
+    assert.ok(logs.some((l) => l.startsWith('ℹ')));
+    assert.equal(process.exitCode, 0);
+  });
+
+  it('uninstaller status failed → ✗ + exit 1', async () => {
+    process.exitCode = 0;
+    const { errors, log, errorLog } = makeLogger();
+    await runUninstallServiceSubcommand([], null, {
+      log,
+      errorLog,
+      uninstaller: async () => ({
+        status: 'failed',
+        message: '제거 실패',
+        error: 'permission denied',
+      }),
+    });
+    assert.ok(errors.some((e) => e.startsWith('✗')));
+    assert.ok(errors.some((e) => e.includes('permission denied')));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+
+  it('confirmFn / promptFn / env / platform 등 옵션이 uninstaller 에 전달됨', async () => {
+    let receivedOptions = null;
+    const { log, errorLog } = makeLogger();
+    await runUninstallServiceSubcommand([], null, {
+      log,
+      errorLog,
+      env: { HOME: '/x', USER: 'u' },
+      platform: 'linux',
+      uninstaller: async (opts) => {
+        receivedOptions = opts;
+        return { status: 'skipped', message: 'mock' };
+      },
+    });
+    assert.equal(receivedOptions.env.USER, 'u');
+    assert.equal(receivedOptions.platform, 'linux');
+    assert.equal(typeof receivedOptions.confirmFn, 'function');
+  });
+});
+
+describe('formatTelegramUninstallServiceHelp', () => {
+  it('첫 줄이 token-weather telegram uninstall-service', () => {
+    assert.match(formatTelegramUninstallServiceHelp()[0], /^token-weather telegram uninstall-service$/);
+  });
+  it('제거 대상 + 주의 단락 포함', () => {
+    const text = formatTelegramUninstallServiceHelp().join('\n');
+    assert.match(text, /제거 대상/);
+    assert.match(text, /config \/ auth\.json 은 건드리지 않습니다/);
+    assert.match(text, /linger 해제는/);
+  });
+});

--- a/packages/telegram/test/uninstall-service-subcommand.test.js
+++ b/packages/telegram/test/uninstall-service-subcommand.test.js
@@ -98,7 +98,10 @@ describe('runUninstallServiceSubcommand (issue #138)', () => {
 
 describe('formatTelegramUninstallServiceHelp', () => {
   it('첫 줄이 token-weather telegram uninstall-service', () => {
-    assert.match(formatTelegramUninstallServiceHelp()[0], /^token-weather telegram uninstall-service$/);
+    assert.match(
+      formatTelegramUninstallServiceHelp()[0],
+      /^token-weather telegram uninstall-service$/,
+    );
   });
   it('제거 대상 + 주의 단락 포함', () => {
     const text = formatTelegramUninstallServiceHelp().join('\n');


### PR DESCRIPTION
## 요약

5-phase Telegram 봇 통합 plan (#126~#130) 의 후속 follow-up. Phase 4 (#129) 의 `telegram setup` 이 OS service template 를 **print 만** 하던 흐름을, 동의 기반 자동 등록으로 확장합니다. **5+ 줄 셸 명령 → Enter 한 번**. 보안 도구 원칙 (동의 필요) 유지.

PR #136 의 review 메시지 #796 → #797 (검토) → #798 (사용자 결정 사양) 후속.

## 변경 내용

### 신규 모듈 `packages/telegram/src/`
- `os-service-installer.js` — `installOsService` / `uninstallOsService` 와 OS 별 install/uninstall 함수 (systemd / launchd / Task Scheduler). 모든 외부 의존성 (fs / exec / confirm / log / env / platform) 주입 가능.
- `uninstall-service-subcommand.js` — `runUninstallServiceSubcommand` 진입점 + `formatTelegramUninstallServiceHelp`.

### `packages/telegram/src/setup-subcommand.js` 갱신
- 6 단계 마지막 (template print) → 동의 프롬프트 `자동으로 설치하시겠습니까? [Y/n]` 분기.
- Y default → installer 호출 → installed / skipped / failed 출력.
- 거부 / skip / failed 시 기존 수동 안내 fallback.

### `packages/telegram/src/index.js`
- `uninstall-service` dispatch + help 갱신.
- 신규 export — installer 함수 8 개 + uninstall-service helper + parseYesNo.

### `packages/telegram/src/os-service-templates.js`
- `linuxSystemdUnit` / `macosLaunchAgent` 의 반환에 `content` / `serviceFilename` 추가 (installer 가 사용). 기존 `instructions` (heredoc) 보존, backward-compat.

### 테스트
- `test/os-service-installer.test.js` (16 it) — parseYesNo / install / uninstall / cleanup / skip / dispatch.
- `test/uninstall-service-subcommand.test.js` (7 it) — help / status 분기 / 옵션 통과.
- `test/setup-subcommand.test.js` — 기존 케이스에 installer mock 주입 (실 systemctl 호출 차단) + 신규 케이스 2 건 (Y default / 거부 n).

### 문서
- `docs/telegram-bot.md` — §빠른 시작 / §명령 표 / §"OS service 등록" 모두 갱신. 자동 등록 / fallback / uninstall-service 흐름 안내. 기존 수동 안내는 fallback section 으로 보존.

### Changeset
- `.changeset/telegram-os-service-installer.md` — 4 패키지 모두 minor.

## UX 비교

| 기존 (#129) | 자동 등록 (본 PR) |
|---|---|
| 1. setup 끝의 template 블록 보기 | 1. setup 끝의 `자동 설치 [Y/n]` 프롬프트 |
| 2. 5+ 줄 셸 명령 셸에 복사 / 붙여넣기 | 2. Enter → 자동 등록 완료 |
| 3. 무시하고 `telegram start` 수동 실행 | 3. 거부 시 기존 수동 안내 fallback |

## 결정된 사양 (메시지 #798)

| 결정 포인트 | 답 |
|---|---|
| 동의 프롬프트 default | Y |
| systemd 부재 fallback (WSL/container/Alpine) | skip + 수동 안내 |
| uninstall 책임 범위 | service / linger 까지만 (config / auth.json 미관여) |
| 기존 service 파일 충돌 시 confirm default | n (덮어쓰지 않음) |
| `uninstall-service` 의 confirm default | Y (제거) |

## 위험 / Fallback

- WSL / Docker / Alpine OpenRC — `systemctl --version` 사전 detect → skip + 수동 안내.
- nvm / fnm path stale — install 완료 메시지에 "Node 버전 매니저 변경 시 setup 재실행 권장".
- 기존 service 파일 충돌 — hash 비교 → confirm (default n).
- install 중간 실패 — try / catch + cleanup (unlink) + status failed.
- uninstall 의 linger 비활성화 — 다른 user-level service 도 영향 가능 (안내).
- 모든 외부 의존성 주입 가능 — OS matrix 실 e2e 없이도 mock 으로 verify.

## 영향 범위

- [x] `packages/telegram` — 2 신규 모듈 + 2 테스트 파일 + setup/index 갱신
- [ ] `packages/agent` / `schemas` / `provider-adapters` — 무변경
- [x] `docs` — `docs/telegram-bot.md` 의 자동 등록 / uninstall-service 안내
- [x] `repo` — `.changeset/telegram-os-service-installer.md`

## 테스트 / 확인

- `npm test` — 1031 통과 (직전 1002 + 신규 29)
- `npm run lint` / `format:check` / `build:types` / `install-smoke.sh` 모두 통과
- `npx changeset status` — 4 패키지 모두 minor
- 수동:
  - `node bin/token-weather.js telegram --help` → 4 subcommand 안내 (setup / start / check / uninstall-service)
  - `node bin/token-weather.js telegram uninstall-service --help` → 제거 대상 / 주의 안내

## 리뷰 포인트

1. **충돌 시 default n** — 사용자 직접 수정 파일 덮어쓰기 사고 회피. 사용자 (메시지 #798) 결정.
2. **uninstall default Y** — 사용자가 명령 입력한 시점에 의도 명확. setup 의 install default Y 와 대칭.
3. **systemctl --version 사전 detect** — install 중 실패 시 cleanup 부담을 사전 차단. WSL / Alpine 등 일반적 케이스에 graceful.
4. **linger 비활성화 안내** — 동일 사용자의 다른 user-level service (예: 다른 daemon) 에도 영향. 사용자에게 명시 (uninstall-service help + 안내 텍스트).
5. **public export 표면 증가** — `parseYesNo` 같은 작은 helper 까지 export. 외부 사용자가 자체 흐름 (커스텀 prompt 등) 에서 호출 가능.
6. **테스트의 mock 깊이** — 실 systemctl / launchctl / schtasks 호출은 모든 케이스에서 차단 (execImpl mock). CI 머신 부작용 0.

## 후속

본 PR 완료 후 5-phase plan + 두 follow-up (#137 deep link + #138 자동 등록) 모두 v0.5.x publish 에 합류.

## 참고

- Closes #138.
- bump: minor (`@token-weather/telegram` 동작 추가, contract 변경 없음).
- 5-phase Telegram 봇 통합 plan: #126 / #127 / #128 / #129 / #130 모두 완료.
- Follow-up: #137 (deep link) + 본 PR (#138 자동 등록).
- 검토 thread: PR #136 의 메시지 #796 → #797 → #798.