### PR TITLE
[docs] README ToC + docs/INDEX.md — 11 docs entry point 정비 (issue #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,21 @@ npm run test:schemas  # schemas 패키지만
 
 ### 추가 문서
 
+빠른 entry point — [docs/INDEX.md](./docs/INDEX.md) (카테고리별).
+
+**외부 사용자용** (npm install 후 직접 참고):
+
 - [docs/architecture.md](./docs/architecture.md) — 고수준 구조 요약
 - [docs/auth-architecture.md](./docs/auth-architecture.md) — 인증 / token / source 우선순위 상세
 - [docs/auth-cli.md](./docs/auth-cli.md) — auth CLI 명령 / 정책
 - [docs/cli-json-output.md](./docs/cli-json-output.md) — `--json` stable contract + redaction 규약
 - [docs/provider-notes.md](./docs/provider-notes.md) — provider별 observed endpoint / client_id
-- [docs/codebase-guide.md](./docs/codebase-guide.md) — 기여자용 상세 가이드 (패키지 레이아웃, shared 헬퍼, 새 기능 체크리스트)
+- [docs/telegram-bot.md](./docs/telegram-bot.md) — Telegram 봇 옵션 패키지 (`@token-weather/telegram`) 가이드
+- [docs/typescript-consumers.md](./docs/typescript-consumers.md) — TypeScript 사용자용 d.ts / import 패턴
+
+**기여자 / 운영자용** (contributor 한국 기반, 한글 only 유지):
+
+- [docs/codebase-guide.md](./docs/codebase-guide.md) — 패키지 레이아웃 / shared 헬퍼 / 새 기능 체크리스트
+- [docs/release-policy.md](./docs/release-policy.md) — semver / changeset / bump 기준
+- [docs/auth-store-schema.md](./docs/auth-store-schema.md) — auth.json 저장 schema (기술 설계)
+- [docs/claude-oauth-plan.md](./docs/claude-oauth-plan.md) — Claude OAuth 구현 과거 계획 (보관용)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,37 +14,37 @@ token-weather 의 모든 문서 entry point. 카테고리 / 사용자 타입 별
 
 운영 / 자동화 / 통합 시 사용자가 직접 보는 문서.
 
-| 문서 | 한 줄 요약 |
-| --- | --- |
-| [architecture.md](./architecture.md) | 패키지 / 모듈 구조의 고수준 요약 |
-| [auth-architecture.md](./auth-architecture.md) | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback) |
-| [auth-cli.md](./auth-cli.md) | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책 |
-| [cli-json-output.md](./cli-json-output.md) | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION |
-| [provider-notes.md](./provider-notes.md) | provider 별 observed endpoint / client_id / refresh 동작 |
-| [telegram-bot.md](./telegram-bot.md) | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 |
-| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성 |
+| 문서                                                 | 한 줄 요약                                                                    |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [architecture.md](./architecture.md)                 | 패키지 / 모듈 구조의 고수준 요약                                              |
+| [auth-architecture.md](./auth-architecture.md)       | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback)      |
+| [auth-cli.md](./auth-cli.md)                         | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책        |
+| [cli-json-output.md](./cli-json-output.md)           | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION             |
+| [provider-notes.md](./provider-notes.md)             | provider 별 observed endpoint / client_id / refresh 동작                      |
+| [telegram-bot.md](./telegram-bot.md)                 | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 |
+| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성                          |
 
 ## 기여자 / 운영자용 — contributor 한국 기반, 한글 only 유지
 
 코드 패턴 / release 운영 / 내부 schema. 외부 사용자에게 가시도 낮은 문서.
 
-| 문서 | 한 줄 요약 |
-| --- | --- |
-| [codebase-guide.md](./codebase-guide.md) | 패키지 레이아웃 / shared 헬퍼 / 새 기능 체크리스트 / anti-patterns |
-| [release-policy.md](./release-policy.md) | semver / changeset / bump 기준 / publish 흐름 |
-| [auth-store-schema.md](./auth-store-schema.md) | auth.json 저장 schema (기술 설계 — 구조 정의) |
-| [claude-oauth-plan.md](./claude-oauth-plan.md) | Claude OAuth 구현 과거 계획 (보관용 — v0.5.0 이후 이력화) |
+| 문서                                           | 한 줄 요약                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------ |
+| [codebase-guide.md](./codebase-guide.md)       | 패키지 레이아웃 / shared 헬퍼 / 새 기능 체크리스트 / anti-patterns |
+| [release-policy.md](./release-policy.md)       | semver / changeset / bump 기준 / publish 흐름                      |
+| [auth-store-schema.md](./auth-store-schema.md) | auth.json 저장 schema (기술 설계 — 구조 정의)                      |
+| [claude-oauth-plan.md](./claude-oauth-plan.md) | Claude OAuth 구현 과거 계획 (보관용 — v0.5.0 이후 이력화)          |
 
 ## 메타 파일
 
-| 파일 | 설명 |
-| --- | --- |
-| [../README.md](../README.md) | 프로젝트 개요 |
-| [../CONTRIBUTING.md](../CONTRIBUTING.md) | 브랜치 / commit / PR / 작업 단위 / 라이선스 |
-| [../SECURITY.md](../SECURITY.md) | 보안 신고 채널 + Telegram 채널 위협 모델 + 토큰 revoke 절차 |
-| [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) | Contributor Covenant 표준 |
-| [../CHANGELOG.md](../CHANGELOG.md) | 사용자-가시 변경 history (Keep a Changelog) |
-| [../.changeset/README.md](../.changeset/README.md) | changesets 도구 사용법 |
+| 파일                                               | 설명                                                        |
+| -------------------------------------------------- | ----------------------------------------------------------- |
+| [../README.md](../README.md)                       | 프로젝트 개요                                               |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md)           | 브랜치 / commit / PR / 작업 단위 / 라이선스                 |
+| [../SECURITY.md](../SECURITY.md)                   | 보안 신고 채널 + Telegram 채널 위협 모델 + 토큰 revoke 절차 |
+| [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)     | Contributor Covenant 표준                                   |
+| [../CHANGELOG.md](../CHANGELOG.md)                 | 사용자-가시 변경 history (Keep a Changelog)                 |
+| [../.changeset/README.md](../.changeset/README.md) | changesets 도구 사용법                                      |
 
 ## 어디서 시작해야 할까
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,56 @@
+# Token Weather Documentation Index
+
+token-weather 의 모든 문서 entry point. 카테고리 / 사용자 타입 별로 분류.
+
+문서 정책 (자세히): [CONTRIBUTING.md](../CONTRIBUTING.md). 한글이 source of truth, 외부 가시 docs 는 영문 번역 (`.en.md`) 도 같이 유지될 예정 (issue #154 roadmap).
+
+## 시작점
+
+- [README.md](../README.md) — 프로젝트 개요 + Install + 핵심 명령. 첫 진입 시 가장 먼저.
+- 권한 / 토큰 누설 시 신고: [SECURITY.md](../SECURITY.md)
+- 기여 / commit / PR 규칙: [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+## 외부 사용자용 — npm install 후 직접 참고
+
+운영 / 자동화 / 통합 시 사용자가 직접 보는 문서.
+
+| 문서 | 한 줄 요약 |
+| --- | --- |
+| [architecture.md](./architecture.md) | 패키지 / 모듈 구조의 고수준 요약 |
+| [auth-architecture.md](./auth-architecture.md) | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback) |
+| [auth-cli.md](./auth-cli.md) | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책 |
+| [cli-json-output.md](./cli-json-output.md) | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION |
+| [provider-notes.md](./provider-notes.md) | provider 별 observed endpoint / client_id / refresh 동작 |
+| [telegram-bot.md](./telegram-bot.md) | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 |
+| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성 |
+
+## 기여자 / 운영자용 — contributor 한국 기반, 한글 only 유지
+
+코드 패턴 / release 운영 / 내부 schema. 외부 사용자에게 가시도 낮은 문서.
+
+| 문서 | 한 줄 요약 |
+| --- | --- |
+| [codebase-guide.md](./codebase-guide.md) | 패키지 레이아웃 / shared 헬퍼 / 새 기능 체크리스트 / anti-patterns |
+| [release-policy.md](./release-policy.md) | semver / changeset / bump 기준 / publish 흐름 |
+| [auth-store-schema.md](./auth-store-schema.md) | auth.json 저장 schema (기술 설계 — 구조 정의) |
+| [claude-oauth-plan.md](./claude-oauth-plan.md) | Claude OAuth 구현 과거 계획 (보관용 — v0.5.0 이후 이력화) |
+
+## 메타 파일
+
+| 파일 | 설명 |
+| --- | --- |
+| [../README.md](../README.md) | 프로젝트 개요 |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | 브랜치 / commit / PR / 작업 단위 / 라이선스 |
+| [../SECURITY.md](../SECURITY.md) | 보안 신고 채널 + Telegram 채널 위협 모델 + 토큰 revoke 절차 |
+| [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) | Contributor Covenant 표준 |
+| [../CHANGELOG.md](../CHANGELOG.md) | 사용자-가시 변경 history (Keep a Changelog) |
+| [../.changeset/README.md](../.changeset/README.md) | changesets 도구 사용법 |
+
+## 어디서 시작해야 할까
+
+- **처음 사용**: [../README.md](../README.md) → `token-weather config init` → `token-weather auth login claude` → `token-weather status`
+- **`--json` 출력으로 외부 dashboard 통합**: [cli-json-output.md](./cli-json-output.md)
+- **Telegram 봇으로 원격 호출**: [telegram-bot.md](./telegram-bot.md)
+- **TypeScript 프로젝트에서 import**: [typescript-consumers.md](./typescript-consumers.md)
+- **기여 / PR 작성**: [../CONTRIBUTING.md](../CONTRIBUTING.md) → [codebase-guide.md](./codebase-guide.md)
+- **release 운영 / publish 흐름**: [release-policy.md](./release-policy.md)


### PR DESCRIPTION
## 요약

- Master issue #154 의 **Phase 1 — 한글 구조 보강**. 외부 가시 docs 의 영문 번역 (Phase 2) 시작 전, ToC 와 entry point 부터 정비.
- README 의 "추가 문서" 섹션을 11 docs 전체로 확장 + 외부 / 기여자 카테고리 분리. `docs/INDEX.md` 신설.

## 변경 내용

- `README.md` 의 "추가 문서" 섹션 ToC 갱신:
  - 기존 6 docs → 11 docs 전체 등재
  - 외부 사용자용 (7개) / 기여자·운영자용 (4개) 카테고리 분리
  - `docs/INDEX.md` 로 가는 entry point 첫 줄 명시
  - 기여자용 카테고리에 "한글 only 유지" 명시 (Phase 2 영어 번역 범위 사전 안내)
- `docs/INDEX.md` 신설:
  - 시작점 / 외부 사용자용 / 기여자·운영자용 / 메타 파일 4 카테고리
  - 각 문서의 한 줄 요약
  - "어디서 시작해야 할까" 시나리오별 진입 경로 안내 (처음 사용 / `--json` 통합 / Telegram 봇 / TypeScript / 기여 / release 운영)
- prettier 정리 commit 1건 — `docs/INDEX.md` 의 라인 폭 조정.

## 변경 이유

Phase 0 audit 결과:

- 모든 외부 가시 docs 가 v0.6.0 까지 반영되어 outdated 없음
- 그러나 README 의 ToC 가 **11 docs 중 6개만 등재** — 신규 (codebase-guide / release-policy / telegram-bot / typescript-consumers / 등) 누락
- `docs/` 하위 통합 INDEX 파일 없음 — 외부 사용자가 어디서 시작해야 할지 모호

Phase 1 은 한글 source 의 outdated 갱신이 아니라 **구조 보강 + entry point 정비** 가 메인. Phase 2 (영어 번역) 가 본 roadmap 의 주요 작업 — 한글이 stable 한 시점에 진행.

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (README.md)
- [x] `docs` (docs/INDEX.md 신규)

## 스크린샷 / 데모

`docs/INDEX.md` 신설 — 카테고리별 표 + 시나리오 안내. GitHub 의 markdown 렌더링에서 ToC 표 형태로 표시. CLI / 봇 동작 영향 없음 (docs only).

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npx prettier --check .` (`.claude/settings.local.json` 작업 범위 밖 warning 만), `npm run lint` clean, `npm test` 1116 pass / 0 fail
- [x] 필요한 문서 업데이트 반영 — README + docs/INDEX.md
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only, 코드 / contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음 — 해당 없음

## 리뷰 포인트

- **카테고리 분류** — 외부 가시 / 기여자 / 메타 의 3 카테고리가 적절한지. `typescript-consumers.md` 가 외부 사용자용 (TypeScript 통합 시 사용자가 직접 봄) 으로 분류된 게 정합한지.
- **`docs/INDEX.md` 의 표 형식** — markdown table 이 GitHub 렌더링에서 한 줄 요약 가독성 OK 인지. 폭이 좁은 화면에서 wrap 정도.
- **"어디서 시작해야 할까" 시나리오** — 6개 시나리오 (처음 사용 / `--json` / Telegram / TypeScript / 기여 / release) 가 실제 사용자 진입 패턴 cover 인지.
- **i18n 사전 안내** — 카테고리 설명에 "한글 only 유지" / 영문 번역 후속 예고 명시. 사용자에게 i18n 진행 의도가 명확한지.

## 참고 사항

- 관련 master issue: #154 (docs i18n + 구조 정비 roadmap)
- 다음 PR: Phase 2-1 — README dual (`README.md` → `README.ko.md` rename + `README.md` 영어 신규)
- Out of scope:
  - 본 PR 에서는 한글 source 의 outdated 갱신 X (audit 결과 큰 변동 없음)
  - 영어 번역 X (Phase 2 부터)
  - 내부 docs 의 한글 변경 X (codebase-guide / release-policy 는 그대로)
- changeset 없음 — 본 PR 은 ToC / entry point 만 변경, 사용자-가시 패키지 동작 변경 없음. Phase 2-1 부터 minor bump.
