### PR TITLE
[docs] root CHANGELOG.md v0.6.0 entry 큐레이트

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@
 
 이 섹션은 publish 시점에 root에서 **수동으로 큐레이트**합니다 — 4 패키지를 가로지르는 사용자-가시 변경의 high-level 요약. 패키지별 상세 release note는 [Changesets](https://github.com/changesets/changesets)가 `packages/*/CHANGELOG.md`를 자동 생성하고, 본 문서는 publish PR에서 그 내용을 참고해 채웁니다. 사용자-가시 변경이 있는 PR은 `npx changeset` 으로 changeset을 함께 commit 해주세요.
 
+## [0.6.0] - 2026-05-20
+
+v0.5.0 의 OS service installer (PR #140 / issue #138) follow-up. 기존 `hasUnsafePathChars` 사전 검사로 공백 / XML 특수문자 포함 경로를 자동 등록 skip + manual fallback 하던 흐름을 **OS 별 정확한 escaping helper** 로 대체. Windows 표준 Node 설치 환경 (`C:\Program Files\nodejs\node.exe`) 사용자가 `telegram setup` 의 [Y/n] 자동 등록 옵션을 비로소 활용 가능 ([#141]).
+
+### Changed — OS service installer
+
+- **경로 escaping 자동 처리** ([#141]) — systemd unit / launchd plist / Windows schtasks 각자의 quoting 규칙에 맞춰 helper 적용. `os-service-path-escape.js` 신규 모듈 (public export):
+  - `escapeSystemdArg(value)` — `ExecStart=` 의 double-quote escape (`"` `\` 만, systemd 는 direct exec 라 `$VAR` 등 expansion 없음)
+  - `escapePlistXml(text)` — launchd plist `<string>` element content 의 XML entity escape (`& < >` 만)
+  - `escapeSchtasksArg(value)` — Windows schtasks `/TR` 의 cmd `\"...\"` 형태 (outer `"..."` 안에서 escape 된 quote)
+- **`hasUnsafePathChars` 사전 검사 제거** — installer 가 모든 정상 경로를 escape 후 자동 등록 진행. 다른 skip 사유 (HOME 누락 / systemctl·launchctl·schtasks 미감지 / linger 부재 등) 는 그대로.
+
+CLI 평문 / `--json` contract 변경 없음. 기존 정상 경로 (alphanumeric) 의 자동 등록 출력 무변경 — escape 결과가 이전 hardcoded quoting 과 동일.
+
+### Documentation
+
+- `docs/telegram-bot.md` — "경로에 공백 / 특수문자" 분기를 "자동 등록 가능" 으로 갱신. OS 별 escape 방식 한 줄씩 명시.
+
 ## [0.5.0] - 2026-05-18
 
 `@token-weather/telegram` 의 본격 등장 release. 5-phase 텔레그램 봇 통합 ([#127]–[#142]) 으로 핸드폰 / 다른 데스크탑에서 `/status` / `/usage` / `/doctor` / `/auth_list` 를 원격 호출할 수 있고, 후속 모바일 UX 시리즈 ([#144], [#146], [#148]) 로 출력이 모바일 폭 친화 compact + progress bar + 자동완성 메뉴까지 갖춰짐. CLI 평문 / `status --json` contract 변경 없음, OAuth 토큰은 여전히 로컬만 (Telegram 활성 시 사용량 메타데이터만 Telegram 서버 경유 — [docs/telegram-bot.md §보안 모델](./docs/telegram-bot.md)).
@@ -81,7 +99,8 @@
 - `packages/agent/test/cli/status-json.test.js` — top-level `schemaVersion` lock 회귀 가드 3 케이스 (값 일치 / 키 항상 present / 모든 출력 경로 통과). `packages/schemas/test/schema-version.test.js` (값 lock) 와 함께 SCHEMA_VERSION 한쪽만 bump 회귀 차단.
 - `packages/agent/src/cli/status-bar-helper.js` 신설 (UI) — `shouldUseColor` / `levelForPercent` / `colorize` / `formatProgressBar` / `formatResetTime` / `formatWindowLabel` pure helper.
 
-[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/LLagoon3/token-weather/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.6.0
 [0.5.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.5.0
 [0.4.0]: https://github.com/LLagoon3/token-weather/releases/tag/v0.4.0
 
@@ -103,6 +122,7 @@
 [#142]: https://github.com/LLagoon3/token-weather/issues/142
 [#144]: https://github.com/LLagoon3/token-weather/issues/144
 [#146]: https://github.com/LLagoon3/token-weather/issues/146
+[#141]: https://github.com/LLagoon3/token-weather/issues/141
 [#148]: https://github.com/LLagoon3/token-weather/issues/148
 
 ## [0.3.0] - 2026-05-11


### PR DESCRIPTION
## 요약

- v0.6.0 publish 시점의 root `CHANGELOG.md` 수동 큐레이트 (release-policy §4). 이전 v0.4.0 PR #125 / v0.5.0 PR #150 패턴 정합.
- 4 패키지 (`@token-weather/cli` / `@token-weather/provider-adapters` / `@token-weather/schemas` / `@token-weather/telegram`) 모두 v0.6.0 publish 완료된 상태 (release.yml 자동, 06:18Z, trusted publisher 4개 모두 등록되어 부분 publish 사고 재발 X).

## 변경 내용

- `[Unreleased]` 정리 + `[0.6.0] - 2026-05-20` entry 신설:
  - **Changed — OS service installer**: 경로 escaping 자동 처리 (#141). `os-service-path-escape.js` 신규 모듈의 helper 3종 (`escapeSystemdArg` / `escapePlistXml` / `escapeSchtasksArg`) + `hasUnsafePathChars` 사전 검사 제거.
  - **Documentation**: `docs/telegram-bot.md` 안내 갱신.
- Link refs: `[#141]` 신규 추가, `[Unreleased]` compare 끝점 `v0.5.0` → `v0.6.0`, `[0.6.0]` entry 추가.

## 변경 이유

per-package `CHANGELOG.md` 4개는 changesets/action 이 자동 생성 (각 v0.6.0 entry ~40 줄, telegram-path-escape changeset 본문 그대로) — 그러나 root `CHANGELOG.md` 는 release-policy §4 정합으로 **publish 시점에 작성자가 수동 큐레이트**. 본 PR 이 그 작업.

v0.6.0 사이클이 단일 changeset (#141) 이지만 Windows 자동 등록 회귀 fix 라 release worthy. 사용자 관점 — 본 entry 만 보고 npm install 후 무엇이 새로 가능한지 (Windows 표준 Node 환경 자동 등록) 즉시 파악 가능한 수준으로 작성.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (root CHANGELOG.md)
- [ ] `docs`

## 스크린샷 / 데모

없음 — docs only PR.

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npx prettier --check CHANGELOG.md` 통과
- [x] 필요한 문서 업데이트 반영 — root CHANGELOG.md (본 PR 의 유일한 변경)
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only, 코드 / contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 민감값을 redact 했음 — 해당 없음

## 리뷰 포인트

- **본문 길이** — v0.5.0 entry 가 자세했던 이유는 telegram 신규 패키지 등장 + 11 changeset 누적. v0.6.0 은 단일 changeset (회귀 fix) 이라 상대적으로 간결. 한 entry 만으로 "Windows 자동 등록 회귀 해소" 가 명확히 전달되는지.
- **카테고리 분류** — Changed (회귀 fix + helper 도입) + Documentation. Added / Removed 카테고리 없음 — helper 모듈이 `@token-weather/telegram` 의 public export 에 추가됐지만 사용자 영향 측면에서는 "기존 자동 등록 시도가 성공" 이 핵심이라 Changed 로 정리.
- **링크 정합** — `v0.6.0` 통합 tag (`v0.x.y` 형식) 부재. 이전 v0.4.0 / v0.5.0 entry 와 동일 컨벤션 유지.

## 참고 사항

- 관련 release PR: #152 (Version Packages, v0.6.0 publish — 2026-05-20 06:18Z 머지)
- per-package CHANGELOG.md 자동 생성: changesets/action 이 머지 시점에 telegram-path-escape changeset 본문을 4 패키지로 옮김. 본 root CHANGELOG 는 그 내용 high-level 요약.
- 후속 cleanup: 본 PR 머지 후 main 자동 FF (release.yml 의 FF sync step). docs only PR 이라 changesets/action 의 publish 는 noop.
