### PR TITLE
[refactor] OS service installer 의 result status 'installed' → 'succeeded' (issue #142)

### DIFF
--- a/.changeset/telegram-status-naming.md
+++ b/.changeset/telegram-status-naming.md
@@ -1,0 +1,37 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+refactor(telegram)!: installer / uninstaller status `'installed'` → `'succeeded'` (issue #142).
+
+PR #140 (issue #138) review 라운드 2 에서 분리된 follow-up. 기존
+`uninstallOsService` 가 정상 완료 시 `{ status: 'installed' }` 를 반환해 외부
+consumer 가 "uninstalled 인데 status 가 installed?" 로 헷갈리던 contract 를 단일
+`'succeeded' | 'skipped' | 'failed'` 로 통일.
+
+**변경 사항**:
+
+- `installOsService` / `installSystemdUnit` / `installLaunchAgent` /
+  `installTaskScheduler` 의 정상 완료 반환: `'installed'` → `'succeeded'`.
+- `uninstallOsService` / `uninstallSystemdUnit` / `uninstallLaunchAgent` /
+  `uninstallTaskScheduler` 의 정상 완료 반환: `'installed'` → `'succeeded'`.
+- `InstallResult` typedef 의 status union: `'installed' | 'skipped' | 'failed'` →
+  `'succeeded' | 'skipped' | 'failed'`.
+- 호출 측 분기 (`setup-subcommand.js` / `uninstall-service-subcommand.js`) 갱신.
+
+**Breaking change** — `@token-weather/telegram` 의 public API result shape 변경.
+PR #140 (이전 release) 의 result 와 호환 안 됨. 다만 PR #140 이 publish 전이라
+**외부 사용자가 본 API 에 의존하기 전에 처리** 하는 게 본 PR 의 의도.
+
+본 PR 머지 후 누적 release PR 머지 → v0.5.0 publish 시점에 `'succeeded'` 가
+첫 공식 contract.
+
+**Migration** (PR #140 의 pre-publish 사용자 한정):
+
+```diff
+- if (result.status === 'installed') { ... }
++ if (result.status === 'succeeded') { ... }
+```

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -56,7 +56,7 @@ function hasUnsafePathChars(p) {
 
 /**
  * @typedef {object} InstallResult
- * @property {'installed' | 'skipped' | 'failed'} status
+ * @property {'succeeded' | 'skipped' | 'failed'} status
  * @property {string} message
  * @property {string[]} [steps]
  * @property {string} [error]
@@ -188,7 +188,7 @@ export async function installSystemdUnit(input, options = {}) {
       }
     }
     return {
-      status: 'installed',
+      status: 'succeeded',
       message: `systemd --user service 등록 완료. Node 버전 매니저 변경 시 \`telegram setup\` 재실행 권장.`,
       steps,
     };
@@ -261,7 +261,7 @@ export async function uninstallSystemdUnit(options = {}) {
         log(`⚠ loginctl disable-linger 실패 (계속 진행): ${err?.message ?? err}`);
       }
     }
-    return { status: 'installed', message: 'systemd service 제거 완료', steps };
+    return { status: 'succeeded', message: 'systemd service 제거 완료', steps };
   } catch (err) {
     return {
       status: 'failed',
@@ -338,7 +338,7 @@ export async function installLaunchAgent(input, options = {}) {
     execImpl('launchctl', ['bootstrap', `gui/${uid}`, plistPath]);
     steps.push(`launchctl bootstrap gui/${uid} ${plistPath}`);
     return {
-      status: 'installed',
+      status: 'succeeded',
       message: 'LaunchAgent 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
       steps,
     };
@@ -399,7 +399,7 @@ export async function uninstallLaunchAgent(options = {}) {
     steps.push(`launchctl bootout gui/${uid} ${plistPath}`);
     fsImpl.unlinkSync(plistPath);
     steps.push(`unlink ${plistPath}`);
-    return { status: 'installed', message: 'LaunchAgent 제거 완료', steps };
+    return { status: 'succeeded', message: 'LaunchAgent 제거 완료', steps };
   } catch (err) {
     return {
       status: 'failed',
@@ -473,7 +473,7 @@ export async function installTaskScheduler(input, options = {}) {
     ]);
     steps.push('schtasks /Create /TN TokenWeatherBot ...');
     return {
-      status: 'installed',
+      status: 'succeeded',
       message:
         'Windows Task Scheduler 등록 완료. Node 버전 매니저 변경 시 `telegram setup` 재실행 권장.',
       steps,
@@ -502,7 +502,7 @@ export async function uninstallTaskScheduler(options = {}) {
   try {
     execImpl('schtasks', ['/Delete', '/TN', 'TokenWeatherBot', '/F']);
     steps.push('schtasks /Delete /TN TokenWeatherBot /F');
-    return { status: 'installed', message: 'Task Scheduler 항목 제거 완료', steps };
+    return { status: 'succeeded', message: 'Task Scheduler 항목 제거 완료', steps };
   } catch (err) {
     return {
       status: 'failed',

--- a/packages/telegram/src/setup-subcommand.js
+++ b/packages/telegram/src/setup-subcommand.js
@@ -219,7 +219,7 @@ export async function runSetupSubcommand(args, deps, options = {}) {
       env: options.env ?? process.env,
       platform: options.platform,
     });
-    if (result.status === 'installed') {
+    if (result.status === 'succeeded') {
       log(`✓ ${result.message}`);
       for (const step of result.steps ?? []) log(`  · ${step}`);
     } else if (result.status === 'skipped') {

--- a/packages/telegram/src/uninstall-service-subcommand.js
+++ b/packages/telegram/src/uninstall-service-subcommand.js
@@ -55,8 +55,7 @@ export async function runUninstallServiceSubcommand(args, _deps, options = {}) {
     platform: options.platform,
   });
 
-  if (result.status === 'installed') {
-    // uninstaller 의 'installed' 는 "정상 완료" 의미 (시퀀스 성공).
+  if (result.status === 'succeeded') {
     log(`✓ ${result.message}`);
     for (const step of result.steps ?? []) log(`  · ${step}`);
   } else if (result.status === 'skipped') {

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -102,7 +102,7 @@ describe('installSystemdUnit (issue #138)', () => {
       execImpl: mockExec.impl,
       env: { HOME: '/home/test', USER: 'test' },
     });
-    assert.equal(r.status, 'installed');
+    assert.equal(r.status, 'succeeded');
     assert.ok(mockFs.calls.some((c) => c.op === 'mkdir'));
     assert.ok(mockFs.calls.some((c) => c.op === 'write'));
     const cmds = mockExec.calls.map((c) => `${c.cmd} ${c.args.join(' ')}`);
@@ -146,7 +146,7 @@ describe('installSystemdUnit (issue #138)', () => {
       log: (m) => logs.push(m),
       env: { HOME: '/home/test', USER: 'test' },
     });
-    assert.equal(r.status, 'installed');
+    assert.equal(r.status, 'succeeded');
     assert.ok(logs.some((l) => l.includes('loginctl enable-linger 실패')));
   });
 
@@ -199,7 +199,7 @@ describe('installSystemdUnit guard 보강 (PR #140 review 2)', () => {
       env: { HOME: '/home/test' }, // USER 부재.
       log: (m) => logs.push(m),
     });
-    assert.equal(r.status, 'installed');
+    assert.equal(r.status, 'succeeded');
     // loginctl 호출 부재.
     assert.equal(
       mockExec.calls.some((c) => c.cmd === 'loginctl'),
@@ -291,7 +291,7 @@ describe('uninstallSystemdUnit (issue #138)', () => {
       confirmFn: async () => true,
       env: { HOME: '/home/test', USER: 'test' },
     });
-    assert.equal(r.status, 'installed');
+    assert.equal(r.status, 'succeeded');
     const cmds = mockExec.calls.map((c) => `${c.cmd} ${c.args.join(' ')}`);
     assert.ok(cmds.some((c) => c.includes('systemctl --user disable --now')));
     assert.ok(cmds.some((c) => c.includes('loginctl disable-linger test')));
@@ -351,7 +351,7 @@ describe('installTaskScheduler (issue #138)', () => {
       },
     });
     assert.equal(queryCalled, 1);
-    assert.equal(r.status, 'installed');
+    assert.equal(r.status, 'succeeded');
     // /Create 호출 단언.
     assert.ok(calls.some((c) => c.cmd === 'schtasks' && c.args.includes('/Create')));
   });

--- a/packages/telegram/test/setup-subcommand.test.js
+++ b/packages/telegram/test/setup-subcommand.test.js
@@ -261,7 +261,7 @@ describe('runSetupSubcommand (Phase 4)', () => {
         installer: async () => {
           installerCalled += 1;
           return {
-            status: 'installed',
+            status: 'succeeded',
             message: 'systemd service 등록 완료',
             steps: ['mkdir', 'write', 'enable'],
           };
@@ -322,7 +322,7 @@ describe('runSetupSubcommand (Phase 4)', () => {
             false,
           );
           return overwrite
-            ? { status: 'installed', message: 'overwrote' }
+            ? { status: 'succeeded', message: 'overwrote' }
             : { status: 'skipped', message: '사용자가 덮어쓰기 거부' };
         },
         log,
@@ -372,7 +372,7 @@ describe('runSetupSubcommand (Phase 4)', () => {
         fsImpl: mockFs.fs,
         installer: async () => {
           installerCalled += 1;
-          return { status: 'installed', message: 'should not be called' };
+          return { status: 'succeeded', message: 'should not be called' };
         },
         log,
         errorLog,

--- a/packages/telegram/test/uninstall-service-subcommand.test.js
+++ b/packages/telegram/test/uninstall-service-subcommand.test.js
@@ -37,7 +37,7 @@ describe('runUninstallServiceSubcommand (issue #138)', () => {
       log,
       errorLog,
       uninstaller: async () => ({
-        status: 'installed',
+        status: 'succeeded',
         message: 'systemd service 제거 완료',
         steps: ['systemctl --user disable', 'unlink ...'],
       }),


### PR DESCRIPTION
## 요약

PR #140 (issue #138) review 라운드 2 에서 분리된 follow-up. `@token-weather/telegram` 의 installer / uninstaller 결과 shape 의 status 명칭을 통일 — `'installed'` 가 uninstall 결과로 헷갈리던 문제 해소.

**publish 전 처리** — PR #140 머지된 release PR 가 머지되어 v0.5.0 이 npm 에 올라가기 전. 외부 사용자가 본 API 에 의존하기 전에 contract 정정.

## 변경 내용

### `packages/telegram/src/os-service-installer.js`
- `installSystemdUnit` / `installLaunchAgent` / `installTaskScheduler` 정상 완료 반환: `'installed'` → `'succeeded'`.
- `uninstallSystemdUnit` / `uninstallLaunchAgent` / `uninstallTaskScheduler` 정상 완료 반환: 동일.
- `InstallResult` typedef 의 status union 갱신.

### `packages/telegram/src/setup-subcommand.js`
- `result.status === 'installed'` → `'succeeded'`.

### `packages/telegram/src/uninstall-service-subcommand.js`
- `result.status === 'installed'` → `'succeeded'`.
- "uninstaller 의 'installed' 는 정상 완료 의미" 주석 제거 (불필요).

### 테스트 (3 파일)
- `test/os-service-installer.test.js` / `test/uninstall-service-subcommand.test.js` / `test/setup-subcommand.test.js` 의 모든 `'installed'` 단언 갱신.

### Changeset
- `.changeset/telegram-status-naming.md` — 4 패키지 모두 minor (linked).
- body: 변경된 함수 8개 + Breaking change 표기 + Migration snippet.

## 변경 이유

`uninstallOsService` 가 정상 완료 시 `{ status: 'installed' }` 를 반환하는 것이 contract 으로 부자연스럽다는 review 지적 (PR #140 review 라운드 2). 단일 `'succeeded' | 'skipped' | 'failed'` 가 의미 명확 + 호출 측 분기도 동일.

권장안 B (install / uninstall 별 status 분리 — `'installed'` / `'removed'`) 대비 A (`'succeeded'`) 선택 이유: 단순성 + 호출 측 분기 동일. 명령 이름 자체로 install / uninstall 구분 가능.

## 영향 범위

- [x] `packages/telegram` — installer + setup + uninstall-service + 3 테스트
- [ ] `packages/agent` / `schemas` / `provider-adapters` — 무변경
- [x] `repo` — `.changeset/telegram-status-naming.md`

## 테스트 / 확인

- `npm test` — 1039 통과 (모든 status 단언 갱신, 회귀 0)
- `npm run lint` / `format:check` / `build:types` 전부 통과
- `npx changeset status` — 4 패키지 모두 minor

## 리뷰 포인트

1. **Breaking change 의 영향** — PR #140 이 publish 전이라 외부 사용자 없음. 본 PR 머지 후 release PR 머지 → v0.5.0 publish 시점에 `'succeeded'` 가 첫 공식 contract. publish 후 변경했으면 major bump + Migration 부담.
2. **bump minor** — v0.x 의 linked 정책 + Breaking change 의 사용자 영향이 사실상 0 (pre-publish). v0.x convention 상 minor + `!` prefix.
3. **`!` commit message** — release-policy §1 의 v0.x convention 에 따라 `refactor(telegram)!:` 형식 (breaking 표시).

## 참고

- Closes #142.
- bump: minor (v0.x convention).
- Follow-up source: PR #140 의 review 라운드 2.
- 남은 follow-up: #141 (Windows 경로 escaping helper) — publish 후 진행 가능.