### PR TITLE
[feat] 텔레그램 봇 슬래시 명령 자동완성 메뉴 + /help (issue #148)

### DIFF
--- a/.changeset/telegram-commands-menu.md
+++ b/.changeset/telegram-commands-menu.md
@@ -1,0 +1,36 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): Telegram 봇 슬래시 명령 자동완성 메뉴 + `/help` (issue #148).
+
+#144 (PR #145) / #146 (PR #147) 의 후속. 사용자가 텔레그램 채팅 입력창에서 `/` 만
+입력하면 client 가 명령 자동완성 메뉴를 띄우도록 [Bot API
+`setMyCommands`](https://core.telegram.org/bots/api#setmycommands) 를 boot 시점에
+호출. 동일 source 를 `/help` 응답으로도 회신.
+
+**변경 사항**:
+
+- `@token-weather/telegram` 새 모듈 `bot-commands.js`:
+  - `BOT_COMMANDS` — 5개 명령 (status / usage / doctor / auth_list / help)
+    단일 source. Telegram BotCommand 형식 `{command, description}`.
+  - `formatHelpText(commands?)` — plain text 빌더 (HTML `<pre>` 미사용).
+- 새 핸들러 `handlers/help-handler.js`:
+  - `createHelpHandler()` — deps 없이 `formatHelpText()` 결과를 reply.
+- `bot-server.js` 의 `createBotServer().start()`:
+  - `bot.init()` 직후 `bot.api.setMyCommands(BOT_COMMANDS)` 호출. 실패해도
+    daemon boot 자체는 진행 (warning log 만).
+- `dispatcher.js`:
+  - `buildDispatcher` 반환 객체에 `help` 키 추가. 새 키는 deps 의존 없음.
+- `index.js` public export 추가: `BOT_COMMANDS`, `formatHelpText`,
+  `createHelpHandler`.
+
+**Non-goal**:
+
+- 명령별 scope (default / private_chats / group / admin) 분리 — 본 PR 은
+  default scope 만.
+- `/start` (페어링 외 일반 사용) 을 `/help` alias 로 처리 — 별도 이슈 후보.
+- CLI 평문 / `--json` contract 변경 없음.

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -59,7 +59,7 @@ token-weather telegram uninstall-service
 
 `token-weather telegram start` daemon 부팅 시 [Bot API `setMyCommands`](https://core.telegram.org/bots/api#setmycommands) 를 호출해 위 명령 목록을 봇에 등록합니다. 사용자는 텔레그램 채팅 입력창에서 `/` 만 눌러도 client (모바일 / 데스크탑) 가 자동완성 메뉴로 명령을 띄워줍니다.
 
-- 등록 source: `packages/telegram/src/bot-commands.js` 의 `BOT_COMMANDS` 배열. 새 명령 추가 시 이 배열만 갱신하면 메뉴 / `/help` / dispatcher 세 곳이 동기화됩니다.
+- 등록 source: `packages/telegram/src/bot-commands.js` 의 `BOT_COMMANDS` 배열. 새 명령을 추가할 때는 핸들러 모듈 / `buildDispatcher()` 키 / 본 배열 entry **세 곳을 함께 갱신** — dispatcher 는 본 배열에서 자동 생성되지 않습니다. dispatcher 키 집합과 `BOT_COMMANDS.command` 의 동기화는 단위 테스트가 drift 가드로 잡습니다.
 - 등록 실패 (네트워크 / 권한 등) 해도 daemon boot 자체는 계속 — 메뉴 등록은 보조 기능이고 사용자가 명령을 직접 입력하면 동일하게 동작합니다.
 - 등록은 idempotent — daemon 재시작마다 자동 갱신.
 

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -43,16 +43,27 @@ token-weather telegram uninstall-service
 
 | Telegram 명령    | 동작 (`token-weather <cmd>` 와 동일)                                                                                  |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `/status`        | 모바일 폭 친화 compact 평문 (HTML `<pre>` 블록, ≤ 32 column)                                                          |
+| `/status`        | 모바일 폭 친화 compact 평문 (HTML `<pre>` 블록, ≤ 32 column, progress bar 포함)                                       |
 | `/status --json` | `formatStatusJson` 결과 (top-level `command` = "status")                                                              |
 | `/usage`         | status alias — 모바일 친화 compact 평문                                                                               |
 | `/usage --json`  | `formatStatusJson` 결과 (top-level `command` = "usage")                                                               |
 | `/doctor`        | `runDoctorRoot` 기본 출력. 인자 / subcommand 차단                                                                     |
 | `/auth_list`     | 모든 provider 의 저장 계정 + claude import 섹션                                                                       |
+| `/help`          | 사용 가능한 명령 목록을 plain text 로 안내 (issue #148)                                                               |
 | `/start <code>`  | 페어링 전용 (setup 시점에만 의미). Telegram deep link 클릭 → 봇 대화창 → (처음이면 Start 버튼) → `/start <code>` 전달 |
 | `/pair <code>`   | 페어링 전용 (setup 시점에만 의미). 수동 입력 fallback                                                                 |
 
 본인이 아닌 봇을 mention 한 명령 (`/status@OtherBot`) 은 silent ignore — group chat 에서 다른 봇 명령에 token-weather 가 응답하지 않습니다.
+
+### 자동완성 메뉴 (issue #148)
+
+`token-weather telegram start` daemon 부팅 시 [Bot API `setMyCommands`](https://core.telegram.org/bots/api#setmycommands) 를 호출해 위 명령 목록을 봇에 등록합니다. 사용자는 텔레그램 채팅 입력창에서 `/` 만 눌러도 client (모바일 / 데스크탑) 가 자동완성 메뉴로 명령을 띄워줍니다.
+
+- 등록 source: `packages/telegram/src/bot-commands.js` 의 `BOT_COMMANDS` 배열. 새 명령 추가 시 이 배열만 갱신하면 메뉴 / `/help` / dispatcher 세 곳이 동기화됩니다.
+- 등록 실패 (네트워크 / 권한 등) 해도 daemon boot 자체는 계속 — 메뉴 등록은 보조 기능이고 사용자가 명령을 직접 입력하면 동일하게 동작합니다.
+- 등록은 idempotent — daemon 재시작마다 자동 갱신.
+
+수동 등록 (자동 등록을 끄거나 별도 봇 username 으로 미리 설정하고 싶을 때) 은 [@BotFather](https://t.me/BotFather) 에 `/setcommands` 명령으로도 가능합니다.
 
 ### `/status` / `/usage` 출력 예시 (issue #144, #146)
 

--- a/packages/telegram/src/bot-commands.js
+++ b/packages/telegram/src/bot-commands.js
@@ -1,0 +1,48 @@
+/**
+ * 봇이 노출하는 슬래시 명령의 단일 source.
+ *
+ * issue #148: Telegram `setMyCommands` Bot API (자동완성 메뉴) 와 `/help` 응답
+ * 두 경로가 동일 배열을 참조해 정합성을 자동 보장한다.
+ *
+ * 각 항목 shape 은 Telegram Bot API `BotCommand` 와 동일:
+ *   - `command`: 1–32자, `[a-z0-9_]`
+ *   - `description`: 1–256자 UTF-8 (한글 OK)
+ *
+ * 새 명령을 dispatcher 에 추가할 때는 본 배열도 함께 갱신 — 매뉴 / `/help` /
+ * dispatcher 세 곳이 동기화된다. dispatcher 의 키는 본 배열의 `command` 와 같은
+ * 형식이어야 (`_` 포함 lowercase) 부합.
+ */
+export const BOT_COMMANDS = Object.freeze([
+  Object.freeze({ command: 'status', description: '사용량 / 인증 상태' }),
+  Object.freeze({ command: 'usage', description: 'status alias' }),
+  Object.freeze({ command: 'doctor', description: '환경 / refresh 진단' }),
+  Object.freeze({ command: 'auth_list', description: '저장된 계정 목록' }),
+  Object.freeze({ command: 'help', description: '사용 가능한 명령 안내' }),
+]);
+
+/**
+ * `/help` 응답용 plain text 빌더. Telegram `<pre>` 미사용 — 일반 메시지로 보내
+ * 모바일이 자연스럽게 reflow 하도록 한다.
+ *
+ * 출력 모양 (BOT_COMMANDS 그대로):
+ *
+ *   Token Weather 봇 명령:
+ *
+ *   /status     — 사용량 / 인증 상태
+ *   /usage      — status alias
+ *   ...
+ *
+ * @param {ReadonlyArray<{command: string, description: string}>} [commands=BOT_COMMANDS]
+ * @returns {string}
+ */
+export function formatHelpText(commands = BOT_COMMANDS) {
+  if (!commands.length) {
+    return 'Token Weather 봇 명령:\n\n(등록된 명령 없음)';
+  }
+  const maxCmdLen = commands.reduce((m, c) => Math.max(m, c.command.length), 0);
+  const lines = ['Token Weather 봇 명령:', ''];
+  for (const { command, description } of commands) {
+    lines.push(`/${command.padEnd(maxCmdLen)}  — ${description}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/telegram/src/bot-server.js
+++ b/packages/telegram/src/bot-server.js
@@ -22,6 +22,7 @@ import { Bot, GrammyError } from 'grammy';
 import { authAllowlistMiddleware } from './auth-allowlist.js';
 import { parseCommand, extractMention, listAvailableCommands } from './command-router.js';
 import { formatErrorForTelegram } from './formatters.js';
+import { BOT_COMMANDS } from './bot-commands.js';
 
 /**
  * @typedef {object} BotServerOptions
@@ -98,6 +99,18 @@ export function createBotServer(options) {
       } catch (err) {
         started = false;
         throw err;
+      }
+      // issue #148: 자동완성 메뉴 등록. 실패해도 daemon boot 자체는 진행 —
+      // 메뉴 등록은 critical 아님 (사용자가 명령을 직접 입력하면 동작). bot
+      // 객체의 api 는 grammy ≥1.x 에 항상 존재 — 호출 자체가 catch 안에서.
+      try {
+        await bot.api.setMyCommands(BOT_COMMANDS);
+      } catch (err) {
+        errorLog(
+          `[token-weather/telegram] setMyCommands 실패 (메뉴 미등록, daemon 계속): ${
+            err?.message ?? String(err)
+          }`,
+        );
       }
       if (!shutdownHandlersRegistered) {
         registerShutdownHandlers(bot);

--- a/packages/telegram/src/dispatcher.js
+++ b/packages/telegram/src/dispatcher.js
@@ -15,6 +15,7 @@ import { createStatusJsonHandler } from './handlers/status-json-handler.js';
 import { createUsageHandler } from './handlers/usage-handler.js';
 import { createDoctorHandler } from './handlers/doctor-handler.js';
 import { createAuthListHandler } from './handlers/auth-list-handler.js';
+import { createHelpHandler } from './handlers/help-handler.js';
 
 /**
  * @typedef {object} TelegramDeps
@@ -39,6 +40,8 @@ export function buildDispatcher(deps) {
   const usageHandler = createUsageHandler(deps);
   const doctorHandler = createDoctorHandler(deps);
   const authListHandler = createAuthListHandler(deps);
+  // issue #148: /help — BOT_COMMANDS 를 plain text 로 회신. deps 인자 없음.
+  const helpHandler = createHelpHandler();
 
   return {
     status: async (ctx, args) => {
@@ -58,5 +61,6 @@ export function buildDispatcher(deps) {
     },
     doctor: doctorHandler,
     auth_list: authListHandler,
+    help: helpHandler,
   };
 }

--- a/packages/telegram/src/handlers/help-handler.js
+++ b/packages/telegram/src/handlers/help-handler.js
@@ -1,0 +1,19 @@
+/**
+ * `/help` 명령 핸들러 — 사용 가능한 슬래시 명령 목록을 plain text 로 회신.
+ *
+ * issue #148. Telegram `setMyCommands` 자동완성 메뉴와 동일 source (BOT_COMMANDS)
+ * 를 사용해 정합성을 보장. `<pre>` 미사용 — 일반 메시지로 보내 모바일 reflow.
+ *
+ * deps 인자는 받지 않음 — formatHelpText 가 BOT_COMMANDS 만 사용하는 pure 함수.
+ */
+
+import { formatHelpText } from '../bot-commands.js';
+
+/**
+ * @returns {(ctx: object, args: string[]) => Promise<void>}
+ */
+export function createHelpHandler() {
+  return async function helpHandler(ctx, _args) {
+    await ctx.reply(formatHelpText());
+  };
+}

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -60,6 +60,8 @@ export {
   TELEGRAM_LINE_WIDTH,
 } from './telegram-status-formatter.js';
 export { compactProgressBar } from './telegram-progress-bar.js';
+export { BOT_COMMANDS, formatHelpText } from './bot-commands.js';
+export { createHelpHandler } from './handlers/help-handler.js';
 
 let _activeServer = null;
 

--- a/packages/telegram/test/bot-commands.test.js
+++ b/packages/telegram/test/bot-commands.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BOT_COMMANDS, formatHelpText } from '../src/bot-commands.js';
+
+describe('BOT_COMMANDS', () => {
+  it('frozen array (외부 변경 차단)', () => {
+    assert.ok(Object.isFrozen(BOT_COMMANDS), 'BOT_COMMANDS 자체가 frozen');
+    for (const entry of BOT_COMMANDS) {
+      assert.ok(Object.isFrozen(entry), `entry frozen: ${entry.command}`);
+    }
+  });
+
+  it('Telegram BotCommand 형식 (command + description) 만 포함', () => {
+    for (const entry of BOT_COMMANDS) {
+      assert.equal(typeof entry.command, 'string');
+      assert.equal(typeof entry.description, 'string');
+      assert.deepEqual(Object.keys(entry).sort(), ['command', 'description']);
+    }
+  });
+
+  it('Telegram 제약: command 는 1–32자 [a-z0-9_], description 은 1–256자', () => {
+    for (const { command, description } of BOT_COMMANDS) {
+      assert.match(command, /^[a-z0-9_]+$/, `command 글자 set: ${command}`);
+      assert.ok(command.length >= 1 && command.length <= 32, `command 길이: ${command}`);
+      assert.ok(
+        description.length >= 1 && description.length <= 256,
+        `description 길이: ${description}`,
+      );
+    }
+  });
+
+  it('중복 command 없음', () => {
+    const names = BOT_COMMANDS.map((c) => c.command);
+    assert.equal(new Set(names).size, names.length, '중복 명령 금지');
+  });
+
+  it('MVP 5 명령이 모두 포함 (status / usage / doctor / auth_list / help)', () => {
+    const names = new Set(BOT_COMMANDS.map((c) => c.command));
+    for (const expected of ['status', 'usage', 'doctor', 'auth_list', 'help']) {
+      assert.ok(names.has(expected), `명령 누락: ${expected}`);
+    }
+  });
+});
+
+describe('formatHelpText', () => {
+  it('첫 줄은 "Token Weather 봇 명령:" + 빈 줄 + 각 명령 한 줄씩', () => {
+    const text = formatHelpText();
+    const lines = text.split('\n');
+    assert.equal(lines[0], 'Token Weather 봇 명령:');
+    assert.equal(lines[1], '');
+    assert.equal(lines.length, 2 + BOT_COMMANDS.length);
+  });
+
+  it('각 명령 라인은 "/cmd ... — description" 형식 + command 폭 padEnd', () => {
+    const text = formatHelpText();
+    const maxCmdLen = Math.max(...BOT_COMMANDS.map((c) => c.command.length));
+    for (const { command, description } of BOT_COMMANDS) {
+      const expected = `/${command.padEnd(maxCmdLen)}  — ${description}`;
+      assert.ok(
+        text.includes(expected),
+        `라인 누락:\nexpected: ${JSON.stringify(expected)}\nactual: ${JSON.stringify(text)}`,
+      );
+    }
+  });
+
+  it('빈 commands 배열 → fallback 안내', () => {
+    const text = formatHelpText([]);
+    assert.match(text, /등록된 명령 없음/);
+  });
+
+  it('사용자 정의 commands 배열 전달 시 그 배열만 사용', () => {
+    const custom = [{ command: 'foo', description: 'bar' }];
+    const text = formatHelpText(custom);
+    assert.ok(text.includes('/foo  — bar'));
+    assert.ok(!text.includes('/status'));
+  });
+
+  it('HTML / <pre> 미사용 (모바일 reflow 의도)', () => {
+    const text = formatHelpText();
+    for (const tag of ['<pre>', '</pre>', '<b>', '<i>', '<code>']) {
+      assert.ok(!text.includes(tag), `${tag} 미포함 기대`);
+    }
+  });
+});

--- a/packages/telegram/test/bot-server.test.js
+++ b/packages/telegram/test/bot-server.test.js
@@ -4,11 +4,24 @@ import assert from 'node:assert/strict';
 import { createBotServer, handleTextMessage } from '../src/bot-server.js';
 import { startBot, stopBot } from '../src/index.js';
 
-function makeMockBot({ initFails = false, initError } = {}) {
+function makeMockBot({
+  initFails = false,
+  initError,
+  setMyCommandsFails = false,
+  setMyCommandsError,
+} = {}) {
   let initAttempts = 0;
   let stopCalled = 0;
+  const setMyCommandsCalls = [];
   return {
-    api: {},
+    api: {
+      setMyCommands: async (commands) => {
+        setMyCommandsCalls.push(commands);
+        if (setMyCommandsFails) {
+          throw setMyCommandsError ?? new Error('mock setMyCommands failure');
+        }
+      },
+    },
     use() {},
     on() {},
     catch() {},
@@ -25,6 +38,9 @@ function makeMockBot({ initFails = false, initError } = {}) {
     },
     get _stopCalled() {
       return stopCalled;
+    },
+    get _setMyCommandsCalls() {
+      return setMyCommandsCalls;
     },
   };
 }
@@ -91,6 +107,53 @@ describe('createBotServer boot validation (PR #133 review)', () => {
     await server.start();
     await server.stop();
     assert.equal(mock._stopCalled, 1);
+  });
+});
+
+describe('createBotServer setMyCommands 자동 등록 (issue #148)', () => {
+  it('start 성공 시 bot.api.setMyCommands(BOT_COMMANDS) 호출 1회', async () => {
+    const mock = makeMockBot();
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+    });
+    await server.start();
+    assert.equal(mock._setMyCommandsCalls.length, 1, 'setMyCommands 1회 호출');
+    const payload = mock._setMyCommandsCalls[0];
+    assert.ok(Array.isArray(payload) && payload.length > 0);
+    const commandNames = payload.map((c) => c.command);
+    for (const expected of ['status', 'usage', 'doctor', 'auth_list', 'help']) {
+      assert.ok(commandNames.includes(expected), `명령 누락: ${expected}`);
+    }
+  });
+
+  it('setMyCommands 실패 시에도 start 는 resolve + errorLog 호출 (daemon 계속)', async () => {
+    const mock = makeMockBot({ setMyCommandsFails: true });
+    const errors = [];
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+      logger: { error: (msg) => errors.push(msg) },
+    });
+    await server.start();
+    assert.equal(mock._setMyCommandsCalls.length, 1);
+    assert.ok(
+      errors.some((m) => m.includes('setMyCommands 실패')),
+      `errorLog 에 실패 안내 누락: ${JSON.stringify(errors)}`,
+    );
+  });
+
+  it('init 실패 시 setMyCommands 호출 없음 (boot 단계 차단)', async () => {
+    const mock = makeMockBot({ initFails: true });
+    const server = createBotServer({
+      botToken: '123:fake',
+      allowedUserIds: [42],
+      botFactory: () => mock,
+    });
+    await assert.rejects(() => server.start());
+    assert.equal(mock._setMyCommandsCalls.length, 0);
   });
 });
 

--- a/packages/telegram/test/dispatcher.test.js
+++ b/packages/telegram/test/dispatcher.test.js
@@ -54,10 +54,24 @@ function makeCtx() {
 }
 
 describe('buildDispatcher (Phase 3 + issue #144)', () => {
-  it('5 명령 키가 정확히 노출됨 (status / usage / doctor / auth_list)', () => {
+  it('명령 키가 정확히 노출됨 (status / usage / doctor / auth_list / help — issue #148)', () => {
     const { deps } = makeDeps();
     const dispatcher = buildDispatcher(deps);
-    assert.deepEqual(Object.keys(dispatcher).sort(), ['auth_list', 'doctor', 'status', 'usage']);
+    assert.deepEqual(
+      Object.keys(dispatcher).sort(),
+      ['auth_list', 'doctor', 'help', 'status', 'usage'],
+    );
+  });
+
+  it('/help → BOT_COMMANDS 기반 plain text reply (issue #148)', async () => {
+    const { deps } = makeDeps();
+    const dispatcher = buildDispatcher(deps);
+    const ctx = makeCtx();
+    await dispatcher.help(ctx, []);
+    assert.equal(ctx.replies.length, 1);
+    assert.match(ctx.replies[0].text, /^Token Weather 봇 명령:/);
+    assert.match(ctx.replies[0].text, /\/help/);
+    assert.equal(ctx.replies[0].options, undefined, 'plain text — parse_mode 없음');
   });
 
   it('/status (no --json) → status-handler 호출 (telegram-compact 출력 + reply)', async () => {

--- a/packages/telegram/test/dispatcher.test.js
+++ b/packages/telegram/test/dispatcher.test.js
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { buildDispatcher } from '../src/dispatcher.js';
+import { BOT_COMMANDS } from '../src/bot-commands.js';
 
 function minimalStatusSnapshot() {
   return {
@@ -64,6 +65,19 @@ describe('buildDispatcher (Phase 3 + issue #144)', () => {
       'status',
       'usage',
     ]);
+  });
+
+  it('dispatcher 키 집합이 BOT_COMMANDS.command 집합과 정확히 일치 (drift 가드, PR #149 self-review)', () => {
+    const { deps } = makeDeps();
+    const dispatcher = buildDispatcher(deps);
+    const dispatcherKeys = Object.keys(dispatcher).sort();
+    const botCommandNames = BOT_COMMANDS.map((c) => c.command).sort();
+    assert.deepEqual(
+      dispatcherKeys,
+      botCommandNames,
+      `drift 발생: dispatcher 키와 BOT_COMMANDS.command 집합이 어긋남. ` +
+        `새 명령 추가 시 핸들러 / buildDispatcher 키 / BOT_COMMANDS entry 세 곳을 모두 갱신하세요.`,
+    );
   });
 
   it('/help → BOT_COMMANDS 기반 plain text reply (issue #148)', async () => {

--- a/packages/telegram/test/dispatcher.test.js
+++ b/packages/telegram/test/dispatcher.test.js
@@ -57,10 +57,13 @@ describe('buildDispatcher (Phase 3 + issue #144)', () => {
   it('명령 키가 정확히 노출됨 (status / usage / doctor / auth_list / help — issue #148)', () => {
     const { deps } = makeDeps();
     const dispatcher = buildDispatcher(deps);
-    assert.deepEqual(
-      Object.keys(dispatcher).sort(),
-      ['auth_list', 'doctor', 'help', 'status', 'usage'],
-    );
+    assert.deepEqual(Object.keys(dispatcher).sort(), [
+      'auth_list',
+      'doctor',
+      'help',
+      'status',
+      'usage',
+    ]);
   });
 
   it('/help → BOT_COMMANDS 기반 plain text reply (issue #148)', async () => {

--- a/packages/telegram/test/handlers/help-handler.test.js
+++ b/packages/telegram/test/handlers/help-handler.test.js
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createHelpHandler } from '../../src/handlers/help-handler.js';
+import { BOT_COMMANDS, formatHelpText } from '../../src/bot-commands.js';
+
+function makeCtx() {
+  const replies = [];
+  return {
+    reply: async (text, options) => {
+      replies.push({ text, options });
+    },
+    replies,
+  };
+}
+
+describe('createHelpHandler (issue #148)', () => {
+  it('reply 1 회 + formatHelpText() 결과와 정확히 일치', async () => {
+    const handler = createHelpHandler();
+    const ctx = makeCtx();
+    await handler(ctx, []);
+    assert.equal(ctx.replies.length, 1);
+    assert.equal(ctx.replies[0].text, formatHelpText());
+  });
+
+  it('reply 옵션 미지정 — plain text (parse_mode 없음)', async () => {
+    const handler = createHelpHandler();
+    const ctx = makeCtx();
+    await handler(ctx, []);
+    assert.equal(ctx.replies[0].options, undefined);
+  });
+
+  it('args 가 무엇이든 동일 출력 (인자 무시)', async () => {
+    const handler = createHelpHandler();
+    const ctx1 = makeCtx();
+    const ctx2 = makeCtx();
+    await handler(ctx1, []);
+    await handler(ctx2, ['--json', 'foo']);
+    assert.equal(ctx1.replies[0].text, ctx2.replies[0].text);
+  });
+
+  it('reply 본문에 모든 BOT_COMMANDS 항목이 등장', async () => {
+    const handler = createHelpHandler();
+    const ctx = makeCtx();
+    await handler(ctx, []);
+    const text = ctx.replies[0].text;
+    for (const { command } of BOT_COMMANDS) {
+      assert.ok(text.includes(`/${command}`), `/${command} 누락`);
+    }
+  });
+});

--- a/packages/telegram/test/router-e2e.test.js
+++ b/packages/telegram/test/router-e2e.test.js
@@ -148,6 +148,18 @@ describe('router e2e — message text → dispatcher → deps + reply (Phase 3 +
     assert.match(ctx.replies[0].text, /<pre>auth list<\/pre>/);
   });
 
+  it('/help → help handler → BOT_COMMANDS plain text reply (issue #148)', async () => {
+    const { deps } = makeDeps();
+    const dispatcher = buildDispatcher(deps);
+    const ctx = makeCtx('/help');
+    await handleTextMessage(ctx, { dispatcher });
+    assert.equal(ctx.replies.length, 1);
+    assert.match(ctx.replies[0].text, /^Token Weather 봇 명령:/);
+    assert.match(ctx.replies[0].text, /\/status/);
+    assert.match(ctx.replies[0].text, /\/help/);
+    assert.equal(ctx.replies[0].options, undefined);
+  });
+
   it('/unknown → "알 수 없는 명령" reply + dispatcher 호출 없음', async () => {
     const { deps, calls } = makeDeps();
     const dispatcher = buildDispatcher(deps);


### PR DESCRIPTION
## 요약

- 텔레그램 봇이 사용 가능한 슬래시 명령 목록을 사용자에게 노출하는 두 경로를 추가합니다 (issue #148).
  - **A. Telegram commands menu** — daemon boot 시 `setMyCommands` Bot API 호출. 사용자가 채팅 입력창에서 `/` 만 누르면 client 자동완성 메뉴 노출.
  - **B. `/help` 명령** — 동일 source 를 plain text 로 회신.

## 변경 내용

- 새 모듈 `packages/telegram/src/bot-commands.js`:
  - `BOT_COMMANDS` — 5개 명령 (`status` / `usage` / `doctor` / `auth_list` / `help`) 단일 source. Telegram BotCommand 형식 `{command, description}`. description 한글 (CLI 다른 문구와 정합).
  - `formatHelpText(commands?)` — plain text 빌더. command 폭 padEnd 정렬.
- 새 핸들러 `packages/telegram/src/handlers/help-handler.js`:
  - `createHelpHandler()` — deps 없이 `formatHelpText()` 결과를 reply (parse_mode 없음, 일반 메시지).
- `bot-server.js`:
  - `createBotServer().start()` 가 `bot.init()` 직후 `bot.api.setMyCommands(BOT_COMMANDS)` 호출. try/catch 로 감싸 실패 시 errorLog 만 출력하고 daemon boot 계속.
- `dispatcher.js`:
  - `buildDispatcher` 반환 객체에 `help: createHelpHandler()` 추가.
- `index.js`: `BOT_COMMANDS`, `formatHelpText`, `createHelpHandler` public export.
- 단위 테스트 신규 (`bot-commands.test.js`, `handlers/help-handler.test.js`, 14 cases).
- 기존 테스트 갱신:
  - `bot-server.test.js` mock 에 `api.setMyCommands` 추가 + 3 단언 (호출 1회 / 실패 시 daemon 계속 / init 실패 시 미호출).
  - `dispatcher.test.js` 키 목록 단언에 `help` 추가 + `/help` plain text 단언.
  - `router-e2e.test.js` `/help` e2e 시나리오 추가.
- `docs/telegram-bot.md` 명령 표에 `/help` 행 + "자동완성 메뉴 (issue #148)" 섹션 신설.
- `.changeset/telegram-commands-menu.md` — 4 패키지 linked minor bump.

## 변경 이유

현재 봇은 5개 명령을 받지만 신규 사용자가 그 목록을 모르면 일일이 외워야 합니다. unknown 명령 응답 (`bot-server.js:164,171`) 의 `listAvailableCommands(dispatcher)` 는 사용자가 일부러 잘못된 명령을 보내야 보이는 구조라 discoverability 가 떨어졌습니다.

Telegram 의 `setMyCommands` Bot API 는 모든 client 가 자동완성 메뉴를 제공하는 정식 UX 이고, `/help` 도 봇이 응답하는 게 관습적입니다. 두 경로가 동일 `BOT_COMMANDS` 배열을 참조하므로 새 명령 추가 시 한 곳만 갱신하면 메뉴 / `/help` / dispatcher 세 곳이 동기화됩니다.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [x] `packages/telegram` (새 source / handler / boot 통합 / dispatcher / 테스트)
- [x] `repo` (changeset)
- [x] `docs` (telegram-bot.md)

## 스크린샷 / 데모

**`/help` 응답 예시**:

```
Token Weather 봇 명령:

/status     — 사용량 / 인증 상태
/usage      — status alias
/doctor     — 환경 / refresh 진단
/auth_list  — 저장된 계정 목록
/help       — 사용 가능한 명령 안내
```

**자동완성 메뉴**: 사용자가 텔레그램 채팅 입력창에서 `/` 만 누르면 client 가 위 5 명령을 list 로 표시 — 실제 모바일 screenshot 은 머지 후 검증.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1094 pass / 0 fail (이전 1075 + 신규 19), `npm run lint` clean
- [x] 필요한 문서 업데이트 반영 — `docs/telegram-bot.md` 의 명령 표 + 자동완성 메뉴 섹션
- [x] schema / provider / CLI 영향 범위를 직접 점검 — telegram 모듈 내부 변경만, schema / provider / CLI 평문 / `--json` contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음

## 리뷰 포인트

- `setMyCommands` 호출이 boot 단계라 정상적이지만, 실패 시 fallback 정책 (daemon 계속 + errorLog) 이 적절한지. 일부 사용자는 network 불안정 시 verbose log 가 짜증 날 수도 — 더 quiet 한 처리를 원하면 의견 주세요.
- `BOT_COMMANDS` description 의 한글 표기 — Telegram 메뉴는 UTF-8 OK 지만 모바일 client 의 메뉴 폭에서 일부 잘릴 수 있음. 더 짧은 표현 / 영어 대안 (예: `usage / auth status`) 도 가능.
- `/help` 응답이 plain text + parse_mode 없음 — `<pre>` monospace 정렬을 쓸 수도 있지만 padEnd 만으로 충분히 정렬되므로 reflow 친화 plain 으로.
- dispatcher 의 `help` 키가 deps 인자 없이 동작 — 다른 핸들러들과 시그니처 약간 다름. `createHelpHandler()` 가 deps 미사용이라 의도된 차이.

## 참고 사항

- 관련 이슈: #148 (PR #145 / #147 의 후속 — 텔레그램 봇 UX 시리즈)
- Out of scope (별도 이슈 후보):
  - 명령별 scope (default / private_chats / group / admin) 분리
  - `/start` (페어링 외 일반 사용) 을 `/help` alias 처리
  - 자동완성 메뉴 description 의 다국어 지원 (`setMyCommands` 의 `language_code` 옵션)
