### PR TITLE
[feat] OS service installer 경로 escaping helper — Windows 표준 Node 환경 자동 등록 (issue #141)

### DIFF
--- a/.changeset/telegram-path-escape.md
+++ b/.changeset/telegram-path-escape.md
@@ -1,0 +1,39 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+feat(telegram): OS service installer 의 경로 escaping helper — 공백 / XML 특수문자
+포함 경로도 자동 등록 가능 (issue #141).
+
+PR #140 (issue #138) 의 review 2 round 에서 분리된 follow-up. 기존에는
+`hasUnsafePathChars(p)` (`/[\s<>&"'`]/`) 사전 검사로 공백 / 특수문자 포함 경로를
+skip + manual fallback 했는데, **Windows 표준 Node 설치 환경**
+(`C:\Program Files\nodejs\node.exe`) 에서 자동 등록이 거의 항상 차단되어
+`telegram setup` 의 [Y/n] 동의 옵션이 무의미했음. 본 release 로 OS 별 정확한
+escape 적용 후 자동 등록 통과 → success rate 확장.
+
+**변경 사항**:
+
+- `@token-weather/telegram` 새 helper `os-service-path-escape.js` (public export):
+  - `escapeSystemdArg(value)` — systemd unit `ExecStart=` 의 double-quote escape.
+    systemd 는 direct exec 라 `$VAR` / `` `cmd` `` expansion 없음 → `"` 와 `\` 만
+    escape.
+  - `escapePlistXml(text)` — launchd plist `<string>` element content 의 XML
+    entity escape (`& < >` 만).
+  - `escapeSchtasksArg(value)` — Windows schtasks `/TR` 의 cmd `\"...\"` 형태
+    (outer `"..."` 안에서 escape 된 quote 로 해석).
+- `os-service-templates.js` 3 template 모두 위 helper 호출. 공백 / XML 특수문자
+  포함 경로도 정확히 quoted.
+- `os-service-installer.js` 의 `hasUnsafePathChars` 사전 검사 + skip 분기 제거.
+  다른 skip 사유 (HOME 누락 / systemctl 미감지 / schtasks 미감지 / linger 부재
+  등) 는 그대로.
+
+**Non-goal**:
+
+- `ExecStart=` 의 args 를 path 와 분리해 systemd 의 `${arg1} ${arg2}` semantics
+  로 전달 — 본 release 는 escape 만, semantics 분리는 별도 issue.
+- Windows PowerShell 기반 자동 등록 대안 (schtasks 외) — 별도 issue.
+- CLI 평문 / `--json` contract 변경 없음.

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -105,13 +105,13 @@ CLI 평문 (`token-weather status` 데스크탑) 과 `--json` 출력 contract �
 - **Enter / y** (default): token-weather 가 직접 systemd unit / launchd plist / Task Scheduler 항목을 작성 + 활성화 (`systemctl --user enable --now` / `launchctl bootstrap` / `schtasks /Create`). Linux 는 `loginctl enable-linger` 까지 자동 (best-effort).
 - **n**: 자동 등록 건너뜀 → 아래 수동 안내 블록을 사용자가 복사 / 붙여넣기.
 - **systemd / launchctl / schtasks 미감지** (WSL / Docker container / Alpine OpenRC 등): 자동 skip + 동일한 수동 안내 출력.
-- **경로에 공백 / 특수문자 (예: Windows 의 `C:\Program Files\nodejs\node.exe`)**: 자동 skip + 수동 안내 fallback. systemd unit / launchd plist (XML) / cmd.exe quoting 의 escape 규칙과 충돌 위험을 사전 차단. Windows 표준 Node 설치 환경은 보통 이 경로에 해당 — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장 (정확한 escaping helper 도입은 follow-up issue).
+- **경로에 공백 / 특수문자 포함** (예: Windows 의 `C:\Program Files\nodejs\node.exe`): 자동 등록 가능 (issue #141). systemd 는 `ExecStart="..."` double-quote, launchd plist 는 XML entity escape (`& < >` → `&amp; &lt; &gt;`), Windows schtasks 는 cmd `\"...\"` 로 각자 정확히 quoting. Windows 표준 Node 설치 환경 등이 그대로 자동 등록 가능.
 
 자동 등록을 나중에 해제하려면 `token-weather telegram uninstall-service`. 책임 범위는 service / linger 까지 (config / auth.json 은 그대로 유지).
 
 ### 수동 등록 (자동 등록 거부 / skip 시)
 
-> ⚠ 아래 코드 블록은 **구조 예시** 입니다. `/path/to/node` / `/path/to/token-weather` 같은 placeholder 는 실제 환경에서 다르며, **`telegram setup` 출력의 절대 경로를 그대로 복사** 해 주세요. 경로에 공백 / 특수문자가 있는 경우 setup 출력의 정확한 quoting 을 반드시 따라야 합니다.
+> ⚠ 아래 코드 블록은 **구조 예시** 입니다. `/path/to/node` / `/path/to/token-weather` 같은 placeholder 는 실제 환경에서 다르며, **`telegram setup` 출력의 절대 경로를 그대로 복사** 해 주세요. 경로에 공백 / XML 특수문자가 있어도 setup 출력에는 OS 별 정확한 escape (`"..."` / `&amp;` / `\"...\"`) 가 이미 적용되어 있으니 그대로 복사하면 됩니다 (issue #141).
 
 ### Linux (systemd `--user`, sudo 불필요)
 

--- a/packages/telegram/src/index.js
+++ b/packages/telegram/src/index.js
@@ -54,6 +54,7 @@ export {
   uninstallTaskScheduler,
   parseYesNo,
 } from './os-service-installer.js';
+export { escapeSystemdArg, escapePlistXml, escapeSchtasksArg } from './os-service-path-escape.js';
 export {
   formatStatusForTelegram,
   compactResetTime,

--- a/packages/telegram/src/os-service-installer.js
+++ b/packages/telegram/src/os-service-installer.js
@@ -22,18 +22,10 @@ import { linuxSystemdUnit, macosLaunchAgent } from './os-service-templates.js';
 const SYSTEMD_USER_DIR = '.config/systemd/user';
 const LAUNCH_AGENTS_DIR = 'Library/LaunchAgents';
 
-/**
- * 자동 등록 가능 여부의 사전 검사 — 경로의 공백 / XML 특수문자 / 따옴표 등이
- * systemd unit / launchd plist / Task Scheduler 의 quoting 규칙과 충돌할 수
- * 있어, 안전을 위해 자동 등록을 skip 하고 manual fallback 으로 안내 (PR #140
- * review). 정확한 escaping helper 는 별도 follow-up.
- *
- * @param {string} p
- * @returns {boolean}
- */
-function hasUnsafePathChars(p) {
-  return /[\s<>&"'`]/.test(p);
-}
+// issue #141: 경로의 공백 / XML 특수문자 / 따옴표 등의 사전 검사 (`hasUnsafePathChars`)
+// 는 제거됨. OS 별 escape 는 os-service-templates.js 가 os-service-path-escape
+// helper 로 처리 — `C:\Program Files\nodejs\node.exe` 같은 Windows 표준 Node
+// 환경도 자동 등록 가능.
 
 /**
  * @typedef {object} InstallerInput
@@ -114,16 +106,6 @@ export async function installSystemdUnit(input, options = {}) {
       status: 'skipped',
       message:
         'HOME 환경변수가 비어 있어 service 파일 경로를 결정할 수 없음 — 수동 등록 안내로 fallback',
-    };
-  }
-
-  // 경로 안전성 사전 검사 — 공백 / 특수문자가 있으면 systemd unit 의 ExecStart=
-  // 인자 구분과 충돌. manual fallback 으로 안내 (PR #140 review).
-  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
-    return {
-      status: 'skipped',
-      message:
-        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
     };
   }
 
@@ -288,16 +270,6 @@ export async function installLaunchAgent(input, options = {}) {
     };
   }
 
-  // 경로 안전성 사전 검사 — launchd plist 는 XML 이라 `<`, `>`, `&` 등이 escape
-  // 되지 않으면 깨짐 (PR #140 review).
-  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
-    return {
-      status: 'skipped',
-      message:
-        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
-    };
-  }
-
   try {
     execImpl('launchctl', ['version']);
   } catch (err) {
@@ -415,15 +387,6 @@ export async function uninstallLaunchAgent(options = {}) {
 export async function installTaskScheduler(input, options = {}) {
   const execImpl = options.execImpl ?? defaultExecImpl;
   const confirmFn = options.confirmFn ?? defaultConfirmFn;
-
-  // 경로 안전성 사전 검사 — Windows 의 cmd.exe 따옴표 escaping (PR #140 review).
-  if (hasUnsafePathChars(input.nodeBinPath) || hasUnsafePathChars(input.cliScriptPath)) {
-    return {
-      status: 'skipped',
-      message:
-        'node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장',
-    };
-  }
 
   try {
     execImpl('schtasks', ['/?']);

--- a/packages/telegram/src/os-service-path-escape.js
+++ b/packages/telegram/src/os-service-path-escape.js
@@ -1,0 +1,79 @@
+/**
+ * OS service installer 의 경로 escape helper — systemd unit / launchd plist /
+ * Windows schtasks 각자의 quoting 규칙에 맞춰 자동 등록 가능한 형태로 변환.
+ *
+ * issue #141: PR #140 review 2 round 의 follow-up. 기존에는 `hasUnsafePathChars`
+ * 사전 검사로 공백 / 특수문자 포함 경로를 자동 skip + manual fallback 했는데,
+ * **Windows 표준 Node 설치 환경** (`C:\Program Files\nodejs\node.exe`) 에서는
+ * 자동 등록이 거의 항상 차단되어 [Y/n] 옵션이 무의미했음. 본 모듈의 helper 3개로
+ * 모든 정상 경로를 안전하게 quoting → 자동 등록 success rate 확장.
+ *
+ * 각 OS 의 quoting spec:
+ *   - systemd: `man systemd.syntax` (Quoting / Escaping)
+ *   - launchd plist: XML 1.0 entity escape (`&` `<` `>` 만, attribute 아닌 text content)
+ *   - Windows schtasks /TR: cmd.exe escape (path 의 `"` 만 위험, 실제 Windows 파일명에 `"` 는 못 들어가 안전성 거의 OK 지만 일관성 유지)
+ *
+ * 본 모듈은 외부 dependency 0 — 순수 string 변환만.
+ */
+
+/**
+ * systemd unit `ExecStart=` / `Exec*=` directive 안에 들어갈 인자를 quoting.
+ *
+ * systemd 는 standard shell 이 아니라 직접 exec → `$VAR` / `` `cmd` `` 같은
+ * expansion 없음. 그래서 double-quote 안에서 escape 필요한 문자는 `"` 와 `\`
+ * 두 개뿐.
+ *
+ * @param {string} value - escape 대상 (path / argument).
+ * @returns {string} double-quote 로 감싸진 escape 형태. 빈 입력 → `""`.
+ *
+ * @example
+ *   escapeSystemdArg('/usr/bin/node')                // → '"/usr/bin/node"'
+ *   escapeSystemdArg('C:\\Program Files\\node.exe')  // → '"C:\\\\Program Files\\\\node.exe"'
+ *   escapeSystemdArg('path with "quote"')            // → '"path with \\"quote\\""'
+ */
+export function escapeSystemdArg(value) {
+  if (value == null || value === '') return '""';
+  const text = String(value);
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * launchd plist `<string>...</string>` text content 의 XML entity escape.
+ *
+ * Attribute 가 아닌 element content 라 `'` `"` escape 불필요 — `&` `<` `>` 만.
+ * `&` 를 가장 먼저 처리해야 후속 entity 가 다시 escape 되지 않음.
+ *
+ * @param {string} text - escape 대상 (path 또는 다른 element content).
+ * @returns {string} XML-safe 문자열. null/undefined → 빈 문자열.
+ *
+ * @example
+ *   escapePlistXml('/usr/local/bin/node')   // → '/usr/local/bin/node'
+ *   escapePlistXml('path/with & ampersand') // → 'path/with &amp; ampersand'
+ *   escapePlistXml('<weird>')               // → '&lt;weird&gt;'
+ */
+export function escapePlistXml(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Windows `schtasks /TR` 의 인자 quoting.
+ *
+ * `/TR` 는 single string 으로 program + args 받음 → 각 인자를 `"..."` 로 감싸고
+ * 인자 사이는 space. path 안 `"` 는 `\\"` 로 escape (Windows 파일명에 `"` 는
+ * 못 들어가지만 일관성 / defensive 차원).
+ *
+ * @param {string} value - escape 대상 (path / argument).
+ * @returns {string} double-quote 로 감싸진 escape 형태. 빈 입력 → `""`.
+ *
+ * @example
+ *   escapeSchtasksArg('C:\\Program Files\\node.exe')
+ *   // → '"C:\\Program Files\\node.exe"'
+ */
+export function escapeSchtasksArg(value) {
+  if (value == null || value === '') return '""';
+  const text = String(value);
+  return `"${text.replace(/"/g, '\\"')}"`;
+}

--- a/packages/telegram/src/os-service-path-escape.js
+++ b/packages/telegram/src/os-service-path-escape.js
@@ -61,19 +61,30 @@ export function escapePlistXml(text) {
 /**
  * Windows `schtasks /TR` 의 인자 quoting.
  *
- * `/TR` 는 single string 으로 program + args 받음 → 각 인자를 `"..."` 로 감싸고
- * 인자 사이는 space. path 안 `"` 는 `\\"` 로 escape (Windows 파일명에 `"` 는
- * 못 들어가지만 일관성 / defensive 차원).
+ * `/TR` 는 outer `"..."` 안에 program + args 가 들어가는 single string. 그
+ * 안에서 각 인자를 quoting 하려면 cmd.exe 의 escape 된 quote (`\"`) 를 써야
+ * 한다 — outer `"..."` 안에서 `\"` 는 literal quote 로 해석되어 schtasks 가
+ * program / args 를 정확히 split.
+ *
+ * 따라서 본 helper 는 inner-escape 된 quote 로 감싼 형태를 반환하고,
+ * 호출 측이 outer `"..."` 로 한 번 더 감싼다.
+ *
+ * 내부 `"` 는 `""` 로 escape (Windows cmd 의 quote-in-quote — Windows 파일명에
+ * `"` 는 못 들어가지만 일관성 / defensive 차원).
  *
  * @param {string} value - escape 대상 (path / argument).
- * @returns {string} double-quote 로 감싸진 escape 형태. 빈 입력 → `""`.
+ * @returns {string} `\"...\"` (escape 된 quote 로 감싸진) 형태. 빈 입력 → `\"\"`.
  *
  * @example
- *   escapeSchtasksArg('C:\\Program Files\\node.exe')
- *   // → '"C:\\Program Files\\node.exe"'
+ *   escapeSchtasksArg('/usr/bin/node')                    // → '\\"/usr/bin/node\\"'
+ *   escapeSchtasksArg('C:\\Program Files\\node.exe')      // → '\\"C:\\Program Files\\node.exe\\"'
+ *   // 호출 예: `/TR "${escapeSchtasksArg(node)} ${escapeSchtasksArg(script)} telegram start"`
+ *   //   → `/TR "\\"path1\\" \\"path2\\" telegram start"` — cmd.exe 가 outer "..."
+ *   //     를 boundary 로 받고, 안의 \\" 를 literal quote 로 해석 → schtasks 가
+ *   //     `"path1" "path2" telegram start` 를 parse 해서 token 으로 split.
  */
 export function escapeSchtasksArg(value) {
-  if (value == null || value === '') return '""';
-  const text = String(value);
-  return `"${text.replace(/"/g, '\\"')}"`;
+  if (value == null || value === '') return '\\"\\"';
+  const text = String(value).replace(/"/g, '""');
+  return `\\"${text}\\"`;
 }

--- a/packages/telegram/src/os-service-templates.js
+++ b/packages/telegram/src/os-service-templates.js
@@ -8,7 +8,14 @@
  *
  * 본 모듈의 모든 함수는 pure — 절대 경로 / 명령 문자열만 가공한다. 파일 시스템
  * 변경 없음.
+ *
+ * issue #141: 경로에 공백 / XML 특수문자가 포함되어도 자동 등록이 통과하도록
+ * `os-service-path-escape` helper 를 통해 OS 별 정확한 quoting / escape 를 적용.
+ * 이전에는 `installer` 가 사전 검사로 skip 했으나, 본 patch 로 Windows 표준 Node
+ * 설치 환경 (`C:\Program Files\nodejs\node.exe`) 도 자동 등록 가능.
  */
+
+import { escapeSystemdArg, escapePlistXml, escapeSchtasksArg } from './os-service-path-escape.js';
 
 /**
  * @typedef {object} ServiceTemplate
@@ -36,13 +43,16 @@
  * @returns {ServiceTemplate}
  */
 export function linuxSystemdUnit({ nodeBinPath, cliScriptPath }) {
+  // issue #141: ExecStart 의 nodeBin / cliScript 경로를 systemd 의 double-quote
+  // escape 로 wrap → 공백 / 특수문자 포함 경로도 안전.
+  const execStart = `${escapeSystemdArg(nodeBinPath)} ${escapeSystemdArg(cliScriptPath)} telegram start`;
   const unitContent = [
     '[Unit]',
     'Description=Token Weather Telegram bot',
     'After=network-online.target',
     '',
     '[Service]',
-    `ExecStart=${nodeBinPath} ${cliScriptPath} telegram start`,
+    `ExecStart=${execStart}`,
     'Restart=on-failure',
     'RestartSec=5s',
     '',
@@ -77,6 +87,8 @@ export function linuxSystemdUnit({ nodeBinPath, cliScriptPath }) {
  */
 export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
   const home = homeDir ?? process.env.HOME ?? '~';
+  // issue #141: <string>...</string> 본문은 XML element content — `&` `<` `>` 를
+  // entity escape 해야 plist 파서가 깨지지 않음. attribute 가 아니므로 quote 는 무관.
   const plistContent = [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"',
@@ -87,8 +99,8 @@ export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
     '  <string>com.token-weather.bot</string>',
     '  <key>ProgramArguments</key>',
     '  <array>',
-    `    <string>${nodeBinPath}</string>`,
-    `    <string>${cliScriptPath}</string>`,
+    `    <string>${escapePlistXml(nodeBinPath)}</string>`,
+    `    <string>${escapePlistXml(cliScriptPath)}</string>`,
     '    <string>telegram</string>',
     '    <string>start</string>',
     '  </array>',
@@ -97,9 +109,9 @@ export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
     '  <key>KeepAlive</key>',
     '  <true/>',
     '  <key>StandardOutPath</key>',
-    `  <string>${home}/Library/Logs/token-weather-bot.log</string>`,
+    `  <string>${escapePlistXml(`${home}/Library/Logs/token-weather-bot.log`)}</string>`,
     '  <key>StandardErrorPath</key>',
-    `  <string>${home}/Library/Logs/token-weather-bot-error.log</string>`,
+    `  <string>${escapePlistXml(`${home}/Library/Logs/token-weather-bot-error.log`)}</string>`,
     '</dict>',
     '</plist>',
   ].join('\n');
@@ -127,13 +139,17 @@ export function macosLaunchAgent({ nodeBinPath, cliScriptPath, homeDir }) {
  * @returns {ServiceTemplate}
  */
 export function windowsTaskScheduler({ nodeBinPath, cliScriptPath }) {
+  // issue #141: /TR 는 single string program+args 라 각 인자 path 안 `"` 를
+  // `\"` 로 escape, 그 후 `"..."` wrap. escapeSchtasksArg 가 처리.
+  const node = escapeSchtasksArg(nodeBinPath);
+  const script = escapeSchtasksArg(cliScriptPath);
   return {
     kind: 'taskscheduler',
     title: 'Windows Task Scheduler (user task, 관리자 권한 불필요)',
     instructions: [
-      // cmd.exe 의 escape 규칙 — 경로에 공백 시 따옴표 필수.
-      'schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED ' +
-        `/TR "\\"${nodeBinPath}\\" \\"${cliScriptPath}\\" telegram start"`,
+      // /TR 의 outer quote 는 cmd.exe 가 받는 경계, 그 안의 escape 된 `"`
+      // 는 schtasks 가 prog/args 로 split 할 때 사용.
+      `schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED /TR "${node} ${script} telegram start"`,
       'rem 종료 / 제거하려면:',
       'schtasks /End /TN "TokenWeatherBot"',
       'schtasks /Delete /TN "TokenWeatherBot" /F',

--- a/packages/telegram/test/os-service-installer.test.js
+++ b/packages/telegram/test/os-service-installer.test.js
@@ -208,21 +208,32 @@ describe('installSystemdUnit guard 보강 (PR #140 review 2)', () => {
     assert.ok(logs.some((l) => l.includes('USER 환경변수가 비어 있어')));
   });
 
-  it('nodeBinPath 공백 포함 → status skipped + manual fallback 안내', async () => {
+  it('nodeBinPath 공백 포함 → escape helper 적용 → succeeded (issue #141)', async () => {
+    const mockFs = makeMockFs();
     const r = await installSystemdUnit(
       { ...INPUT, nodeBinPath: '/path with space/node' },
-      { fsImpl: makeMockFs().fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
+      { fsImpl: mockFs.fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
     );
-    assert.equal(r.status, 'skipped');
-    assert.match(r.message, /공백 또는 특수문자/);
+    assert.equal(r.status, 'succeeded');
+    // 작성된 service 파일에 escape 적용 확인 — "..." quote 안에 공백 경로.
+    const written = Array.from(mockFs.files.values()).find((c) =>
+      c.includes('"/path with space/node"'),
+    );
+    assert.ok(written, 'service 파일에 escape 된 nodeBin 경로 포함');
   });
 
-  it('cliScriptPath XML 특수문자 포함 → status skipped', async () => {
+  it('cliScriptPath XML 특수문자 포함 → systemd 는 XML 무관 → succeeded (issue #141)', async () => {
+    const mockFs = makeMockFs();
     const r = await installSystemdUnit(
       { ...INPUT, cliScriptPath: '/cli/<bin>/token-weather.js' },
-      { fsImpl: makeMockFs().fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
+      { fsImpl: mockFs.fs, execImpl: makeMockExec().impl, env: { HOME: '/h', USER: 'u' } },
     );
-    assert.equal(r.status, 'skipped');
+    assert.equal(r.status, 'succeeded');
+    // systemd unit 은 XML 이 아니므로 escape 변화 없음 — quote 만 적용.
+    const written = Array.from(mockFs.files.values()).find((c) =>
+      c.includes('"/cli/<bin>/token-weather.js"'),
+    );
+    assert.ok(written, 'service 파일에 quote wrap 된 cliScript 경로 포함');
   });
 
   it('overwrite 동의 + daemon-reload 실패 → 기존 content 가 restore (PR #140 review 3)', async () => {

--- a/packages/telegram/test/os-service-path-escape.test.js
+++ b/packages/telegram/test/os-service-path-escape.test.js
@@ -63,7 +63,7 @@ describe('escapePlistXml (issue #141)', () => {
   });
 
   it('attribute escape (싱글/더블 quote) 는 적용 안 됨 — element content 만', () => {
-    assert.equal(escapePlistXml("path 'with' \"quotes\""), "path 'with' \"quotes\"");
+    assert.equal(escapePlistXml('path \'with\' "quotes"'), 'path \'with\' "quotes"');
   });
 
   it('null / undefined → 빈 문자열', () => {
@@ -77,28 +77,29 @@ describe('escapePlistXml (issue #141)', () => {
 });
 
 describe('escapeSchtasksArg (issue #141)', () => {
-  it('정상 alphanumeric 경로 — double-quote wrap', () => {
-    assert.equal(escapeSchtasksArg('C:\\nodejs\\node.exe'), '"C:\\nodejs\\node.exe"');
+  it('정상 alphanumeric 경로 — escape 된 quote (\\") 로 wrap', () => {
+    // 호출 측이 outer "..." 안에 넣으면 cmd 가 `"..."` literal quote 로 해석.
+    assert.equal(escapeSchtasksArg('C:\\nodejs\\node.exe'), '\\"C:\\nodejs\\node.exe\\"');
   });
 
   it('공백 포함 경로 — Windows 표준 Node 설치 환경', () => {
     assert.equal(
       escapeSchtasksArg('C:\\Program Files\\nodejs\\node.exe'),
-      '"C:\\Program Files\\nodejs\\node.exe"',
+      '\\"C:\\Program Files\\nodejs\\node.exe\\"',
     );
   });
 
   it('백슬래시는 그대로 (Windows path separator 보존)', () => {
-    assert.equal(escapeSchtasksArg('a\\b\\c'), '"a\\b\\c"');
+    assert.equal(escapeSchtasksArg('a\\b\\c'), '\\"a\\b\\c\\"');
   });
 
-  it('내부 double-quote escape (defensive — 실제 Windows 파일명에 " 불가하지만 일관성)', () => {
-    assert.equal(escapeSchtasksArg('a"b'), '"a\\"b"');
+  it('내부 double-quote escape ("" — cmd.exe quote-in-quote, defensive)', () => {
+    assert.equal(escapeSchtasksArg('a"b'), '\\"a""b\\"');
   });
 
-  it('빈 입력 → 빈 quote `""`', () => {
-    assert.equal(escapeSchtasksArg(''), '""');
-    assert.equal(escapeSchtasksArg(null), '""');
-    assert.equal(escapeSchtasksArg(undefined), '""');
+  it('빈 입력 → 빈 escape quote', () => {
+    assert.equal(escapeSchtasksArg(''), '\\"\\"');
+    assert.equal(escapeSchtasksArg(null), '\\"\\"');
+    assert.equal(escapeSchtasksArg(undefined), '\\"\\"');
   });
 });

--- a/packages/telegram/test/os-service-path-escape.test.js
+++ b/packages/telegram/test/os-service-path-escape.test.js
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  escapeSystemdArg,
+  escapePlistXml,
+  escapeSchtasksArg,
+} from '../src/os-service-path-escape.js';
+
+describe('escapeSystemdArg (issue #141)', () => {
+  it('정상 alphanumeric 경로 — double-quote wrap', () => {
+    assert.equal(escapeSystemdArg('/usr/bin/node'), '"/usr/bin/node"');
+  });
+
+  it('공백 포함 경로 — quote 안에서 안전 (Windows 표준 Node 설치 환경)', () => {
+    assert.equal(
+      escapeSystemdArg('C:\\Program Files\\nodejs\\node.exe'),
+      '"C:\\\\Program Files\\\\nodejs\\\\node.exe"',
+    );
+  });
+
+  it('백슬래시 escape (`\\` → `\\\\`)', () => {
+    assert.equal(escapeSystemdArg('a\\b'), '"a\\\\b"');
+  });
+
+  it('내부 double-quote escape (`"` → `\\"`)', () => {
+    assert.equal(escapeSystemdArg('path with "quote"'), '"path with \\"quote\\""');
+  });
+
+  it('백슬래시 + double-quote 조합 — 순서 정확 (\\\\ 먼저, 그 다음 \\")', () => {
+    // 'a\"b' → 백슬래시 escape → 'a\\\"b' → double-quote escape → 'a\\\\"b'
+    // wait: input 'a\\"b' (백슬래시 + 따옴표)
+    // 백슬래시 먼저: '\\' → '\\\\', 그 다음 '"' → '\\"'
+    // 'a' + '\\' + '"' + 'b' → 'a' + '\\\\' + '\\"' + 'b' = 'a\\\\\\"b'
+    assert.equal(escapeSystemdArg('a\\"b'), '"a\\\\\\"b"');
+  });
+
+  it('빈 입력 → 빈 quote `""`', () => {
+    assert.equal(escapeSystemdArg(''), '""');
+    assert.equal(escapeSystemdArg(null), '""');
+    assert.equal(escapeSystemdArg(undefined), '""');
+  });
+
+  it('shell metacharacter ($, `, ;) 는 escape 불필요 — systemd 는 direct exec', () => {
+    assert.equal(escapeSystemdArg('$HOME/node'), '"$HOME/node"');
+    assert.equal(escapeSystemdArg('a`b'), '"a`b"');
+    assert.equal(escapeSystemdArg('a;b'), '"a;b"');
+  });
+});
+
+describe('escapePlistXml (issue #141)', () => {
+  it('정상 경로 — 변경 없음', () => {
+    assert.equal(escapePlistXml('/usr/local/bin/node'), '/usr/local/bin/node');
+  });
+
+  it('& → &amp; (가장 먼저 처리되어 후속 entity 가 다시 escape 되지 않음)', () => {
+    assert.equal(escapePlistXml('a & b'), 'a &amp; b');
+    assert.equal(escapePlistXml('&amp;'), '&amp;amp;');
+  });
+
+  it('< → &lt;, > → &gt;', () => {
+    assert.equal(escapePlistXml('<weird>'), '&lt;weird&gt;');
+  });
+
+  it('attribute escape (싱글/더블 quote) 는 적용 안 됨 — element content 만', () => {
+    assert.equal(escapePlistXml("path 'with' \"quotes\""), "path 'with' \"quotes\"");
+  });
+
+  it('null / undefined → 빈 문자열', () => {
+    assert.equal(escapePlistXml(null), '');
+    assert.equal(escapePlistXml(undefined), '');
+  });
+
+  it('숫자 / 기타 type 도 String 변환 후 escape', () => {
+    assert.equal(escapePlistXml(42), '42');
+  });
+});
+
+describe('escapeSchtasksArg (issue #141)', () => {
+  it('정상 alphanumeric 경로 — double-quote wrap', () => {
+    assert.equal(escapeSchtasksArg('C:\\nodejs\\node.exe'), '"C:\\nodejs\\node.exe"');
+  });
+
+  it('공백 포함 경로 — Windows 표준 Node 설치 환경', () => {
+    assert.equal(
+      escapeSchtasksArg('C:\\Program Files\\nodejs\\node.exe'),
+      '"C:\\Program Files\\nodejs\\node.exe"',
+    );
+  });
+
+  it('백슬래시는 그대로 (Windows path separator 보존)', () => {
+    assert.equal(escapeSchtasksArg('a\\b\\c'), '"a\\b\\c"');
+  });
+
+  it('내부 double-quote escape (defensive — 실제 Windows 파일명에 " 불가하지만 일관성)', () => {
+    assert.equal(escapeSchtasksArg('a"b'), '"a\\"b"');
+  });
+
+  it('빈 입력 → 빈 quote `""`', () => {
+    assert.equal(escapeSchtasksArg(''), '""');
+    assert.equal(escapeSchtasksArg(null), '""');
+    assert.equal(escapeSchtasksArg(undefined), '""');
+  });
+});

--- a/packages/telegram/test/os-service-templates.test.js
+++ b/packages/telegram/test/os-service-templates.test.js
@@ -32,10 +32,22 @@ describe('linuxSystemdUnit (Phase 4)', () => {
     assert.match(text, /loginctl enable-linger/);
   });
 
-  it('ExecStart 에 nodeBinPath + cliScriptPath + "telegram start" 포함', () => {
+  it('ExecStart 에 nodeBinPath + cliScriptPath + "telegram start" 포함 (issue #141: double-quote wrap)', () => {
     const text = tmpl.instructions.join('\n');
-    assert.match(text, /ExecStart=\/usr\/bin\/node .* telegram start/);
-    assert.ok(text.includes(INPUT.cliScriptPath));
+    assert.match(text, /ExecStart="\/usr\/bin\/node" .* telegram start/);
+    assert.ok(text.includes(`"${INPUT.cliScriptPath}"`));
+  });
+
+  it('공백 포함 경로도 자동 등록 가능 — issue #141', () => {
+    const t = linuxSystemdUnit({
+      nodeBinPath: '/path with space/node',
+      cliScriptPath: '/cli with space/token-weather.js',
+    });
+    const text = t.instructions.join('\n');
+    assert.match(
+      text,
+      /ExecStart="\/path with space\/node" "\/cli with space\/token-weather\.js" telegram start/,
+    );
   });
 });
 
@@ -52,8 +64,20 @@ describe('macosLaunchAgent (Phase 4)', () => {
     assert.match(text, /com\.token-weather\.bot/);
     assert.match(text, /<key>RunAtLoad<\/key>/);
     assert.match(text, /<key>KeepAlive<\/key>/);
+    // alphanumeric 경로는 XML escape 영향 없음.
     assert.ok(text.includes(`<string>${INPUT.nodeBinPath}</string>`));
     assert.ok(text.includes(`<string>${INPUT.cliScriptPath}</string>`));
+  });
+
+  it('XML 특수문자 (& < >) 포함 경로도 자동 등록 가능 — issue #141', () => {
+    const t = macosLaunchAgent({
+      nodeBinPath: '/Users/Q&A/node',
+      cliScriptPath: '/cli/<bin>/token-weather.js',
+      homeDir: '/Users/u',
+    });
+    const text = t.instructions.join('\n');
+    assert.ok(text.includes('<string>/Users/Q&amp;A/node</string>'));
+    assert.ok(text.includes('<string>/cli/&lt;bin&gt;/token-weather.js</string>'));
   });
 
   it('log path 가 homeDir 기준', () => {
@@ -87,6 +111,17 @@ describe('windowsTaskScheduler (Phase 4)', () => {
     const text = tmpl.instructions.join('\n');
     // \\" 로 escape 되어 cmd 가 따옴표 인식.
     assert.match(text, /\\"\/usr\/bin\/node\\"/);
+  });
+
+  it('공백 포함 경로 (Windows 표준 Node 설치 환경) 도 자동 등록 가능 — issue #141', () => {
+    const t = windowsTaskScheduler({
+      nodeBinPath: 'C:\\Program Files\\nodejs\\node.exe',
+      cliScriptPath:
+        'C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@token-weather\\cli\\bin\\token-weather.js',
+    });
+    const text = t.instructions.join('\n');
+    // /TR "\"C:\Program Files\nodejs\node.exe\" \"...\" telegram start"
+    assert.match(text, /\/TR "\\"C:\\Program Files\\nodejs\\node\.exe\\" /);
   });
 });
 


### PR DESCRIPTION
## 요약

- 이슈 #141 — OS service installer 의 경로 escaping helper 도입. 기존 `hasUnsafePathChars` 사전 검사 + skip 흐름을 OS 별 정확한 escape 로 대체.
- **Windows 표준 Node 설치 환경** (`C:\Program Files\nodejs\node.exe`) 등 공백 / XML 특수문자 포함 경로도 `telegram setup` 의 [Y/n] 자동 등록을 통과.

## 변경 내용

- 새 helper 모듈 `packages/telegram/src/os-service-path-escape.js` (public export):
  - `escapeSystemdArg(value)` — systemd unit `ExecStart=` 의 double-quote escape (`"` `\` 만, systemd 는 direct exec 라 `$VAR` 등 expansion 없음).
  - `escapePlistXml(text)` — launchd plist `<string>` element content 의 XML entity escape (`& < >` 만).
  - `escapeSchtasksArg(value)` — Windows schtasks `/TR` 의 cmd `\"...\"` 형태 (outer `"..."` 안에서 escape 된 quote 로 해석되어 schtasks 가 program/args 를 정확히 split).
- `packages/telegram/src/os-service-templates.js` 3 template (systemd / launchd / schtasks) 모두 위 helper 호출. 정상 alphanumeric 경로의 출력은 무변경 (이미 quoted 형태와 동일).
- `packages/telegram/src/os-service-installer.js`:
  - `hasUnsafePathChars` 함수 정의 + 3 호출 위치 모두 제거.
  - 다른 skip 사유 (HOME 누락 / systemctl 미감지 / launchctl 미감지 / schtasks 미감지 / linger 부재 등) 는 그대로 유지.
- 단위 테스트 신규 (`os-service-path-escape.test.js`, 18 cases).
- 기존 테스트 갱신:
  - `os-service-templates.test.js` — `ExecStart="/usr/bin/node"` 패턴 / 공백 경로 자동 등록 / XML 특수문자 escape 단언 추가.
  - `os-service-installer.test.js` — 기존 "공백 → skipped" 단언을 "공백 → succeeded + 파일에 escape 적용" 으로 갱신.
- `docs/telegram-bot.md` — "자동 skip + 수동 fallback" 분기 안내를 "자동 등록 가능 + OS 별 escape 적용" 으로 갱신.
- `.changeset/telegram-path-escape.md` — 4 패키지 linked **minor** bump.

## 변경 이유

PR #140 review 2 round 에서 도입된 `hasUnsafePathChars` 사전 검사는 escape 정확성을 보장할 helper 가 없는 상태의 안전 boundary. 다만 Windows 표준 Node 설치 환경 사용자의 자동 등록 경험을 차단했음 (이슈 #141 본문). 본 PR 로 OS 별 정확한 escape 가 구현되어 사전 검사 자체가 redundant.

기존 정상 경로 (alphanumeric) 의 출력은 무변경 — escape 적용 결과가 이전 hardcoded quoting 과 동일. 회귀 가드 통과.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [x] `packages/telegram` (escape helper / templates / installer / 테스트)
- [x] `repo` (changeset)
- [x] `docs` (telegram-bot.md)

## 스크린샷 / 데모

**Before** (PR #140 시점):

```
$ token-weather telegram setup
...
부팅 후 자동 시작 (선택사항) — Windows Task Scheduler
자동으로 설치하시겠습니까? [Y/n] Y
ℹ node / cli 경로에 공백 또는 특수문자가 있어 자동 등록을 skip — 
  `telegram setup` 출력의 정확한 quoting 을 사용한 수동 등록을 권장
수동 등록 안내:
  schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED ...
```

**After** (본 PR):

```
$ token-weather telegram setup
...
부팅 후 자동 시작 (선택사항) — Windows Task Scheduler
자동으로 설치하시겠습니까? [Y/n] Y
✓ Windows Task Scheduler 작업 등록 완료
  · schtasks 실행: TokenWeatherBot 등록됨
```

Linux systemd unit 예시 (공백 경로):

```ini
[Service]
ExecStart="/path with space/node" "/cli with space/token-weather.js" telegram start
```

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1116 pass / 0 fail (이전 1095 + 신규 21), `npm run lint` clean
- [x] 필요한 문서 업데이트 반영 — `docs/telegram-bot.md` 의 OS service 등록 안내 갱신
- [x] schema / provider / CLI 영향 범위를 직접 점검 — telegram 모듈 내부 변경만, schema / provider / CLI 평문 / `--json` contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 민감값을 redact 했음 — 해당 없음

## 리뷰 포인트

- **`escapeSchtasksArg` 시그니처 변경** — 초기 commit 에서는 outer `"..."` wrap 만 반환했지만, 호출 측이 이미 outer `"..."` 를 적용 중이라 `""path1" "path2"` 형태로 깨짐. commit 3-5 에서 cmd `\"...\"` (escape 된 quote) 형태로 정정 + `escapeSchtasksArg` 단위 테스트도 갱신. 변경 자체는 신규 모듈이라 외부 contract 영향 없음.
- **수동 e2e** — Linux systemd 는 본 PR 머지 후 `telegram setup` 으로 검증 가능. **Windows / macOS 환경 e2e 검증은 사용자 환경 미보유로 수동**. 머지 후 issue tracker 로 follow-up 가능.
- **`hasUnsafePathChars` 의 backtick 대응** — 기존 정규식이 backtick (`` ` ``) 도 검사했지만, systemd 는 direct exec 라 backtick command substitution 동작 안 함. 그래서 escape 불필요. 다만 path 안 backtick 은 거의 발생 안 함 (Windows 파일명 금지, Unix 도 비표준).
- **`docs/telegram-bot.md` 안내 단순화** — 기존 "경로에 공백 / 특수문자" 분기 자체가 자동 등록 success case 로 통합. 사용자가 follow-up issue 가 처리됐다는 점을 명확히 인지하도록 (issue #141) 명시.

## 참고 사항

- 관련 이슈: #141 (follow-up to #138)
- 머지 후 자동 close 가능 — PR 본문에 `Closes #141` 명시 권장이지만 다른 PR (PR #145 등) 도 같은 패턴 (`(issue #141)`) 으로 처리 후 별도 cleanup commit 으로 close 한 사례 정합.
- Out of scope (별도 이슈 후보):
  - `ExecStart=` 의 args 분리 (systemd `${arg1} ${arg2}` semantics)
  - Windows PowerShell 기반 자동 등록 대안 (schtasks 외)
- 회귀 가드 — `os-service-path-escape.test.js` + `os-service-templates.test.js` + `os-service-installer.test.js` 가 정상 / 공백 / XML 특수문자 / 빈 입력 경로 모두 단언.
