### PR TITLE
[docs] root CHANGELOG.md v0.5.0 entry 큐레이트

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,41 @@
 
 본 파일은 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 포맷을 따르고, 프로젝트는 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)을 사용합니다. 카테고리 정의와 bump 기준은 [docs/release-policy.md](./docs/release-policy.md) 참고.
 
-3 패키지(`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas`)는 v0.x 동안 linked 되어 같은 version으로 release 됩니다.
+4 패키지(`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas` / `@token-weather/telegram`)는 v0.x 동안 linked 되어 같은 version으로 release 됩니다.
 
 ## [Unreleased]
 
-이 섹션은 publish 시점에 root에서 **수동으로 큐레이트**합니다 — 3 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 패키지별 상세 release note는 [Changesets](https://github.com/changesets/changesets)가 `packages/*/CHANGELOG.md`를 자동 생성하고, 본 문서는 publish PR에서 그 내용을 참고해 채웁니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 changeset을 함께 commit 해주세요.
+이 섹션은 publish 시점에 root에서 **수동으로 큐레이트**합니다 — 4 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 패키지별 상세 release note는 [Changesets](https://github.com/changesets/changesets)가 `packages/*/CHANGELOG.md`를 자동 생성하고, 본 문서는 publish PR에서 그 내용을 참고해 채웁니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 changeset을 함께 commit 해주세요.
+
+## [0.5.0] - 2026-05-18
+
+`@token-weather/telegram` 의 본격 등장 release. 5-phase 텔레그램 봇 통합 ([#127]–[#142]) 으로 핸드폰 / 다른 데스크탑에서 `/status` / `/usage` / `/doctor` / `/auth_list` 를 원격 호출할 수 있고, 후속 모바일 UX 시리즈 ([#144], [#146], [#148]) 로 출력이 모바일 폭 친화 compact + progress bar + 자동완성 메뉴까지 갖춰짐. CLI 평문 / `status --json` contract 변경 없음, OAuth 토큰은 여전히 로컬만 (Telegram 활성 시 사용량 메타데이터만 Telegram 서버 경유 — [docs/telegram-bot.md §보안 모델](./docs/telegram-bot.md)).
+
+### Added — `@token-weather/telegram` 신규 패키지
+
+- **long-poll daemon** ([#127], [#133]) — grammy 기반 `createBotServer` / `startBot` / `stopBot`. boot 시 `bot.init()` token validation, 단일 인스턴스 lock, 409 Conflict 친절한 종료, SIGINT/SIGTERM graceful shutdown.
+- **명령 핸들러 + dispatcher** ([#128], [#134]) — `/status`, `/status --json`, `/usage`, `/usage --json`, `/doctor`, `/auth_list`. `runTelegramCommand(argv, deps)` 가 cli 의 core 함수를 deps 로 주입받아 동작 (telegram 패키지는 cli 를 직접 import 하지 않음 — PR #131 review 정책).
+- **`telegram setup`** ([#129], [#135], [#137], [#139]) — 대화형 봇 토큰 등록 + getMe 검증 + 1회용 페어링 코드 + Telegram deep link / `/pair <code>` / `/start <code>` 흐름 + config 저장 (chmod 600) + default config deep-merge.
+- **`telegram check`** ([#129]) — config / token / linger 상태 read-only 진단.
+- **`telegram start --help`** ([#134]) — 활성화 사전 조건 안내.
+- **OS service installer** ([#138], [#140]) — systemd `--user` / launchd LaunchAgent / Windows Task Scheduler 자동 등록. `setup` 마지막 단계 [Y/n] 프롬프트. 경로 공백 / XML 특수문자 / 권한 부족 시 manual fallback. `telegram uninstall-service` 로 제거 (config / auth.json 은 유지).
+- **자동완성 메뉴 + `/help`** ([#148]) — Telegram Bot API `setMyCommands` 를 boot 시 자동 등록. 사용자가 `/` 만 누르면 client 가 5 명령 자동완성 메뉴 노출. `/help` 는 동일 source (`BOT_COMMANDS`) 의 plain text 응답. drift 가드 단위 테스트.
+- **보안 / 격리** ([#133], [#127]) — `allowedUserIds` 미들웨어로 비허가 user_id silent ignore. group chat 의 다른 봇 mention (`/cmd@OtherBot`) silent ignore. raw prompt / response 미전송, 사용량 / 계정 label 메타데이터만 Telegram 서버 경유.
+
+### Changed — Telegram 출력 UX (모바일 가독성)
+
+- **`/status`, `/usage` 응답을 모바일 폭 친화 compact 출력으로 전환** ([#144]) — CLI 의 `formatStatusOutput` 은 80+ column 박스 (`╭─` / `│` / `╰─`) + 50 column heavy rule 가정이라 모바일 (~30–40 col) 에서 wrap 깨짐 회귀. 새 `formatStatusForTelegram` 이 32 column 안에 들어가는 라인, timezone 생략 reset 시각, `5h` / `7d` 짧은 window 라벨.
+- **window 라인에 10-column ASCII progress bar 복원** ([#146]) — 1/8 정밀도 fractional block (`█▏▎▍▌▋▊▉`) + light shade `░`. 새 `compactProgressBar` — CLI 의 `formatProgressBar` 사본 (ANSI 컬러 분기 제거, Telegram `<pre>` 미지원).
+
+### Changed — Internal
+
+- **OS service installer/uninstaller return shape 통일** ([#142]) — `status: 'installed'` → `'succeeded'`. PR #140 publish 전 처리 → 외부 사용자가 의존한 적 없음.
+
+### Documentation / Security
+
+- `docs/telegram-bot.md` 신규 ([#130], [#148]) — Quick start, 보안 모델, OS service 가이드 (자동 등록 + 수동 등록), FAQ. 출력 예시 mockup, 자동완성 메뉴 설명.
+- `SECURITY.md` ([#130]) — Telegram 채널 위협 모델 + bot token revoke / `/deletebot` 절차. OAuth / bot token / 페어링 코드 저장 위치 분리 명시.
+- README ([#130]) — Telegram 봇 옵션 섹션, "로컬 only" 약속을 Telegram 활성 시 메타데이터 경유로 정밀화.
 
 ## [0.4.0] - 2026-05-12
 
@@ -51,13 +81,29 @@
 - `packages/agent/test/cli/status-json.test.js` — top-level `schemaVersion` lock 회귀 가드 3 케이스 (값 일치 / 키 항상 present / 모든 출력 경로 통과). `packages/schemas/test/schema-version.test.js` (값 lock) 와 함께 SCHEMA_VERSION 한쪽만 bump 회귀 차단.
 - `packages/agent/src/cli/status-bar-helper.js` 신설 (UI) — `shouldUseColor` / `levelForPercent` / `colorize` / `formatProgressBar` / `formatResetTime` / `formatWindowLabel` pure helper.
 
-[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.5.0
 [0.4.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.4.0
 
 [#117]: https://github.com/LLagoon3/token-weather/pull/117
 [#119]: https://github.com/LLagoon3/token-weather/issues/119
 [#120]: https://github.com/LLagoon3/token-weather/issues/120
 [#121]: https://github.com/LLagoon3/token-weather/issues/121
+[#127]: https://github.com/LLagoon3/token-weather/issues/127
+[#128]: https://github.com/LLagoon3/token-weather/issues/128
+[#129]: https://github.com/LLagoon3/token-weather/issues/129
+[#130]: https://github.com/LLagoon3/token-weather/issues/130
+[#133]: https://github.com/LLagoon3/token-weather/pull/133
+[#134]: https://github.com/LLagoon3/token-weather/pull/134
+[#135]: https://github.com/LLagoon3/token-weather/pull/135
+[#137]: https://github.com/LLagoon3/token-weather/issues/137
+[#138]: https://github.com/LLagoon3/token-weather/issues/138
+[#139]: https://github.com/LLagoon3/token-weather/pull/139
+[#140]: https://github.com/LLagoon3/token-weather/pull/140
+[#142]: https://github.com/LLagoon3/token-weather/issues/142
+[#144]: https://github.com/LLagoon3/token-weather/issues/144
+[#146]: https://github.com/LLagoon3/token-weather/issues/146
+[#148]: https://github.com/LLagoon3/token-weather/issues/148
 
 ## [0.3.0] - 2026-05-11
 


### PR DESCRIPTION
## 요약

- v0.5.0 publish 시점의 root `CHANGELOG.md` 수동 큐레이트 (release-policy §4). 이전 v0.4.0 의 PR #125 패턴 정합.
- 4 패키지 (`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas` / `@token-weather/telegram`) 모두 v0.5.0 publish 완료된 상태.

## 변경 내용

- intro 의 "3 패키지" → "4 패키지" 갱신 (`@token-weather/telegram` 신규 publish 반영).
- `[Unreleased]` 정리 + `[0.5.0] - 2026-05-18` entry 신설:
  - **Added — `@token-weather/telegram` 신규 패키지** — long-poll daemon (#127, #133), 핸들러 + dispatcher (#128, #134), `telegram setup` 대화형 페어링 (#129, #135, #137, #139), `telegram check` (#129), OS service installer (#138, #140), 자동완성 메뉴 + `/help` (#148), `allowedUserIds` / mention silent ignore 보안 모델 (#133, #127).
  - **Changed — Telegram 출력 UX** — `/status` `/usage` 모바일 폭 친화 compact (#144), window 라인 10-column ASCII progress bar 복원 (#146).
  - **Changed — Internal** — installer status `'installed'` → `'succeeded'` (#142, pre-publish breaking).
  - **Documentation / Security** — `docs/telegram-bot.md` 신규 (#130, #148), `SECURITY.md` 텔레그램 채널 위협 모델 (#130), README 의 "로컬 only" 약속 정밀화 (#130).
- Link refs: [#127] ~ [#148] 12개 신규 추가, `[Unreleased]` compare 끝점 `v0.4.0` → `v0.5.0`, `[0.5.0]` entry 추가.

## 변경 이유

per-package `CHANGELOG.md` 는 changesets/action 이 자동 생성하지만 (각 패키지 v0.5.0 entry 가 500+ 줄, 11개 changeset 본문 그대로), root `CHANGELOG.md` 는 release-policy §4 정합으로 **publish 시점에 작성자가 수동 큐레이트** — 4 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 본 PR 은 그 큐레이트 작업.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (root CHANGELOG.md)
- [ ] `docs`

## 스크린샷 / 데모

없음 — docs only PR.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npx prettier --check CHANGELOG.md` 통과
- [x] 필요한 문서 업데이트 반영 — root CHANGELOG.md (본 PR 의 유일한 변경)
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only, 코드 / contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 민감값을 redact 했음 — 해당 없음 (docs only)

## 리뷰 포인트

- **카테고리 분류 적절성** — v0.4.0 entry 는 "Changed (Breaking) — `status --json` contract" + "Changed — `cli:status` 평문" + "Internal" 의 3 트랙. v0.5.0 은 telegram 신규 패키지 등장이라 "Added — `@token-weather/telegram` 신규 패키지" 를 새 카테고리로 첫 위치에. 적절한지.
- **본문 길이 / 깊이** — v0.4.0 entry 가 매우 자세한 이유는 `status --json` breaking change 의 migration guide 필요였음. v0.5.0 은 CLI 평문 / `--json` contract 변경 없음 + telegram 추가가 핵심이라 상대적으로 간결. 사용자가 본 entry 만 보고 npm install 후 무엇이 새로 가능한지 파악되는 수준으로 작성.
- **링크 정합** — `v0.5.0` 통합 tag (`v0.x.y` 형식) 는 본 repo 에 존재하지 않음 (4 패키지 별도 tag 만 존재 — `@token-weather/<name>@0.5.0` × 4). 이전 v0.4.0 entry 도 동일 패턴 (`v0.4.0` 통합 tag 부재) 이라 컨벤션 유지. 별도 `v0.5.0` 통합 tag 가 필요하면 후속.

## 참고 사항

- 관련 release PR: #132 (Version Packages, v0.5.0 publish — 2026-05-18 머지)
- per-package CHANGELOG.md 자동 생성: changesets/action 이 머지 시점에 11 changeset 본문을 패키지별로 옮김. 본 root CHANGELOG 는 그 내용을 high-level 요약.
- v0.5.0 publish 사이클의 부분 publish 사고 (`@token-weather/telegram` trusted publisher 미설정 → 재시도) 는 별도 issue 가 아닌 release.yml 운영 메모로 정리. 다음 publish 사이클부터는 trusted publisher 가 등록되어 있어 동일 문제 재발 X.
- 후속 cleanup: 본 PR 머지 후 main 자동 FF (release-policy §3 정합 — sync workflow 가 처리). docs only PR 이라 changesets/action 의 `--json` shape lock 회귀 가드 영향 없음.
