### PR TITLE
[feat] 텔레그램 봇 /status, /usage 모바일 가독성 (issue #144)

### DIFF
--- a/.changeset/telegram-status-formatter.md
+++ b/.changeset/telegram-status-formatter.md
@@ -1,0 +1,36 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): `/status`, `/usage` Telegram 응답을 모바일 폭 친화 compact 출력으로
+교체 (issue #144).
+
+기존에는 CLI 의 `formatStatusOutput` (데스크탑 80+ column 가정 — `╭─` rounded box +
+`━━━━ ... ━━━━━` 50–55 column heavy rule + 50 column progress bar) 출력을 그대로
+`<pre>` 로 감싸 보냈는데, 텔레그램 모바일 (폭 ~30–40 column) 에서 본문이 word
+wrap 되어 박스가 갈라지는 회귀가 있었음.
+
+**변경 사항**:
+
+- `@token-weather/telegram` 에 모바일 폭 친화 formatter 추가:
+  - `formatStatusForTelegram(snapshot, ctx?) → string[]` — 라인 폭 ≤ 32 column,
+    `━━ Title ━━` 짧은 section 라벨, 박스 / 50-column progress bar 미사용
+  - `compactResetTime(isoDate, now?) → string` — `9:42pm` / `Sat 4:42am` /
+    `May 22 3am` 형식. timezone 표기 생략 (모바일 폭 확보)
+  - `TELEGRAM_LINE_WIDTH = 32` 상수
+- `status-handler.js` / `usage-handler.js` 가 `deps.formatStatusOutput` 대신
+  새 formatter 호출. `formatPreChunksForTelegram` 4096 자 entity-safe chunking
+  은 그대로 (PR #134 review 정합).
+- `dispatcher.js` 의 `TelegramDeps` jsdoc 에서 `formatStatusOutput` 항목 제거.
+- `@token-weather/cli` 의 `run-cli.js` 가 telegram 패키지로 주입하는 deps 에서
+  `formatStatusOutput` 항목 제거 (telegram 패키지가 더 이상 요구하지 않음).
+  CLI 평문 (`token-weather status` 데스크탑) / `--json` contract 는 변경 없음.
+
+**Non-goal**:
+
+- CLI 평문 출력 변경 — `formatStatusOutput` 는 데스크탑 사용자용으로 그대로 유지.
+- `--json` stable contract 변경 없음.
+- doctor / auth_list / status-json 핸들러는 폭 가정이 없어 영향 없음.

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -43,9 +43,9 @@ token-weather telegram uninstall-service
 
 | Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                                                                                  |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `/status`        | 평문 status 출력 (HTML `<pre>` 블록)                                                                                  |
+| `/status`        | 모바일 폭 친화 compact 평문 (HTML `<pre>` 블록, ≤ 32 column)                                                          |
 | `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status")                                                              |
-| `/usage`         | status alias — 평문                                                                                                   |
+| `/usage`         | status alias — 모바일 친화 compact 평문                                                                               |
 | `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")                                                               |
 | `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단                                                                     |
 | `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션                                                                       |
@@ -53,6 +53,35 @@ token-weather telegram uninstall-service
 | `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback                                                                 |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
+
+### `/status` / `/usage` 출력 예시 (issue #144)
+
+CLI 의 데스크탑 박스 (`╭─` / `│` / `╰─`) + 50-column heavy rule 은 모바일 폭 (~30–40 column) 에서 wrap 으로 박스가 깨지기 때문에, 텔레그램 봇은 `@token-weather/telegram` 패키지의 `formatStatusForTelegram` 으로 박스 미사용 compact 출력을 보냅니다 (라인 폭 ≤ 32 column 가이드, timezone 표기 생략):
+
+```
+━━ Status ━━
+Codex  enabled
+Claude enabled
+Sync   disabled
+
+━━ Codex ━━
+me@example.com · Pro
+✓ OK (200)
+· primary: 38%
+  reset 9:42pm
+· secondary: 71%
+  reset Sat 4:42am
+
+━━ Claude ━━
+me@anthropic.example
+✓ OK (200)
+· 5h: 19%
+  reset 3pm
+· 7d: 8%
+  reset May 22 3am
+```
+
+CLI 평문 (`token-weather status` 데스크탑) 과 `--json` 출력 contract 는 변경 없이 유지됩니다 — 텔레그램 채널 전용 가공.
 
 ## OS service 등록
 

--- a/packages/agent/src/cli/run-cli.js
+++ b/packages/agent/src/cli/run-cli.js
@@ -17,7 +17,6 @@ import { runAuthLogoutCommand, formatAuthLogoutHelp } from './auth-logout-comman
 import { runAuthImportCommand, formatAuthImportHelp } from './auth-import-command.js';
 
 import { getStatusSnapshot } from '../services/status-service.js';
-import { formatStatusOutput } from './status-formatters.js';
 import { formatStatusJson } from './status-json.js';
 import { resolveAgentConfigPath } from '../config/config-path.js';
 import { createDefaultConfig } from '../config/default-config.js';
@@ -104,7 +103,6 @@ async function runTelegramSubcommand(argv) {
   }
   const deps = {
     getStatusSnapshot,
-    formatStatusOutput,
     formatStatusJson,
     collectDoctorReport,
     formatDoctorReportLines,

--- a/packages/telegram/src/dispatcher.js
+++ b/packages/telegram/src/dispatcher.js
@@ -19,7 +19,6 @@ import { createAuthListHandler } from './handlers/auth-list-handler.js';
 /**
  * @typedef {object} TelegramDeps
  * @property {(options?: object) => Promise<object>} getStatusSnapshot
- * @property {(snapshot: object, ctx?: object) => string[]} formatStatusOutput
  * @property {(snapshot: object, meta?: object) => string} formatStatusJson
  * @property {() => Promise<object>} collectDoctorReport
  * @property {(report: object) => string[]} formatDoctorReportLines

--- a/packages/telegram/src/handlers/status-handler.js
+++ b/packages/telegram/src/handlers/status-handler.js
@@ -1,24 +1,28 @@
 /**
- * `/status` 명령 핸들러 — 평문 (formatStatusOutput) 출력을 Telegram 으로 전송.
+ * `/status` 명령 핸들러 — Telegram 전용 compact 포맷으로 <pre> 응답.
  *
- * Phase 3 (#128). 의존성 주입 — `@token-weather/cli` 의 core 함수를 deps 로
- * 받아 사용하고, 본 패키지는 cli 를 직접 import 하지 않는다 (순환 회피 정책).
+ * Phase 3 (#128) 에서 도입, issue #144 로 CLI 의 formatStatusOutput (데스크탑
+ * 박스 / heavy rule / 50-column progress bar) 대신 본 패키지의
+ * formatStatusForTelegram 을 사용하도록 교체. 텔레그램 모바일 폭 (~30–40
+ * column) 에서 박스가 wrap 으로 깨지는 회귀 해소.
  *
- * `--json` 분기는 dispatcher 가 책임 — 본 핸들러는 단일 책임 (평문 출력).
+ * 의존성 주입은 `deps.getStatusSnapshot` 만 — 텍스트 가공은 본 패키지가
+ * 책임지므로 `formatStatusOutput` deps 의존이 제거되었음. dispatcher 의
+ * `--json` 분기는 본 핸들러 책임이 아님 (status-json-handler).
  */
 
 import { formatPreChunksForTelegram } from '../formatters.js';
+import { formatStatusForTelegram } from '../telegram-status-formatter.js';
 
 /**
  * @param {object} deps
  * @param {(options?: object) => Promise<object>} deps.getStatusSnapshot
- * @param {(snapshot: object, ctx?: object) => string[]} deps.formatStatusOutput
  * @returns {(ctx: object, args: string[]) => Promise<void>}
  */
 export function createStatusHandler(deps) {
   return async function statusHandler(ctx, _args) {
     const snapshot = await deps.getStatusSnapshot({});
-    const text = deps.formatStatusOutput(snapshot, { useColor: false }).join('\n');
+    const text = formatStatusForTelegram(snapshot).join('\n');
     const chunks = formatPreChunksForTelegram(text);
     for (const chunk of chunks) {
       await ctx.reply(chunk, { parse_mode: 'HTML' });

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -54,6 +54,11 @@ export {
   uninstallTaskScheduler,
   parseYesNo,
 } from './os-service-installer.js';
+export {
+  formatStatusForTelegram,
+  compactResetTime,
+  TELEGRAM_LINE_WIDTH,
+} from './telegram-status-formatter.js';
 
 let _activeServer = null;
 

--- a/packages/telegram/src/telegram-status-formatter.js
+++ b/packages/telegram/src/telegram-status-formatter.js
@@ -1,0 +1,219 @@
+/**
+ * Telegram 전용 status / usage 출력 formatter — 모바일 폭 친화 compact 변형.
+ *
+ * issue #144: CLI 의 `formatStatusOutput` 은 데스크탑 80+ column 가정으로
+ * `╭─` rounded box + `━━━━ ... ━━━━━` 50–55 column heavy rule + 50 column
+ * progress bar 를 사용. 텔레그램 모바일 (폭 ~30–40 column) 에서 `<pre>`
+ * 본문이 word wrap 되어 박스가 갈라지는 회귀가 있었음. 본 formatter 는 동일
+ * snapshot 을 받아 모바일 폭 안에 들어가는 라인 배열을 만든다.
+ *
+ * 디자인 가이드:
+ *   - 라인 폭 목표 ≤ TELEGRAM_LINE_WIDTH (32 column)
+ *   - rounded box / 50-column progress bar 미사용
+ *   - section 라벨은 짧은 `━━ Title ━━` heavy rule (모바일 폭 안)
+ *   - 긴 값 (config path / email) 은 우측-우선 truncate
+ *   - useColor / ANSI 무시 — 텔레그램 `<pre>` 는 monospace, ANSI 미지원
+ *   - reset 시각 표기는 timezone 생략 (모바일 폭 확보, 사용자가 자기 tz 임을 인지)
+ *
+ * 본 모듈은 `@token-weather/cli` 를 import 하지 않는다 (PR #131 review 정책).
+ * 입력 snapshot 의 shape 는 cli 의 `getStatusSnapshot()` 결과와 동일.
+ */
+
+export const TELEGRAM_LINE_WIDTH = 32;
+
+const SECTION_RULE = '━━';
+
+/**
+ * Telegram 출력 라인 배열.
+ *
+ * @param {object} snapshot — `getStatusSnapshot()` 결과
+ * @param {{ now?: Date }} [ctx]
+ * @returns {string[]}
+ */
+export function formatStatusForTelegram(snapshot, ctx = {}) {
+  const lines = [];
+  const now = ctx.now ?? new Date();
+
+  lines.push(sectionHeader('Status'));
+  lines.push(`Codex  ${enabledLabel(snapshot?.providers?.codex?.enabled)}`);
+  lines.push(`Claude ${enabledLabel(snapshot?.providers?.claude?.enabled)}`);
+  lines.push(`Sync   ${enabledLabel(snapshot?.sync?.enabled)}`);
+  if (snapshot?.accountFilter) {
+    lines.push(`Acct filter: ${truncate(snapshot.accountFilter, TELEGRAM_LINE_WIDTH - 13)}`);
+  }
+  if (snapshot?.providerFilter) {
+    lines.push(`Prov filter: ${snapshot.providerFilter}`);
+  }
+
+  if (snapshot?.codex) {
+    lines.push('');
+    lines.push(...formatCodexSection(snapshot.codex, now));
+  }
+  if (snapshot?.claude) {
+    lines.push('');
+    lines.push(...formatClaudeSection(snapshot.claude, now));
+  }
+  return lines;
+}
+
+function formatCodexSection(codex, now) {
+  const lines = [sectionHeader('Codex')];
+  if (!codex.enabled) {
+    lines.push('Disabled');
+    return lines;
+  }
+  const snapshots = codex.usageSnapshots ?? [];
+  if (snapshots.length === 0) {
+    if (codex.filteredOut) {
+      lines.push(`No match: ${truncate(String(codex.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`);
+    } else {
+      lines.push('No Codex profile');
+    }
+    return lines;
+  }
+  for (let i = 0; i < snapshots.length; i++) {
+    if (i > 0) lines.push('');
+    lines.push(...formatAccountBlock('openai-codex', snapshots[i], now));
+  }
+  return lines;
+}
+
+function formatClaudeSection(claude, now) {
+  const lines = [sectionHeader('Claude')];
+  const snapshots = claude.usageSnapshots ?? [];
+  if (snapshots.length === 0) {
+    if (claude.filteredOut) {
+      lines.push(`No match: ${truncate(String(claude.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`);
+    } else {
+      lines.push('Skipped (disabled / no token)');
+    }
+    return lines;
+  }
+  for (let i = 0; i < snapshots.length; i++) {
+    if (i > 0) lines.push('');
+    lines.push(...formatAccountBlock('anthropic-claude', snapshots[i], now));
+  }
+  return lines;
+}
+
+function formatAccountBlock(providerId, snapshot, now) {
+  const lines = [];
+  const id = accountIdentifier(snapshot.account);
+  const plan = snapshot.account?.plan;
+  const headerParts = [id ?? providerLabel(providerId)];
+  if (plan) headerParts.push(plan);
+  lines.push(truncate(headerParts.join(' · '), TELEGRAM_LINE_WIDTH));
+
+  if (snapshot.status?.ok) {
+    lines.push(`✓ OK${snapshot.status.httpStatus ? ` (${snapshot.status.httpStatus})` : ''}`);
+  } else {
+    lines.push('✗ FAILED');
+    if (snapshot.status?.message) {
+      lines.push(`  ${truncate(trimMessage(snapshot.status.message), TELEGRAM_LINE_WIDTH - 2)}`);
+    }
+  }
+
+  for (const window of snapshot.usageWindows ?? []) {
+    lines.push(...formatWindowCompact(window, now));
+  }
+  return lines;
+}
+
+function formatWindowCompact(window, now) {
+  const label = compactWindowLabel(window);
+  const pct = formatPercent(window?.usedPercent);
+  const reset = compactResetTime(window?.resetAt, now);
+  return [`· ${label}: ${pct}`, `  reset ${truncate(reset, TELEGRAM_LINE_WIDTH - 8)}`];
+}
+
+function sectionHeader(title) {
+  return `${SECTION_RULE} ${title} ${SECTION_RULE}`;
+}
+
+function enabledLabel(enabled) {
+  return enabled ? 'enabled' : 'disabled';
+}
+
+function accountIdentifier(account) {
+  if (!account) return null;
+  return (
+    account.email ??
+    account.accountId ??
+    account.accountKey ??
+    account.profileId ??
+    null
+  );
+}
+
+function providerLabel(providerId) {
+  if (providerId === 'openai-codex') return 'codex';
+  if (providerId === 'anthropic-claude') return 'claude';
+  return providerId;
+}
+
+/**
+ * window kind → 모바일 친화 짧은 라벨. CLI 의 WINDOW_LABELS 와 의도적으로
+ * 다름 — `'Current session (5h)'` 같은 긴 라벨이 32 column 에 안 들어옴.
+ */
+function compactWindowLabel(window) {
+  const kind = window?.kind;
+  const compact = {
+    five_hour: '5h',
+    seven_day: '7d',
+    seven_day_sonnet: '7d sonnet',
+    seven_day_opus: '7d opus',
+    primary: 'primary',
+    secondary: 'secondary',
+  };
+  if (kind && compact[kind]) return compact[kind];
+  if (window?.label) return truncate(window.label, 16);
+  if (kind) return truncate(kind, 16);
+  return 'window';
+}
+
+function formatPercent(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${Math.round(value)}%`;
+}
+
+function trimMessage(message) {
+  if (typeof message !== 'string') return String(message ?? '');
+  const idx = message.indexOf(' — ');
+  return idx >= 0 ? message.slice(0, idx) : message;
+}
+
+function truncate(value, limit) {
+  const text = String(value ?? '');
+  if (text.length <= limit) return text;
+  if (limit <= 1) return '…';
+  return `${text.slice(0, limit - 1)}…`;
+}
+
+/**
+ * Reset 시각 모바일 친화 표기 — timezone 생략.
+ *
+ *   - 잘못된 입력 → 'unknown' / 원문
+ *   - 같은 day (now 기준) → `9pm` 또는 `9:42pm`
+ *   - 다른 day → `Sat 9pm` 또는 `May 15 9pm`
+ */
+export function compactResetTime(isoDate, now = new Date()) {
+  if (!isoDate) return 'unknown';
+  const d = new Date(isoDate);
+  if (Number.isNaN(d.getTime())) return String(isoDate);
+
+  const hour = d.getHours();
+  const min = d.getMinutes();
+  const ampm = hour < 12 ? 'am' : 'pm';
+  const h12 = hour % 12 || 12;
+  const timeStr = min === 0 ? `${h12}${ampm}` : `${h12}:${String(min).padStart(2, '0')}${ampm}`;
+
+  if (d.toDateString() === now.toDateString()) return timeStr;
+
+  const diffDays = Math.round((d.getTime() - now.getTime()) / 86_400_000);
+  if (diffDays > 0 && diffDays < 7) {
+    const weekday = d.toLocaleString('en-US', { weekday: 'short' });
+    return `${weekday} ${timeStr}`;
+  }
+  const month = d.toLocaleString('en-US', { month: 'short' });
+  return `${month} ${d.getDate()} ${timeStr}`;
+}

--- a/packages/telegram/src/telegram-status-formatter.js
+++ b/packages/telegram/src/telegram-status-formatter.js
@@ -65,7 +65,9 @@ function formatCodexSection(codex, now) {
   const snapshots = codex.usageSnapshots ?? [];
   if (snapshots.length === 0) {
     if (codex.filteredOut) {
-      lines.push(`No match: ${truncate(String(codex.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`);
+      lines.push(
+        `No match: ${truncate(String(codex.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`,
+      );
     } else {
       lines.push('No Codex profile');
     }
@@ -83,7 +85,9 @@ function formatClaudeSection(claude, now) {
   const snapshots = claude.usageSnapshots ?? [];
   if (snapshots.length === 0) {
     if (claude.filteredOut) {
-      lines.push(`No match: ${truncate(String(claude.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`);
+      lines.push(
+        `No match: ${truncate(String(claude.accountFilter ?? ''), TELEGRAM_LINE_WIDTH - 10)}`,
+      );
     } else {
       lines.push('Skipped (disabled / no token)');
     }
@@ -136,13 +140,7 @@ function enabledLabel(enabled) {
 
 function accountIdentifier(account) {
   if (!account) return null;
-  return (
-    account.email ??
-    account.accountId ??
-    account.accountKey ??
-    account.profileId ??
-    null
-  );
+  return account.email ?? account.accountId ?? account.accountKey ?? account.profileId ?? null;
 }
 
 function providerLabel(providerId) {

--- a/packages/telegram/test/dispatcher.test.js
+++ b/packages/telegram/test/dispatcher.test.js
@@ -3,9 +3,18 @@ import assert from 'node:assert/strict';
 
 import { buildDispatcher } from '../src/dispatcher.js';
 
+function minimalStatusSnapshot() {
+  return {
+    schemaVersion: '0.5.0',
+    providers: { codex: { enabled: true }, claude: { enabled: true } },
+    sync: { enabled: false },
+    accountFilter: null,
+    providerFilter: null,
+  };
+}
+
 function makeDeps() {
   let snapshotCalls = 0;
-  let outputCalls = 0;
   let jsonCalls = 0;
   let doctorCalls = 0;
   let authListCalls = 0;
@@ -13,11 +22,7 @@ function makeDeps() {
     deps: {
       getStatusSnapshot: async () => {
         snapshotCalls += 1;
-        return { schemaVersion: '0.5.0' };
-      },
-      formatStatusOutput: () => {
-        outputCalls += 1;
-        return ['status text'];
+        return minimalStatusSnapshot();
       },
       formatStatusJson: () => {
         jsonCalls += 1;
@@ -34,7 +39,7 @@ function makeDeps() {
       },
       formatAuthListLines: () => ['auth list'],
     },
-    counts: () => ({ snapshotCalls, outputCalls, jsonCalls, doctorCalls, authListCalls }),
+    counts: () => ({ snapshotCalls, jsonCalls, doctorCalls, authListCalls }),
   };
 }
 
@@ -48,22 +53,23 @@ function makeCtx() {
   };
 }
 
-describe('buildDispatcher (Phase 3)', () => {
+describe('buildDispatcher (Phase 3 + issue #144)', () => {
   it('5 명령 키가 정확히 노출됨 (status / usage / doctor / auth_list)', () => {
     const { deps } = makeDeps();
     const dispatcher = buildDispatcher(deps);
-    // status_json 은 별도 키가 아니라 status/usage 의 --json 분기로 들어감.
     assert.deepEqual(Object.keys(dispatcher).sort(), ['auth_list', 'doctor', 'status', 'usage']);
   });
 
-  it('/status (no --json) → status-handler 호출 (formatStatusOutput 사용)', async () => {
+  it('/status (no --json) → status-handler 호출 (telegram-compact 출력 + reply)', async () => {
     const { deps, counts } = makeDeps();
     const dispatcher = buildDispatcher(deps);
     const ctx = makeCtx();
     await dispatcher.status(ctx, []);
     const c = counts();
-    assert.equal(c.outputCalls, 1);
+    assert.equal(c.snapshotCalls, 1);
     assert.equal(c.jsonCalls, 0);
+    assert.equal(ctx.replies.length, 1);
+    assert.match(ctx.replies[0].text, /<pre>━━ Status ━━/);
   });
 
   it('/status --json → status-json-handler 로 위임 (formatStatusJson 사용)', async () => {
@@ -73,14 +79,13 @@ describe('buildDispatcher (Phase 3)', () => {
     await dispatcher.status(ctx, ['--json']);
     const c = counts();
     assert.equal(c.jsonCalls, 1);
-    assert.equal(c.outputCalls, 0);
+    assert.equal(ctx.replies.length, 1);
   });
 
   it('/status --json 의 meta.command 는 "status" (PR #134 review)', async () => {
     let captured = null;
     const deps = {
       getStatusSnapshot: async () => ({}),
-      formatStatusOutput: () => [],
       formatStatusJson: (_, meta) => {
         captured = meta;
         return '{}';
@@ -100,7 +105,6 @@ describe('buildDispatcher (Phase 3)', () => {
     let captured = null;
     const deps = {
       getStatusSnapshot: async () => ({}),
-      formatStatusOutput: () => [],
       formatStatusJson: (_, meta) => {
         captured = meta;
         return '{}';
@@ -116,13 +120,15 @@ describe('buildDispatcher (Phase 3)', () => {
     assert.equal(captured.command, 'usage');
   });
 
-  it('/usage (no --json) → status alias (formatStatusOutput 사용)', async () => {
+  it('/usage (no --json) → status alias (telegram-compact 출력 + reply)', async () => {
     const { deps, counts } = makeDeps();
     const dispatcher = buildDispatcher(deps);
     const ctx = makeCtx();
     await dispatcher.usage(ctx, []);
     const c = counts();
-    assert.equal(c.outputCalls, 1);
+    assert.equal(c.snapshotCalls, 1);
+    assert.equal(ctx.replies.length, 1);
+    assert.match(ctx.replies[0].text, /<pre>━━ Status ━━/);
   });
 
   it('/usage --json 도 동일 status-json 위임', async () => {

--- a/packages/telegram/test/handlers/status-handler.test.js
+++ b/packages/telegram/test/handlers/status-handler.test.js
@@ -14,57 +14,76 @@ function makeCtx() {
   };
 }
 
-describe('createStatusHandler (Phase 3)', () => {
-  it('deps.getStatusSnapshot + deps.formatStatusOutput 호출 + <pre> wrap reply', async () => {
+function minimalSnapshot() {
+  return {
+    schemaVersion: '0.5.0',
+    configPath: '/home/u/.config/token-weather/config.json',
+    providers: { codex: { enabled: true }, claude: { enabled: true } },
+    sync: { enabled: false },
+    accountFilter: null,
+    providerFilter: null,
+  };
+}
+
+describe('createStatusHandler (Phase 3 + issue #144)', () => {
+  it('deps.getStatusSnapshot 호출 + telegram-compact 출력을 <pre> wrap reply', async () => {
     let snapshotCalled = 0;
-    let formatCalled = 0;
     const deps = {
       getStatusSnapshot: async () => {
         snapshotCalled += 1;
-        return { schemaVersion: '0.5.0', providers: [] };
-      },
-      formatStatusOutput: (snapshot, ctx) => {
-        formatCalled += 1;
-        assert.equal(ctx.useColor, false, 'Telegram 응답은 항상 NO_COLOR');
-        return ['line one', 'line two'];
+        return minimalSnapshot();
       },
     };
     const handler = createStatusHandler(deps);
     const ctx = makeCtx();
     await handler(ctx, []);
     assert.equal(snapshotCalled, 1);
-    assert.equal(formatCalled, 1);
     assert.equal(ctx.replies.length, 1);
-    assert.match(ctx.replies[0].text, /<pre>line one\nline two<\/pre>/);
+    assert.match(ctx.replies[0].text, /^<pre>━━ Status ━━\n/);
+    assert.match(ctx.replies[0].text, /<\/pre>$/);
     assert.deepEqual(ctx.replies[0].options, { parse_mode: 'HTML' });
   });
 
-  it('출력이 길면 여러 chunk 로 split 후 각각 reply', async () => {
-    const longText = Array.from({ length: 100 }, (_, i) => `line-${i}-${'x'.repeat(50)}`);
+  it('출력은 박스 글리프 없이 telegram 친화 포맷 (회귀 가드)', async () => {
+    const deps = { getStatusSnapshot: async () => minimalSnapshot() };
+    const handler = createStatusHandler(deps);
+    const ctx = makeCtx();
+    await handler(ctx, []);
+    const text = ctx.replies[0].text;
+    for (const glyph of ['╭', '│', '╰', '┌', '└', '█', '░']) {
+      assert.ok(!text.includes(glyph), `glyph 미포함 기대: ${glyph}`);
+    }
+  });
+
+  it('긴 출력은 formatPreChunksForTelegram 으로 chunk 분할', async () => {
+    const manyAccounts = Array.from({ length: 200 }, (_, i) => ({
+      account: { email: `user${i}@example.com`, plan: 'Pro' },
+      status: { ok: true, httpStatus: 200 },
+      usageWindows: [],
+    }));
     const deps = {
-      getStatusSnapshot: async () => ({}),
-      formatStatusOutput: () => longText,
+      getStatusSnapshot: async () => ({
+        ...minimalSnapshot(),
+        codex: { enabled: true, usageSnapshots: manyAccounts, filteredOut: false },
+      }),
     };
     const handler = createStatusHandler(deps);
     const ctx = makeCtx();
     await handler(ctx, []);
     assert.ok(ctx.replies.length > 1, 'expected multiple chunks');
     for (const r of ctx.replies) {
-      assert.ok(r.text.length <= 4000, 'each chunk respects safe limit');
+      assert.ok(r.text.length <= 4096, '각 chunk 4096 자 한도 준수');
     }
   });
 });
 
 describe('createUsageHandler (Phase 3 — status alias)', () => {
   it('createStatusHandler 와 동일 동작', async () => {
-    const deps = {
-      getStatusSnapshot: async () => ({}),
-      formatStatusOutput: () => ['usage line'],
-    };
+    const deps = { getStatusSnapshot: async () => minimalSnapshot() };
     const handler = createUsageHandler(deps);
     const ctx = makeCtx();
     await handler(ctx, []);
     assert.equal(ctx.replies.length, 1);
-    assert.match(ctx.replies[0].text, /<pre>usage line<\/pre>/);
+    assert.match(ctx.replies[0].text, /<pre>━━ Status ━━/);
   });
 });

--- a/packages/telegram/test/router-e2e.test.js
+++ b/packages/telegram/test/router-e2e.test.js
@@ -16,7 +16,6 @@ import { handleTextMessage } from '../src/bot-server.js';
 function makeDeps() {
   const calls = {
     snapshot: 0,
-    output: 0,
     json: 0,
     doctorReport: 0,
     doctorLines: 0,
@@ -27,11 +26,13 @@ function makeDeps() {
     deps: {
       getStatusSnapshot: async () => {
         calls.snapshot += 1;
-        return { schemaVersion: '0.5.0' };
-      },
-      formatStatusOutput: () => {
-        calls.output += 1;
-        return ['status text'];
+        return {
+          schemaVersion: '0.5.0',
+          providers: { codex: { enabled: true }, claude: { enabled: true } },
+          sync: { enabled: false },
+          accountFilter: null,
+          providerFilter: null,
+        };
       },
       formatStatusJson: () => {
         calls.json += 1;
@@ -58,6 +59,8 @@ function makeDeps() {
   };
 }
 
+const TELEGRAM_BOX_GLYPHS = ['╭', '│', '╰', '┌', '└', '█', '░'];
+
 function makeCtx(text, { username = 'TokenWeatherBot' } = {}) {
   const replies = [];
   return {
@@ -70,18 +73,28 @@ function makeCtx(text, { username = 'TokenWeatherBot' } = {}) {
   };
 }
 
-describe('router e2e — message text → dispatcher → deps + reply (Phase 3)', () => {
-  it('/status → status handler → formatStatusOutput + <pre> reply', async () => {
+describe('router e2e — message text → dispatcher → deps + reply (Phase 3 + issue #144)', () => {
+  it('/status → status handler → telegram-compact 출력 + <pre> reply', async () => {
     const { deps, calls } = makeDeps();
     const dispatcher = buildDispatcher(deps);
     const ctx = makeCtx('/status');
     await handleTextMessage(ctx, { dispatcher });
     assert.equal(calls.snapshot, 1);
-    assert.equal(calls.output, 1);
     assert.equal(calls.json, 0);
     assert.equal(ctx.replies.length, 1);
-    assert.match(ctx.replies[0].text, /<pre>status text<\/pre>/);
+    assert.match(ctx.replies[0].text, /<pre>━━ Status ━━/);
     assert.deepEqual(ctx.replies[0].options, { parse_mode: 'HTML' });
+  });
+
+  it('/status 출력에 데스크탑 박스 글리프 미포함 (issue #144 회귀 가드)', async () => {
+    const { deps } = makeDeps();
+    const dispatcher = buildDispatcher(deps);
+    const ctx = makeCtx('/status');
+    await handleTextMessage(ctx, { dispatcher });
+    const text = ctx.replies[0].text;
+    for (const glyph of TELEGRAM_BOX_GLYPHS) {
+      assert.ok(!text.includes(glyph), `glyph 미포함 기대: ${glyph}`);
+    }
   });
 
   it('/status --json → status-json handler → formatStatusJson + <pre> reply', async () => {
@@ -90,16 +103,27 @@ describe('router e2e — message text → dispatcher → deps + reply (Phase 3)'
     const ctx = makeCtx('/status --json');
     await handleTextMessage(ctx, { dispatcher });
     assert.equal(calls.json, 1);
-    assert.equal(calls.output, 0);
     assert.match(ctx.replies[0].text, /<pre>\{.*schemaVersion.*\}<\/pre>/);
   });
 
-  it('/usage → status alias (formatStatusOutput 호출)', async () => {
+  it('/usage → status alias (snapshot 1 회 + <pre> reply)', async () => {
     const { deps, calls } = makeDeps();
     const dispatcher = buildDispatcher(deps);
     const ctx = makeCtx('/usage');
     await handleTextMessage(ctx, { dispatcher });
-    assert.equal(calls.output, 1);
+    assert.equal(calls.snapshot, 1);
+    assert.match(ctx.replies[0].text, /<pre>━━ Status ━━/);
+  });
+
+  it('/usage 출력에도 데스크탑 박스 글리프 미포함 (issue #144 회귀 가드)', async () => {
+    const { deps } = makeDeps();
+    const dispatcher = buildDispatcher(deps);
+    const ctx = makeCtx('/usage');
+    await handleTextMessage(ctx, { dispatcher });
+    const text = ctx.replies[0].text;
+    for (const glyph of TELEGRAM_BOX_GLYPHS) {
+      assert.ok(!text.includes(glyph), `glyph 미포함 기대: ${glyph}`);
+    }
   });
 
   it('/doctor → collectDoctorReport + formatDoctorReportLines + reply', async () => {

--- a/packages/telegram/test/telegram-status-formatter.test.js
+++ b/packages/telegram/test/telegram-status-formatter.test.js
@@ -1,0 +1,304 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatStatusForTelegram,
+  compactResetTime,
+  TELEGRAM_LINE_WIDTH,
+} from '../src/telegram-status-formatter.js';
+
+const NOW = new Date('2026-05-15T10:00:00');
+
+function makeMinimalSnapshot(overrides = {}) {
+  return {
+    schemaVersion: '0.5.0',
+    configPath: '/home/u/.config/token-weather/config.json',
+    providers: { codex: { enabled: true }, claude: { enabled: true } },
+    sync: { enabled: false },
+    accountFilter: null,
+    providerFilter: null,
+    ...overrides,
+  };
+}
+
+function makeCodexSnapshot(opts = {}) {
+  return {
+    enabled: true,
+    accountFilter: null,
+    filteredOut: false,
+    usageSnapshots: [
+      {
+        account: { email: 'me@example.com', plan: 'Pro' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [
+          { kind: 'primary', usedPercent: 38, resetAt: '2026-05-15T21:42:00' },
+          { kind: 'secondary', usedPercent: 71, resetAt: '2026-05-16T04:42:00' },
+        ],
+        ...opts.snapshotOverride,
+      },
+    ],
+    ...opts.codexOverride,
+  };
+}
+
+function makeClaudeSnapshot(opts = {}) {
+  return {
+    enabled: true,
+    accountFilter: null,
+    filteredOut: false,
+    usageSnapshots: [
+      {
+        account: { email: 'me@anthropic.example' },
+        status: { ok: true, httpStatus: 200 },
+        usageWindows: [
+          { kind: 'five_hour', usedPercent: 19, resetAt: '2026-05-15T15:00:00' },
+          { kind: 'seven_day', usedPercent: 8, resetAt: '2026-05-22T03:00:00' },
+        ],
+        ...opts.snapshotOverride,
+      },
+    ],
+    ...opts.claudeOverride,
+  };
+}
+
+function assertAllLinesWithinWidth(lines, limit = TELEGRAM_LINE_WIDTH) {
+  for (const line of lines) {
+    assert.ok(
+      [...line].length <= limit,
+      `line over ${limit}: ${JSON.stringify(line)} (len=${[...line].length})`,
+    );
+  }
+}
+
+describe('formatStatusForTelegram', () => {
+  it('top-level summary 는 enabled / disabled flag 만 노출 (config path 미노출 — 모바일 폭 보호)', () => {
+    const lines = formatStatusForTelegram(makeMinimalSnapshot(), { now: NOW });
+    assert.deepEqual(lines.slice(0, 4), [
+      '━━ Status ━━',
+      'Codex  enabled',
+      'Claude enabled',
+      'Sync   disabled',
+    ]);
+    assertAllLinesWithinWidth(lines);
+  });
+
+  it('disabled provider 는 disabled 로 표시', () => {
+    const lines = formatStatusForTelegram(
+      makeMinimalSnapshot({
+        providers: { codex: { enabled: false }, claude: { enabled: false } },
+      }),
+      { now: NOW },
+    );
+    assert.ok(lines.includes('Codex  disabled'));
+    assert.ok(lines.includes('Claude disabled'));
+  });
+
+  it('Codex section — 단일 계정 OK', () => {
+    const snapshot = makeMinimalSnapshot({ codex: makeCodexSnapshot() });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.includes('━━ Codex ━━'));
+    assert.ok(lines.includes('me@example.com · Pro'));
+    assert.ok(lines.includes('✓ OK (200)'));
+    assert.ok(lines.some((l) => l.startsWith('· primary:')));
+    assert.ok(lines.some((l) => l.startsWith('· secondary:')));
+    assertAllLinesWithinWidth(lines);
+  });
+
+  it('Claude section — kind 매핑 (five_hour → 5h, seven_day → 7d)', () => {
+    const snapshot = makeMinimalSnapshot({ claude: makeClaudeSnapshot() });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.includes('━━ Claude ━━'));
+    assert.ok(lines.some((l) => l.startsWith('· 5h:')));
+    assert.ok(lines.some((l) => l.startsWith('· 7d:')));
+    assertAllLinesWithinWidth(lines);
+  });
+
+  it('multi-account 일 때 각 계정 블록 사이 빈 줄', () => {
+    const snapshot = makeMinimalSnapshot({
+      codex: {
+        enabled: true,
+        accountFilter: null,
+        filteredOut: false,
+        usageSnapshots: [
+          {
+            account: { email: 'a@example.com', plan: 'Free' },
+            status: { ok: true, httpStatus: 200 },
+            usageWindows: [],
+          },
+          {
+            account: { email: 'b@example.com', plan: 'Pro' },
+            status: { ok: true, httpStatus: 200 },
+            usageWindows: [],
+          },
+        ],
+      },
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    const aIdx = lines.findIndex((l) => l.includes('a@example.com'));
+    const bIdx = lines.findIndex((l) => l.includes('b@example.com'));
+    assert.ok(aIdx >= 0 && bIdx > aIdx);
+    assert.equal(lines[bIdx - 1], '', '계정 블록 사이 빈 줄 필요');
+  });
+
+  it('Codex 비활성화 / 계정 없음 / 필터 미스 분기', () => {
+    const disabled = formatStatusForTelegram(
+      makeMinimalSnapshot({ codex: { enabled: false, usageSnapshots: [] } }),
+      { now: NOW },
+    );
+    assert.ok(disabled.includes('Disabled'));
+
+    const empty = formatStatusForTelegram(
+      makeMinimalSnapshot({ codex: { enabled: true, usageSnapshots: [] } }),
+      { now: NOW },
+    );
+    assert.ok(empty.includes('No Codex profile'));
+
+    const filtered = formatStatusForTelegram(
+      makeMinimalSnapshot({
+        codex: {
+          enabled: true,
+          usageSnapshots: [],
+          filteredOut: true,
+          accountFilter: 'unknown',
+        },
+      }),
+      { now: NOW },
+    );
+    assert.ok(filtered.some((l) => l.startsWith('No match:')));
+  });
+
+  it('Claude 비활성 (snapshot 미존재) 시 섹션 자체 미포함', () => {
+    const snapshot = makeMinimalSnapshot({ codex: makeCodexSnapshot() });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(!lines.some((l) => l.includes('Claude ━━')));
+  });
+
+  it('Claude usageSnapshots 빈 + filteredOut=false → "Skipped" 라벨', () => {
+    const snapshot = makeMinimalSnapshot({
+      claude: { enabled: true, usageSnapshots: [], filteredOut: false },
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.includes('Skipped (disabled / no token)'));
+  });
+
+  it('FAILED status 는 ✗ + trim 된 에러 메시지', () => {
+    const snapshot = makeMinimalSnapshot({
+      codex: {
+        enabled: true,
+        accountFilter: null,
+        filteredOut: false,
+        usageSnapshots: [
+          {
+            account: { email: 'fail@example.com' },
+            status: { ok: false, message: 'token refresh failed: 401 — {"error":"..."}' },
+            usageWindows: [],
+          },
+        ],
+      },
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.includes('✗ FAILED'));
+    assert.ok(lines.some((l) => l.trim().startsWith('token refresh failed: 401')));
+    assert.ok(!lines.some((l) => l.includes('{"error"')), '— 이후 raw payload 미포함');
+    assertAllLinesWithinWidth(lines);
+  });
+
+  it('긴 email 은 truncate — 라인 폭 32 자 이하 보장', () => {
+    const snapshot = makeMinimalSnapshot({
+      codex: {
+        enabled: true,
+        usageSnapshots: [
+          {
+            account: {
+              email: 'very-long-test-account-xyz@verylongdomain.example',
+              plan: 'Enterprise-Premium-Plus',
+            },
+            status: { ok: true, httpStatus: 200 },
+            usageWindows: [],
+          },
+        ],
+      },
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assertAllLinesWithinWidth(lines);
+    assert.ok(lines.some((l) => l.endsWith('…')), '긴 헤더가 truncate 표시(…)로 끝남');
+  });
+
+  it('window 의 usedPercent 가 null → "—" 로 표시', () => {
+    const snapshot = makeMinimalSnapshot({
+      claude: {
+        enabled: true,
+        usageSnapshots: [
+          {
+            account: { email: 'me@example.com' },
+            status: { ok: true, httpStatus: 200 },
+            usageWindows: [{ kind: 'five_hour', usedPercent: null, resetAt: null }],
+          },
+        ],
+      },
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.some((l) => l.startsWith('· 5h: —')));
+    assert.ok(lines.some((l) => l.startsWith('  reset unknown')));
+  });
+
+  it('accountFilter / providerFilter 가 있으면 noise 없이 한 줄씩 추가', () => {
+    const snapshot = makeMinimalSnapshot({
+      accountFilter: 'mylabel',
+      providerFilter: 'codex',
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    assert.ok(lines.some((l) => l.startsWith('Acct filter:')));
+    assert.ok(lines.some((l) => l.startsWith('Prov filter: codex')));
+  });
+
+  it('박스 글리프 (╭ │ ╰ ┌ └ ─ progress bar █ ░) 미사용 — CLI formatter 와 분리 회귀 가드', () => {
+    const snapshot = makeMinimalSnapshot({
+      codex: makeCodexSnapshot(),
+      claude: makeClaudeSnapshot(),
+    });
+    const lines = formatStatusForTelegram(snapshot, { now: NOW });
+    const joined = lines.join('\n');
+    for (const glyph of ['╭', '│', '╰', '┌', '└', '─', '█', '░']) {
+      assert.ok(!joined.includes(glyph), `glyph 미포함 기대: ${glyph}`);
+    }
+  });
+});
+
+describe('compactResetTime', () => {
+  it('null / 잘못된 입력 처리', () => {
+    assert.equal(compactResetTime(null, NOW), 'unknown');
+    assert.equal(compactResetTime(undefined, NOW), 'unknown');
+    assert.equal(compactResetTime('not-a-date', NOW), 'not-a-date');
+  });
+
+  it('같은 day → 시간만 (timezone 미포함)', () => {
+    const same = new Date('2026-05-15T21:42:00');
+    assert.equal(compactResetTime(same, NOW), '9:42pm');
+    const onTheHour = new Date('2026-05-15T15:00:00');
+    assert.equal(compactResetTime(onTheHour, NOW), '3pm');
+  });
+
+  it('7일 이내 다른 day → weekday + 시간', () => {
+    const tomorrow = new Date('2026-05-16T04:42:00');
+    const result = compactResetTime(tomorrow, NOW);
+    assert.match(result, /^Sat 4:42am$/);
+  });
+
+  it('7일 이후 → month day + 시간', () => {
+    const later = new Date('2026-06-10T09:00:00');
+    const result = compactResetTime(later, NOW);
+    assert.match(result, /^Jun 10 9am$/);
+  });
+
+  it('어떤 입력이어도 반환값에 괄호 timezone 없음 (모바일 폭 보호)', () => {
+    const cases = [
+      new Date('2026-05-15T21:42:00'),
+      new Date('2026-05-16T04:42:00'),
+      new Date('2026-06-10T09:00:00'),
+    ];
+    for (const c of cases) {
+      assert.ok(!compactResetTime(c, NOW).includes('('));
+    }
+  });
+});

--- a/packages/telegram/test/telegram-status-formatter.test.js
+++ b/packages/telegram/test/telegram-status-formatter.test.js
@@ -221,7 +221,10 @@ describe('formatStatusForTelegram', () => {
     });
     const lines = formatStatusForTelegram(snapshot, { now: NOW });
     assertAllLinesWithinWidth(lines);
-    assert.ok(lines.some((l) => l.endsWith('…')), '긴 헤더가 truncate 표시(…)로 끝남');
+    assert.ok(
+      lines.some((l) => l.endsWith('…')),
+      '긴 헤더가 truncate 표시(…)로 끝남',
+    );
   });
 
   it('window 의 usedPercent 가 null → "—" 로 표시', () => {


### PR DESCRIPTION
## 요약

- 텔레그램 봇 `/status` `/usage` 응답을 모바일 화면 (폭 ~30–40 column) 에 맞춰 박스 미사용 compact 출력으로 교체합니다 (issue #144).
- CLI 평문 (`token-weather status`) 과 `--json` 출력 contract 는 변경 없이 유지합니다.

## 변경 내용

- `@token-weather/telegram` 에 새 모듈 `telegram-status-formatter.js` 추가:
  - `formatStatusForTelegram(snapshot, ctx?) → string[]` — 라인 폭 ≤ 32 column, `━━ Title ━━` 짧은 section 라벨, 박스 / 50-column progress bar 미사용
  - `compactResetTime(isoDate, now?)` — `9:42pm` / `Sat 4:42am` / `May 22 3am`. timezone 표기 생략 (모바일 폭 확보)
  - `TELEGRAM_LINE_WIDTH = 32` public export
- `handlers/status-handler.js` 가 `deps.formatStatusOutput` 대신 새 formatter 호출. `formatPreChunksForTelegram` 4096 자 entity-safe chunking 은 그대로 (PR #134 review 정합).
- `dispatcher.js` `TelegramDeps` jsdoc 에서 `formatStatusOutput` 항목 제거. `packages/agent/src/cli/run-cli.js` 가 telegram 패키지로 주입하는 deps 에서도 같은 항목 제거.
- 단위 테스트 신규 (`telegram-status-formatter.test.js`) + 기존 핸들러 / dispatcher / router-e2e 테스트 갱신 — 박스 글리프 (`╭ │ ╰ ┌ └ █ ░`) 미포함 회귀 가드 추가.
- `docs/telegram-bot.md` 의 명령 표 설명 갱신 + "출력 예시" 섹션 신설.
- `.changeset/telegram-status-formatter.md` — 4 패키지 linked minor bump.

## 변경 이유

`@token-weather/telegram` 도입 (Phase 2~5, #127–#142) 이후 모바일에서 `/status` `/usage` 응답을 받아보면, `formatStatusOutput` 의 데스크탑 80+ column 박스 (`╭─` rounded corner / 50-column heavy rule / 50-column ASCII progress bar) 가 모바일 폭에서 word wrap 되어 박스가 깨졌습니다. CLI 평문은 데스크탑 사용자가 의도한 layout 이므로 그대로 두고, 텔레그램 채널 전용 가공만 추가하는 방향으로 분리합니다 — `@token-weather/telegram` 은 `@token-weather/cli` 를 import 하지 않는 정책 (PR #131 review) 도 유지.

영향 범위 감사 결과:

| 핸들러 | 폭 가정 | 영향 |
| --- | --- | --- |
| status-handler / usage-handler | `formatStatusOutput` 박스 + heavy rule | ❌ → ✅ 본 PR |
| doctor-handler | 박스 없음 | ✅ |
| auth-list-handler | `── name ──` 구분자만 | ✅ |
| status-json-handler | 단일 JSON 라인 (자동화 컨텍스트) | ➖ 변경 없음 |

## 영향 범위

- [x] `packages/agent` (deps 객체 정리 — `formatStatusOutput` 주입 제거)
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [x] `packages/telegram` (새 formatter + 핸들러 교체 + 테스트)
- [x] `repo` (changeset)
- [x] `docs` (telegram-bot.md)

## 스크린샷 / 데모

CLI 평문은 변화 없고, 텔레그램 응답 mockup:

```
━━ Status ━━
Codex  enabled
Claude enabled
Sync   disabled

━━ Codex ━━
me@example.com · Pro
✓ OK (200)
· primary: 38%
  reset 9:42pm
· secondary: 71%
  reset Sat 4:42am

━━ Claude ━━
me@anthropic.example
✓ OK (200)
· 5h: 19%
  reset 3pm
· 7d: 8%
  reset May 22 3am
```

실제 모바일 텔레그램 client screenshot 은 머지 전 추가 가능 (필요 시).

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1060 pass / 0 fail (이전 1039 + 신규 21), `npm run lint` clean
- [x] 필요한 문서 업데이트 반영 — `docs/telegram-bot.md` 의 명령 표 + 출력 예시 신설
- [x] schema / provider / CLI 영향 범위를 직접 점검 — telegram 모듈 내부 변경 + cli 의 deps 객체 정리만 영향, schema 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음 — fixture 는 `me@example.com` / `me@anthropic.example` 등 placeholder

## 리뷰 포인트

- 새 formatter 의 라인 폭 가이드 (32 column) 가 적절한지. 사용자의 실제 모바일 화면 폭 (Telegram 의 monospace 폰트 기준) 과 align 되는지.
- `compactResetTime` 이 timezone 표기를 생략 — 모바일 폭 확보를 위해 의도된 trade-off (CLI 평문은 `(Asia/Seoul)` 등 그대로 유지). 사용자가 자기 tz 임을 인지하는 가정.
- `compactWindowLabel` 의 kind → 짧은 라벨 매핑 (`five_hour → 5h`, `seven_day → 7d` 등). 매핑 미존재 kind 는 16 자 truncate.
- `packages/agent/src/cli/run-cli.js` 의 deps 정리 — `formatStatusOutput` 항목 제거. 외부 사용자가 `runTelegramCommand(argv, deps)` 를 직접 호출하는 케이스에서 옛 deps 객체 (formatStatusOutput 포함) 를 그대로 넘겨도 동작은 깨지지 않음 (추가 키 무시).

## 참고 사항

- 관련 이슈: #144
- 후속 후보 (별도 이슈로 분리):
  - `--json` 출력의 모바일 환경 가독성 (자동화 컨텍스트라 유지 결정 — 본 PR 범위 밖)
  - doctor / auth_list 핸들러의 줄 길이 점검 (현재 박스 없음 — 별도 측정 후 필요 시)
  - 모바일 실제 환경 screenshot 을 README / docs 에 첨부
