### PR TITLE
[docs] telegram-bot / cli-json-output / provider-notes 영어 번역 (issue #154)

### DIFF
--- a/.changeset/docs-i18n-external-core.md
+++ b/.changeset/docs-i18n-external-core.md
@@ -1,0 +1,40 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+docs(repo): 외부 가시 docs 영어 번역 — telegram-bot / cli-json-output /
+provider-notes (issue #154 Phase 2-2).
+
+README 영어 default 전환 (Phase 2-1) 에 이어, 외부 사용자 진입도가 가장 높은
+3개 docs 의 영어 번역본 (.en.md) 을 추가. 영어권 사용자가 README 의 외부 docs
+link 따라 갈 때 한 클릭으로 영어 본 접근 가능.
+
+**변경 사항**:
+
+- `docs/telegram-bot.en.md` 신규 — 봇 setup / 핸들러 / OS service 가이드 / 보안
+  모델 / FAQ
+- `docs/cli-json-output.en.md` 신규 — `status --json` stable contract,
+  field-absence 정책, redaction 규약, v0.4.0 / v0.5.0 migration
+- `docs/provider-notes.en.md` 신규 — provider 별 observed endpoint /
+  client_id / refresh 동작 / 알려진 limits
+- `docs/INDEX.md` 갱신 — 외부 사용자용 표에 '영문' 컬럼 추가. Phase 2-2 의 3
+  개만 link 노출, 나머지 4 개 (architecture / auth-architecture / auth-cli /
+  typescript-consumers) 는 Phase 2-3 예정 표기
+
+**번역 정책 정합** (CONTRIBUTING §6 + §10):
+
+- 한글 source (`docs/X.md`) 가 source of truth. 영문 `.en.md` 는 번역본.
+- 코드 식별자 / 외부 lib name / 경로 / 명령 예시 / JSON shape key / endpoint
+  URL / scope 명 — 양쪽 동일.
+- 영문 본 상단에 번역 footer (`> Translated from ... last sync 2026-05-20`).
+
+**Non-goal** (Phase 2-3 / 2-4 후속):
+
+- `docs/auth-architecture.en.md` / `auth-cli.en.md` / `architecture.en.md` /
+  `typescript-consumers.en.md` — Phase 2-3
+- `SECURITY.md` 영어화 — Phase 2-4
+- CONTRIBUTING §10 의 운영 절차 보강 (test 가드 등) — Phase 2-4
+- 내부 docs (codebase-guide / release-policy) 영어화 보류

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > Translated from [README.ko.md](./README.ko.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](./CONTRIBUTING.md) for the i18n drift policy.
 
 > **Local CLI dashboard for AI service usage and OAuth credentials.**
-> A CLI that checks usage and auth status for multiple AI services (Codex / Claude) in one place, locally. **OAuth tokens never leave your machine** (even with the optional `@token-weather/telegram` activated, the bot token and OAuth tokens stay local — only usage metadata flows through Telegram servers; see [details](./docs/telegram-bot.md#보안-모델)).
+> A CLI that checks usage and auth status for multiple AI services (Codex / Claude) in one place, locally. **OAuth tokens never leave your machine** (even with the optional `@token-weather/telegram` activated, the bot token and OAuth tokens stay local — only usage metadata flows through Telegram servers; see [details](./docs/telegram-bot.en.md#security-model)).
 
 ## Install
 
@@ -52,11 +52,11 @@ You can record the first-minute flow of `token-weather` locally with `bash scrip
 ## What & Why
 
 - **What**: A CLI that unifies OAuth credentials and usage windows for AI tools, locally. Two providers in operation today — Codex (OpenAI) and Claude (Anthropic).
-- **Why**: Other dashboards send tokens to external servers or depend on a separate auth service. Token Weather works with **its own broker + local credential store** — **OAuth tokens never leave your machine**. Even when `@token-weather/telegram` is enabled, tokens themselves stay local; only usage and account-label metadata flows through Telegram servers ([details](./docs/telegram-bot.md#보안-모델)).
+- **Why**: Other dashboards send tokens to external servers or depend on a separate auth service. Token Weather works with **its own broker + local credential store** — **OAuth tokens never leave your machine**. Even when `@token-weather/telegram` is enabled, tokens themselves stay local; only usage and account-label metadata flows through Telegram servers ([details](./docs/telegram-bot.en.md#security-model)).
 - **How it's different**:
   - **Multi-account**: store multiple accounts per provider, query them in parallel, attach labels
   - **Automatic refresh**: expired access tokens are refreshed preflight before any provider call, with a single retry on auth failure
-  - **`status --json` stable contract**: normalized output with token redaction guaranteed — directly consumable by external dashboards / collectors ([docs/cli-json-output.md](./docs/cli-json-output.md))
+  - **`status --json` stable contract**: normalized output with token redaction guaranteed — directly consumable by external dashboards / collectors ([docs/cli-json-output.en.md](./docs/cli-json-output.en.md))
   - **Observed `client_id`**: uses the values observed from the provider binaries (not an officially registered OAuth client). Every publish of this tool itself is verified by npm Trusted Publishing OIDC + SLSA provenance, so the supply chain is independently auditable
 
 ## Supported providers
@@ -66,7 +66,7 @@ You can record the first-minute flow of `token-weather` locally with `bash scrip
 | Codex (OpenAI)     | ✓ `auth login codex`  | `wham/usage`   | ✓       | In production |
 | Claude (Anthropic) | ✓ `auth login claude` | `oauth/usage`  | ✓       | In production |
 
-For provider-specific observed endpoint / client_id details, see [docs/provider-notes.md](./docs/provider-notes.md).
+For provider-specific observed endpoint / client_id details, see [docs/provider-notes.en.md](./docs/provider-notes.en.md).
 
 ## Commands
 
@@ -98,7 +98,7 @@ token-weather telegram setup             # bot token + pairing + OS service guid
 token-weather telegram start             # run the daemon (or use the systemd / launchd / Task Scheduler entry created at the end of setup)
 ```
 
-Details / security model / manual OS service registration / FAQ: [docs/telegram-bot.md](./docs/telegram-bot.md).
+Details / security model / manual OS service registration / FAQ: [docs/telegram-bot.en.md](./docs/telegram-bot.en.md).
 
 ## JSON output (automation)
 
@@ -108,7 +108,7 @@ Details / security model / manual OS service registration / FAQ: [docs/telegram-
 token-weather status --json | jq '.providers[0]'
 ```
 
-Shape / redaction rules / limits: [docs/cli-json-output.md](./docs/cli-json-output.md).
+Shape / redaction rules / limits: [docs/cli-json-output.en.md](./docs/cli-json-output.en.md).
 
 ## Security principles
 
@@ -149,9 +149,9 @@ Quick entry point — [docs/INDEX.md](./docs/INDEX.md) (categorized).
 - [docs/architecture.md](./docs/architecture.md) — high-level structure summary
 - [docs/auth-architecture.md](./docs/auth-architecture.md) — auth / token / source priority details
 - [docs/auth-cli.md](./docs/auth-cli.md) — auth CLI commands / policy
-- [docs/cli-json-output.md](./docs/cli-json-output.md) — `--json` stable contract + redaction rules
-- [docs/provider-notes.md](./docs/provider-notes.md) — per-provider observed endpoint / client_id
-- [docs/telegram-bot.md](./docs/telegram-bot.md) — Telegram bot optional package (`@token-weather/telegram`) guide
+- [docs/cli-json-output.en.md](./docs/cli-json-output.en.md) — `--json` stable contract + redaction rules
+- [docs/provider-notes.en.md](./docs/provider-notes.en.md) — per-provider observed endpoint / client_id
+- [docs/telegram-bot.en.md](./docs/telegram-bot.en.md) — Telegram bot optional package (`@token-weather/telegram`) guide
 - [docs/typescript-consumers.md](./docs/typescript-consumers.md) — d.ts / import patterns for TypeScript users
 
 **For contributors / maintainers** (contributors are Korean-based — kept in Korean only):

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,15 +14,15 @@ token-weather 의 모든 문서 entry point. 카테고리 / 사용자 타입 별
 
 운영 / 자동화 / 통합 시 사용자가 직접 보는 문서.
 
-| 문서                                                 | 한 줄 요약                                                                    |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [architecture.md](./architecture.md)                 | 패키지 / 모듈 구조의 고수준 요약                                              |
-| [auth-architecture.md](./auth-architecture.md)       | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback)      |
-| [auth-cli.md](./auth-cli.md)                         | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책        |
-| [cli-json-output.md](./cli-json-output.md)           | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION             |
-| [provider-notes.md](./provider-notes.md)             | provider 별 observed endpoint / client_id / refresh 동작                      |
-| [telegram-bot.md](./telegram-bot.md)                 | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 |
-| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성                          |
+| 문서                                                 | 한 줄 요약                                                                    | 영문                                             |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ |
+| [architecture.md](./architecture.md)                 | 패키지 / 모듈 구조의 고수준 요약                                              | (Phase 2-3 예정)                                 |
+| [auth-architecture.md](./auth-architecture.md)       | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback)      | (Phase 2-3 예정)                                 |
+| [auth-cli.md](./auth-cli.md)                         | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책        | (Phase 2-3 예정)                                 |
+| [cli-json-output.md](./cli-json-output.md)           | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION             | [cli-json-output.en.md](./cli-json-output.en.md) |
+| [provider-notes.md](./provider-notes.md)             | provider 별 observed endpoint / client_id / refresh 동작                      | [provider-notes.en.md](./provider-notes.en.md)   |
+| [telegram-bot.md](./telegram-bot.md)                 | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 | [telegram-bot.en.md](./telegram-bot.en.md)       |
+| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성                          | (Phase 2-3 예정)                                 |
 
 ## 기여자 / 운영자용 — contributor 한국 기반, 한글 only 유지
 

--- a/docs/cli-json-output.en.md
+++ b/docs/cli-json-output.en.md
@@ -1,0 +1,224 @@
+# CLI JSON output (`--json`)
+
+> Translated from [cli-json-output.md](./cli-json-output.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+The `status` / `usage` commands emit a single normalized JSON line to stdout when given the `--json` flag. This is a specification so that automation / dashboards / backend collectors can consume the output directly without re-parsing text formatting.
+
+This document is the **stable contract** for the output shape. Changes require a schema bump (the current `schemaVersion` is shared with `packages/schemas` — a string semver, see [docs/release-policy.md §3](./release-policy.md)).
+
+## Usage
+
+```bash
+token-weather status --json
+token-weather usage  --json
+token-weather status --json --provider codex
+token-weather status --json --account work@example.com --provider claude
+```
+
+- stdout carries **only one JSON line** (terminated by a single newline).
+- Notices / warnings / failure messages go to stderr (automation only needs to parse stdout).
+- Unknown `--provider` input behaves like text mode — stderr message + `exit 1`. It does **not** fall back to JSON (so the caller is forced to recognize the failure explicitly).
+
+## Top-level shape
+
+```json
+{
+  "command": "status",
+  "generatedAt": "2026-04-25T08:30:00.000Z",
+  "schemaVersion": "0.5.0",
+  "configPath": "/home/user/.config/token-weather/config.json",
+  "accountFilter": null,
+  "providerFilter": null,
+  "providers": [
+    { "id": "codex",  "snapshot": { ... } },
+    { "id": "claude", "snapshot": { ... } }
+  ]
+}
+```
+
+| Field            | Type                    | When absent                              | Description                                                                                                                                                                              |
+| ---------------- | ----------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`        | `"status"` \| `"usage"` | Always present                           | The invoked command name.                                                                                                                                                                |
+| `generatedAt`    | ISO-8601 string         | Always present                           | Time the snapshot was serialized (client-side).                                                                                                                                          |
+| `schemaVersion`  | string semver \| null   | Always present (value may be null)       | Passed through from `packages/schemas/src/index.js::SCHEMA_VERSION` (currently `'0.5.0'`). Independent of package `version`; bump triggers in [docs/release-policy.md §3](./release-policy.md). |
+| `configPath`     | string \| null          | Always present                           | Resolved config file path.                                                                                                                                                               |
+| `accountFilter`  | string \| null          | `null` when unspecified (key not absent) | `--account <id>` input as given (case-insensitive matching is handled separately).                                                                                                       |
+| `providerFilter` | string \| null          | `null` when unspecified (key not absent) | `--provider <id>` input, lowercase-normalized.                                                                                                                                           |
+| `providers`      | array                   | Always present (`[]` possible)           | See §providers below.                                                                                                                                                                    |
+
+### Field-absence policy — null vs missing key
+
+Scope:
+
+- **Top-level defined fields** (`command` / `generatedAt` / `schemaVersion` / `configPath` / `accountFilter` / `providerFilter` / `providers`) — **always present**. When there is no value, it appears as an explicit `null` (or empty array `[]`); the key itself is never absent.
+- **Defined fields on a provider snapshot in `providers[]`** (`enabled` / `authSource` / `credentialsPath` / `usageSnapshots` / `accountFilter` / `filteredOut`) — **always with an explicit default value**. Absent values appear as `null` / `[]` / `false` etc.
+
+**Exception**: when only some providers are requested via `--provider <id>`, **the entries for unselected providers are not included in `providers[]` at all** (no snapshot is created). E.g., with `--provider codex`, the `claude` entry is missing from the array.
+
+```js
+// Top-level field: check the value (avoid the `'key' in data` anti-pattern)
+if (data.accountFilter !== null) {
+  /* ... */
+}
+
+// Provider entry presence: reflects providerFilter
+const claude = data.providers.find((p) => p.id === 'claude');
+if (claude) {
+  // defined fields on claude.snapshot always have a default
+  if (claude.snapshot.usageSnapshots.length > 0) {
+    /* ... */
+  }
+}
+```
+
+When adding new keys, follow this policy — always specify a default value (no `undefined` and no missing key).
+
+## providers
+
+`providers` is an array of `[{ id, snapshot }]`. `id` is the registry id (`codex` / `claude`), matching what `--provider` accepts.
+
+If `providerFilter` is specified, only matching providers are included in the array (snapshots for others are not even created, so the entries are absent). Otherwise all providers are included in registration order.
+
+`snapshot` is a **deep clone with sensitive keys removed** of the object returned by each provider builder (`getCodexSnapshot` / `getClaudeSnapshot`).
+
+### Provider entry shape (v0.5.0, symmetric)
+
+Since v0.5.0 (issue #120), the keysets of codex / claude provider snapshots are **identical**. External consumers can query the data on a single path without branching by provider.
+
+| Field             | Type                 | Description                                                                                                                                                  |
+| ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`         | boolean              | Pass-through of `config.providers.<id>.enabled`. Whether the provider is a call target.                                                                      |
+| `authSource`      | string               | One of `'agent-store'` / `'codex-cli-import'` / `'claude-cli-import'` / `'not-found'`.                                                                       |
+| `credentialsPath` | string \| null       | Set only when the auth source is `cli-import`. `null` otherwise (same policy for codex / claude).                                                            |
+| `usageSnapshots`  | Array<UsageSnapshot> | Per-account usage snapshots as a direct array. Element shape matches [usage-snapshot.schema.json](../packages/schemas/usage-snapshot.schema.json).            |
+| `accountFilter`   | string \| null       | Pass-through of `--account` (case-insensitive matching is handled separately).                                                                               |
+| `filteredOut`     | boolean              | Whether a filter was specified but no matching account was found.                                                                                            |
+
+### `authSource` enum values
+
+| Value                 | Meaning                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `'agent-store'`       | Found an active account in `~/.config/token-weather/auth.json` (token-weather's own store).                              |
+| `'codex-cli-import'`  | (codex only) Fallback-imported from `~/.codex/auth.json` (Codex CLI itself). `credentialsPath` is exposed alongside.     |
+| `'claude-cli-import'` | (claude only) Fallback-imported from `~/.claude/.credentials.json` (Claude CLI itself). `credentialsPath` is alongside.  |
+| `'not-found'`         | No active account found in any source. `credentialsPath` is `null`.                                                      |
+
+Changing the enum (add / remove / meaning change) is a major-bump trigger per [release-policy §1](./release-policy.md) — `SCHEMA_VERSION` bump required.
+
+### Sensitive keys removed (redaction)
+
+The following keys are dropped from the output at any depth, in objects or arrays (the entire subtree is removed).
+Matching is **case-insensitive** (`AccessToken` / `ACCESSTOKEN` are equally blocked).
+
+- OAuth tokens (camelCase + snake_case): `accessToken`, `refreshToken`, `idToken`, `tokens`, `access_token`, `refresh_token`, `id_token`
+- OAuth client secret / verifier: `client_secret`, `clientSecret`, `codeVerifier`, `code_verifier`
+- Session / cookie material: `sessionKey`, `sessionCookie`, `session_key`, `session_cookie`
+- HTTP credential headers: `authorization`, `cookie`
+- Generic API key / password: `apiKey`, `api_key`, `password`
+
+When a new provider/schema introduces new token-bearing fields, register them in `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS` at the same time.
+
+### Limits (key-name match list, not a value detector)
+
+This redaction operates by **exact key name** (case-insensitive comparison, no regex / no value pattern detection). That means:
+
+- Tokens delivered under a name not in the list above are **not** automatically filtered (e.g., new identifiers like `bearer`, `access-key`, `secretToken`).
+- Don't serialize tokens into free-form subtrees like `raw` / `meta` — or register the relevant name in SENSITIVE_KEYS.
+- A JWT-like value pattern stuck into arbitrary keys like `notes` or `description` is not redacted — the provider adapter is responsible for not copying token values into such free-form fields.
+
+This limit is a design decision: the `--json` contract is an *explicit leak blocker*, not a *value detector*. When a new identifier is found, update SENSITIVE_KEYS via a PR.
+
+### The `raw` area's responsibility (provider adapter contract)
+
+`usageSnapshots[].raw` is a free-form subtree that preserves the provider's response. The schema has `additionalProperties: true`, so it's a danger zone where the key-name-match redaction cannot reach.
+
+**The provider adapter's responsibility**:
+
+1. **Do not copy token values into free-form keys in `raw`.** If they come in through SENSITIVE_KEYS-matching keys like `access_token` / `refresh_token`, redaction handles them — but if a token string lands in a key like `body`/`response`/`payload`, it leaks as-is.
+2. **Do not dump the entire response body into `raw`.** Extract only the necessary fields explicitly — e.g., `raw: { provider, plan, ...selectedFields }`.
+3. **When a new token-pattern identifier is found, file a PR to register it in `SENSITIVE_KEYS`.**
+
+These responsibilities are enforced by code review + a regression guard (the redaction unit tests in `status-json.test.js`).
+
+## Stability
+
+- Adding new keys is **non-breaking** (consumers are advised to ignore unknown fields).
+- Removing keys / changing meaning / restructuring shape is **breaking** — requires a `schemaVersion` bump.
+- The `providers[].id` identifier stays in sync with `PROVIDER_REGISTRY`; adding/removing is a schema-bump reason.
+
+## Removed backward-compat aliases (v0.4.0)
+
+In v0.4.0 (issue #119), three aliases on the claude provider snapshot were removed. External consumers that parsed alias keys need to migrate to the official keys.
+
+| Removed alias                                          | Official key                                       | Note                                                                                                                                |
+| ------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `.providers[].snapshot.networkUsage` (single object)   | `.providers[].snapshot.networkUsages[]` (array)    | **Mind the element wrapper** — see below. Single-account uses `[0]`; multi-account iterates the array.                              |
+| `.providers[].snapshot.importedAccount`                | `.providers[].snapshot.selectedAccount`            | The values were identical.                                                                                                          |
+| `.providers[].snapshot.parsed`                         | `.providers[].snapshot.found`                      | Always had the same value as `found`.                                                                                               |
+
+In earlier versions (v0.3.x and below), both keys were emitted in parallel for backward-compat. Since v0.4.0, only the official keys are exposed.
+
+## Provider shape symmetry (v0.5.0)
+
+In v0.5.0 (issue #120), the codex / claude provider snapshot key names were unified and the claude wrapper pattern was removed.
+
+| Area                  | v0.4.x and below (Codex)             | v0.4.x and below (Claude)                            | v0.5.0+ (same on both providers)                                       |
+| --------------------- | ------------------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| Usage array key       | `snapshots[]`                        | `networkUsages[]`                                    | **`usageSnapshots[]`**                                                 |
+| Usage array element   | Direct `UsageSnapshot`               | `{ accountKey, account, snapshot }` wrapper          | **Direct `UsageSnapshot`** (wrapper removed)                           |
+| Active flag           | `enabled: bool`                      | `detected` / `found` (2 keys)                        | **`enabled: bool`** (single)                                           |
+| Default account       | (none)                               | `selectedAccount`                                    | (none, removed on both providers)                                      |
+| credentialsPath       | Only at `cli-import` time (not null) | Always (never null)                                  | **Only at `cli-import` time**, otherwise `null` (same policy on both)  |
+
+### Migration (v0.4.x → v0.5.0)
+
+```js
+// before (v0.4.x)
+const codexEnabled = data.providers.find((p) => p.id === 'codex').snapshot.enabled;
+const codexSnaps = data.providers.find((p) => p.id === 'codex').snapshot.snapshots;
+const claudeEnabled = data.providers.find((p) => p.id === 'claude').snapshot.detected;
+const claudeFound = data.providers.find((p) => p.id === 'claude').snapshot.found;
+const claudeWindows = data.providers.find((p) => p.id === 'claude').snapshot.networkUsages[0]
+  .snapshot.usageWindows;
+const claudeAccount = data.providers.find((p) => p.id === 'claude').snapshot.selectedAccount;
+
+// after (v0.5.0+) — same path on codex / claude
+const provider = (id) => data.providers.find((p) => p.id === id).snapshot;
+const codexEnabled = provider('codex').enabled;
+const codexSnaps = provider('codex').usageSnapshots;
+const claudeEnabled = provider('claude').enabled;
+//   found / detected: subtly different — "credential found anywhere" is the same as enabled.
+//   To check pure credential-file existence, use credentialsPath != null instead.
+const claudeWindows = provider('claude').usageSnapshots[0].usageWindows;
+//   Wrapper removed — the `.snapshot` step no longer exists.
+const claudeAccount = provider('claude').usageSnapshots.find(/* by criteria */)?.account;
+//   Default-account concept removed — iterate usageSnapshots[] to identify if needed.
+```
+
+### `networkUsages[]` element structure (v0.4.x — removed in v0.5.0)
+
+> **v0.5.0 (issue #120) update**: `networkUsages[]` itself was renamed to `usageSnapshots[]`, and the wrapper `{ accountKey, account, snapshot }` was unwrapped so that **UsageSnapshot is direct**. So in v0.5.0+ the wrapper step disappears: `.snapshot.usageWindows` → `.usageWindows`, one level shorter. See the Migration in §"Provider shape symmetry (v0.5.0)" above.
+
+In the older `networkUsage` (v0.3.x, single object), the value was the usage snapshot object **directly**. But in v0.4.x's `networkUsages[]`, each element was a `{ accountKey, account, snapshot }` **wrapper**. The actual data (`usageWindows` / `status` etc.) was inside `.snapshot`.
+
+```js
+// before (v0.3.x — removed)
+const ok = data.providers.find((p) => p.id === 'claude').snapshot.networkUsage.status.ok;
+const windows = data.providers.find((p) => p.id === 'claude').snapshot.networkUsage.usageWindows;
+
+// after (v0.4.0+)
+const claude = data.providers.find((p) => p.id === 'claude').snapshot;
+const ok = claude.networkUsages[0].snapshot.status.ok; // ← added .snapshot step
+const windows = claude.networkUsages[0].snapshot.usageWindows;
+
+// Multi-account iteration pattern
+for (const entry of claude.networkUsages) {
+  console.log(entry.accountKey, entry.snapshot.status.ok); // ← entry.snapshot
+}
+```
+
+## Security principles
+
+- Tokens are forbidden in stdout/stderr in any form (same for text mode).
+- The `--json` mode is designed to be safe for sending through logging pipelines or external systems as-is, since it goes through redaction.
+- When introducing free-form fields like `raw`, audit token-leakage risk case by case.

--- a/docs/cli-json-output.en.md
+++ b/docs/cli-json-output.en.md
@@ -36,15 +36,15 @@ token-weather status --json --account work@example.com --provider claude
 }
 ```
 
-| Field            | Type                    | When absent                              | Description                                                                                                                                                                              |
-| ---------------- | ----------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `command`        | `"status"` \| `"usage"` | Always present                           | The invoked command name.                                                                                                                                                                |
-| `generatedAt`    | ISO-8601 string         | Always present                           | Time the snapshot was serialized (client-side).                                                                                                                                          |
+| Field            | Type                    | When absent                              | Description                                                                                                                                                                                     |
+| ---------------- | ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`        | `"status"` \| `"usage"` | Always present                           | The invoked command name.                                                                                                                                                                       |
+| `generatedAt`    | ISO-8601 string         | Always present                           | Time the snapshot was serialized (client-side).                                                                                                                                                 |
 | `schemaVersion`  | string semver \| null   | Always present (value may be null)       | Passed through from `packages/schemas/src/index.js::SCHEMA_VERSION` (currently `'0.5.0'`). Independent of package `version`; bump triggers in [docs/release-policy.md §3](./release-policy.md). |
-| `configPath`     | string \| null          | Always present                           | Resolved config file path.                                                                                                                                                               |
-| `accountFilter`  | string \| null          | `null` when unspecified (key not absent) | `--account <id>` input as given (case-insensitive matching is handled separately).                                                                                                       |
-| `providerFilter` | string \| null          | `null` when unspecified (key not absent) | `--provider <id>` input, lowercase-normalized.                                                                                                                                           |
-| `providers`      | array                   | Always present (`[]` possible)           | See §providers below.                                                                                                                                                                    |
+| `configPath`     | string \| null          | Always present                           | Resolved config file path.                                                                                                                                                                      |
+| `accountFilter`  | string \| null          | `null` when unspecified (key not absent) | `--account <id>` input as given (case-insensitive matching is handled separately).                                                                                                              |
+| `providerFilter` | string \| null          | `null` when unspecified (key not absent) | `--provider <id>` input, lowercase-normalized.                                                                                                                                                  |
+| `providers`      | array                   | Always present (`[]` possible)           | See §providers below.                                                                                                                                                                           |
 
 ### Field-absence policy — null vs missing key
 
@@ -85,23 +85,23 @@ If `providerFilter` is specified, only matching providers are included in the ar
 
 Since v0.5.0 (issue #120), the keysets of codex / claude provider snapshots are **identical**. External consumers can query the data on a single path without branching by provider.
 
-| Field             | Type                 | Description                                                                                                                                                  |
-| ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `enabled`         | boolean              | Pass-through of `config.providers.<id>.enabled`. Whether the provider is a call target.                                                                      |
-| `authSource`      | string               | One of `'agent-store'` / `'codex-cli-import'` / `'claude-cli-import'` / `'not-found'`.                                                                       |
-| `credentialsPath` | string \| null       | Set only when the auth source is `cli-import`. `null` otherwise (same policy for codex / claude).                                                            |
-| `usageSnapshots`  | Array<UsageSnapshot> | Per-account usage snapshots as a direct array. Element shape matches [usage-snapshot.schema.json](../packages/schemas/usage-snapshot.schema.json).            |
-| `accountFilter`   | string \| null       | Pass-through of `--account` (case-insensitive matching is handled separately).                                                                               |
-| `filteredOut`     | boolean              | Whether a filter was specified but no matching account was found.                                                                                            |
+| Field             | Type                 | Description                                                                                                                                        |
+| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`         | boolean              | Pass-through of `config.providers.<id>.enabled`. Whether the provider is a call target.                                                            |
+| `authSource`      | string               | One of `'agent-store'` / `'codex-cli-import'` / `'claude-cli-import'` / `'not-found'`.                                                             |
+| `credentialsPath` | string \| null       | Set only when the auth source is `cli-import`. `null` otherwise (same policy for codex / claude).                                                  |
+| `usageSnapshots`  | Array<UsageSnapshot> | Per-account usage snapshots as a direct array. Element shape matches [usage-snapshot.schema.json](../packages/schemas/usage-snapshot.schema.json). |
+| `accountFilter`   | string \| null       | Pass-through of `--account` (case-insensitive matching is handled separately).                                                                     |
+| `filteredOut`     | boolean              | Whether a filter was specified but no matching account was found.                                                                                  |
 
 ### `authSource` enum values
 
-| Value                 | Meaning                                                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `'agent-store'`       | Found an active account in `~/.config/token-weather/auth.json` (token-weather's own store).                              |
-| `'codex-cli-import'`  | (codex only) Fallback-imported from `~/.codex/auth.json` (Codex CLI itself). `credentialsPath` is exposed alongside.     |
-| `'claude-cli-import'` | (claude only) Fallback-imported from `~/.claude/.credentials.json` (Claude CLI itself). `credentialsPath` is alongside.  |
-| `'not-found'`         | No active account found in any source. `credentialsPath` is `null`.                                                      |
+| Value                 | Meaning                                                                                                                 |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `'agent-store'`       | Found an active account in `~/.config/token-weather/auth.json` (token-weather's own store).                             |
+| `'codex-cli-import'`  | (codex only) Fallback-imported from `~/.codex/auth.json` (Codex CLI itself). `credentialsPath` is exposed alongside.    |
+| `'claude-cli-import'` | (claude only) Fallback-imported from `~/.claude/.credentials.json` (Claude CLI itself). `credentialsPath` is alongside. |
+| `'not-found'`         | No active account found in any source. `credentialsPath` is `null`.                                                     |
 
 Changing the enum (add / remove / meaning change) is a major-bump trigger per [release-policy §1](./release-policy.md) — `SCHEMA_VERSION` bump required.
 
@@ -126,7 +126,7 @@ This redaction operates by **exact key name** (case-insensitive comparison, no r
 - Don't serialize tokens into free-form subtrees like `raw` / `meta` — or register the relevant name in SENSITIVE_KEYS.
 - A JWT-like value pattern stuck into arbitrary keys like `notes` or `description` is not redacted — the provider adapter is responsible for not copying token values into such free-form fields.
 
-This limit is a design decision: the `--json` contract is an *explicit leak blocker*, not a *value detector*. When a new identifier is found, update SENSITIVE_KEYS via a PR.
+This limit is a design decision: the `--json` contract is an _explicit leak blocker_, not a _value detector_. When a new identifier is found, update SENSITIVE_KEYS via a PR.
 
 ### The `raw` area's responsibility (provider adapter contract)
 
@@ -150,11 +150,11 @@ These responsibilities are enforced by code review + a regression guard (the red
 
 In v0.4.0 (issue #119), three aliases on the claude provider snapshot were removed. External consumers that parsed alias keys need to migrate to the official keys.
 
-| Removed alias                                          | Official key                                       | Note                                                                                                                                |
-| ------------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `.providers[].snapshot.networkUsage` (single object)   | `.providers[].snapshot.networkUsages[]` (array)    | **Mind the element wrapper** — see below. Single-account uses `[0]`; multi-account iterates the array.                              |
-| `.providers[].snapshot.importedAccount`                | `.providers[].snapshot.selectedAccount`            | The values were identical.                                                                                                          |
-| `.providers[].snapshot.parsed`                         | `.providers[].snapshot.found`                      | Always had the same value as `found`.                                                                                               |
+| Removed alias                                        | Official key                                    | Note                                                                                                   |
+| ---------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `.providers[].snapshot.networkUsage` (single object) | `.providers[].snapshot.networkUsages[]` (array) | **Mind the element wrapper** — see below. Single-account uses `[0]`; multi-account iterates the array. |
+| `.providers[].snapshot.importedAccount`              | `.providers[].snapshot.selectedAccount`         | The values were identical.                                                                             |
+| `.providers[].snapshot.parsed`                       | `.providers[].snapshot.found`                   | Always had the same value as `found`.                                                                  |
 
 In earlier versions (v0.3.x and below), both keys were emitted in parallel for backward-compat. Since v0.4.0, only the official keys are exposed.
 
@@ -162,13 +162,13 @@ In earlier versions (v0.3.x and below), both keys were emitted in parallel for b
 
 In v0.5.0 (issue #120), the codex / claude provider snapshot key names were unified and the claude wrapper pattern was removed.
 
-| Area                  | v0.4.x and below (Codex)             | v0.4.x and below (Claude)                            | v0.5.0+ (same on both providers)                                       |
-| --------------------- | ------------------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------- |
-| Usage array key       | `snapshots[]`                        | `networkUsages[]`                                    | **`usageSnapshots[]`**                                                 |
-| Usage array element   | Direct `UsageSnapshot`               | `{ accountKey, account, snapshot }` wrapper          | **Direct `UsageSnapshot`** (wrapper removed)                           |
-| Active flag           | `enabled: bool`                      | `detected` / `found` (2 keys)                        | **`enabled: bool`** (single)                                           |
-| Default account       | (none)                               | `selectedAccount`                                    | (none, removed on both providers)                                      |
-| credentialsPath       | Only at `cli-import` time (not null) | Always (never null)                                  | **Only at `cli-import` time**, otherwise `null` (same policy on both)  |
+| Area                | v0.4.x and below (Codex)             | v0.4.x and below (Claude)                   | v0.5.0+ (same on both providers)                                      |
+| ------------------- | ------------------------------------ | ------------------------------------------- | --------------------------------------------------------------------- |
+| Usage array key     | `snapshots[]`                        | `networkUsages[]`                           | **`usageSnapshots[]`**                                                |
+| Usage array element | Direct `UsageSnapshot`               | `{ accountKey, account, snapshot }` wrapper | **Direct `UsageSnapshot`** (wrapper removed)                          |
+| Active flag         | `enabled: bool`                      | `detected` / `found` (2 keys)               | **`enabled: bool`** (single)                                          |
+| Default account     | (none)                               | `selectedAccount`                           | (none, removed on both providers)                                     |
+| credentialsPath     | Only at `cli-import` time (not null) | Always (never null)                         | **Only at `cli-import` time**, otherwise `null` (same policy on both) |
 
 ### Migration (v0.4.x → v0.5.0)
 

--- a/docs/provider-notes.en.md
+++ b/docs/provider-notes.en.md
@@ -1,0 +1,97 @@
+# Provider notes
+
+> Translated from [provider-notes.md](./provider-notes.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+## OpenAI Codex
+
+- Endpoint: `https://chatgpt.com/backend-api/wham/usage`
+- Auth: OAuth bearer token (`Authorization: Bearer <accessToken>`)
+- Optional header: `ChatGPT-Account-Id` (used to distinguish multiple accounts)
+- Status: **Verified working in production** (live 200 OK confirmed)
+
+### Auth flow
+
+- Default: localhost callback OAuth (`http://localhost:<port>/auth/callback`)
+  - PKCE S256 / state verification included
+  - On port conflict, falls back automatically (up to 3 retries) → switches to manual paste
+- Fallback: paste callback URL / code directly with the `--manual` flag
+- Token exchange: default is a real endpoint POST (with `--mock`, only a mock account is stored)
+- Auth store priority: `agent-store > openclaw-import`
+
+### OAuth endpoints
+
+- authorize: `https://auth.openai.com/oauth/authorize`
+- token: `https://auth.openai.com/oauth/token`
+- callback: `http://localhost:1455/auth/callback`
+- client_id: `app_EMoamEEZ73f0CkXaXp7hrann` (observed, not officially confirmed)
+- Extra authorize params: `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`, `originator=pi`
+
+### Known limits
+
+- `auth logout` only removes the local store (does not call the provider's revoke endpoint)
+- Network calls don't use timeout / AbortController → issue #7
+- Whether `client_secret` is required is not confirmed
+
+---
+
+## Anthropic / Claude
+
+### Auth flow
+
+Two paths coexist.
+
+- `auth login claude`: independent OAuth (browser login) → live token saved to agent-store (default)
+- `auth import claude`: reads `~/.claude/.credentials.json` → copies into agent-store
+
+Credential source priority: `agent-store > claude-cli-import`
+
+### Live usage endpoint
+
+- `GET https://api.anthropic.com/api/oauth/usage`
+- Headers: `Authorization: Bearer <token>`, `anthropic-version: 2023-06-01`, `anthropic-beta: oauth-2025-04-20`
+- Status: **Verified working in production** (live 200 OK, returns utilization numbers)
+- Response shape (observed):
+  - `five_hour: { utilization, resets_at }` — 5-hour window
+  - `seven_day: { utilization, resets_at }` — weekly window
+  - `seven_day_sonnet / seven_day_opus: { utilization }` — per-model weekly
+
+### OAuth endpoints (observed — extracted from the Claude Code v2.1.107 binary)
+
+- authorize: `https://claude.com/cai/oauth/authorize` (claude.ai user OAuth)
+- token: `https://platform.claude.com/v1/oauth/token`
+- redirect_uri: `http://localhost:<port>/callback` (path differs from Codex)
+- manual redirect: `https://platform.claude.com/oauth/code/callback`
+- success page: `https://platform.claude.com/oauth/code/success?app=claude-code`
+- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+- scopes: `org:create_api_key user:profile user:inference`
+
+### Observation-based caveats (Claude-specific)
+
+- The authorize URL also sends a `code=true` parameter (an extension outside the OAuth spec)
+- The token endpoint requires a **JSON body**. form-urlencoded gets a Claude API error (`invalid_request_error`)
+- The `authorization_code` grant requires a `state` field in the body
+- `https://platform.claude.com/oauth/authorize` is a separate flow for API-key issuance → do not confuse with the claude.ai path
+
+### Credential file (claude-cli-import)
+
+- Path: `~/.claude/.credentials.json`
+- Shape: `{ claudeAiOauth: { accessToken, refreshToken, expiresAt, scopes, subscriptionType, rateLimitTier } }`
+
+### Refresh token
+
+- `refreshClaudeToken` implemented (same shape as Codex `refreshCodexToken`; no feature gate since #97)
+- Manually verifiable via `doctor claude --refresh-live`
+- Rotation handling: replace `refresh_token` with the one in the response if present; keep the existing one otherwise
+
+### Local usage (stats-cache) — removed in v0.3.0
+
+The dependency on `~/.claude/stats-cache.json` (Claude Code's client-side telemetry artifact) was removed in v0.3.0 (issue #110). Users who need cumulative stats (totalSessions, totalMessages, per-model) can parse that file directly — it's Anthropic's internal artifact, so this tool does not abstract over it.
+
+This tool now exposes only the window-based utilization information (five_hour / seven_day) from the network endpoint (`/api/oauth/usage`) — architectural symmetry with Codex's server-side rate-limit model.
+
+### Known limits / unconfirmed
+
+- Whether `client_secret` is required (currently assumed to be a public client)
+- Detailed refresh-token rotation policy
+- Network calls don't use timeout / AbortController (issue #7)
+- Web session cookie fallback is not implemented (issue #14)

--- a/docs/telegram-bot.en.md
+++ b/docs/telegram-bot.en.md
@@ -4,7 +4,7 @@
 
 The `@token-weather/telegram` package provides a long-poll daemon that exposes token-weather's `status` / `usage` / `doctor` / `auth list` commands over Telegram. Run the bot locally, and you can send commands from your phone or another desktop and get immediate responses.
 
-> **Trust model summary**: bot token / OAuth tokens are **stored only in local files**. Usage numbers / account labels / command response bodies do flow through Telegram servers. For the full security model see [§Security model](#보안-모델).
+> **Trust model summary**: bot token / OAuth tokens are **stored only in local files**. Usage numbers / account labels / command response bodies do flow through Telegram servers. For the full security model see [§Security model](#security-model).
 
 ## Quick start
 
@@ -71,7 +71,7 @@ Manual registration (if you want to disable auto-registration or preconfigure wi
 
 The CLI's desktop boxes (`╭─` / `│` / `╰─`) + 50-column heavy rule break under wrap at mobile widths (~30–40 columns), so the Telegram bot uses `@token-weather/telegram`'s `formatStatusForTelegram` to emit a box-less compact output (line width ≤ 32 columns guideline, timezone omitted).
 
-Issue #146 restored 10-column ASCII progress bars (1/8-precision fractional blocks `█▏▎▍▌▋▊▉` + light shade `░`) on the window lines — ANSI colors are not applied because Telegram's `<pre>` does not support them.
+Issue #146 restored 10-column Unicode block progress bars (1/8-precision fractional blocks `█▏▎▍▌▋▊▉` + light shade `░`) on the window lines — ANSI colors are not applied because Telegram's `<pre>` does not support them.
 
 ```
 ━━ Status ━━
@@ -169,7 +169,7 @@ schtasks /Delete /TN "TokenWeatherBot" /F
 
   All three paths are protected by `SENSITIVE_KEYS` redaction — they don't show up in any output (`status --json` / Telegram responses / logs).
 
-- **Goes through Telegram servers**: usage numbers / account labels / email / token expiry / command response bodies / user_id. The README's promise "tokens never leave the external server" is **scoped to OAuth tokens + Telegram bot tokens** — when the bot is active, metadata flows through Telegram infrastructure.
+- **Goes through Telegram servers**: usage numbers / account labels / email / token expiry / command response bodies / user_id. The README's promise that tokens never leave your machine is **scoped to OAuth tokens + Telegram bot tokens** — when the bot is active, metadata flows through Telegram infrastructure.
 
 ### First-line defenses
 

--- a/docs/telegram-bot.en.md
+++ b/docs/telegram-bot.en.md
@@ -1,0 +1,217 @@
+# Telegram bot integration
+
+> Translated from [telegram-bot.md](./telegram-bot.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+The `@token-weather/telegram` package provides a long-poll daemon that exposes token-weather's `status` / `usage` / `doctor` / `auth list` commands over Telegram. Run the bot locally, and you can send commands from your phone or another desktop and get immediate responses.
+
+> **Trust model summary**: bot token / OAuth tokens are **stored only in local files**. Usage numbers / account labels / command response bodies do flow through Telegram servers. For the full security model see [§Security model](#보안-모델).
+
+## Quick start
+
+```bash
+# 1) Install both packages — cli + telegram
+npm install -g @token-weather/cli @token-weather/telegram
+
+# 2) Create a bot in BotFather → get a token
+#    https://core.telegram.org/bots#how-do-i-create-a-bot
+#    /newbot → choose name + username → copy the token
+
+# 3) Bot token + chat pairing + config save + OS service auto-registration / guidance, all in one command
+token-weather telegram setup
+#    token prompt → getMe validation → click the deep link in the output → (Start button) → pairing complete
+#    → "Auto-install? [Y/n]" → Enter → systemd / launchd / Task Scheduler auto-registered
+
+# 4) (Optional) diagnostics
+token-weather telegram check
+
+# 5) Manual run (when not using an OS service)
+token-weather telegram start
+
+# 6) Remove (undo auto-registration)
+token-weather telegram uninstall-service
+```
+
+## Commands
+
+| Command                                              | Description                                                                                                                                                                                  |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `token-weather telegram setup`                       | Enter bot token → `getMe` validation → **click deep link** or type `/pair <code>` manually → save config (chmod 600) → **OS service auto-register [Y/n]** (falls back to manual instructions on decline) |
+| `token-weather telegram start`                       | Run long-poll daemon in the foreground. Ctrl+C to exit                                                                                                                                       |
+| `token-weather telegram check`                       | Read-only diagnostics of config / token / chmod / linger state                                                                                                                               |
+| `token-weather telegram uninstall-service`           | Remove the OS service registered via `setup` (config / auth.json untouched)                                                                                                                  |
+| `... telegram --help`<br>`... telegram <sub> --help` | Help text for each command                                                                                                                                                                   |
+
+## Chat commands the bot receives
+
+| Telegram command | Behavior (equivalent to `token-weather <cmd>`)                                                                                            |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `/status`        | Mobile-width-friendly compact plain text (HTML `<pre>` block, ≤ 32 columns, includes progress bar)                                        |
+| `/status --json` | `formatStatusJson` result (top-level `command` = "status")                                                                                |
+| `/usage`         | Alias of status — mobile-friendly compact plain text                                                                                      |
+| `/usage --json`  | `formatStatusJson` result (top-level `command` = "usage")                                                                                 |
+| `/doctor`        | Default `runDoctorRoot` output. Arguments / subcommands blocked                                                                           |
+| `/auth_list`     | All providers' stored accounts + claude import section                                                                                    |
+| `/help`          | Plain-text list of available commands (issue #148)                                                                                        |
+| `/start <code>`  | Pairing only (meaningful only during setup). Click the Telegram deep link → bot chat → (Start button if first time) → `/start <code>` is sent |
+| `/pair <code>`   | Pairing only (meaningful only during setup). Manual input fallback                                                                        |
+
+Commands that mention another bot (`/status@OtherBot`) are silently ignored — so in group chats, token-weather won't respond to other bots' commands.
+
+### Autocompletion menu (issue #148)
+
+When `token-weather telegram start` daemon boots, it calls the [Bot API `setMyCommands`](https://core.telegram.org/bots/api#setmycommands) to register the command list with the bot. The user can then type `/` in the chat input, and Telegram clients (mobile / desktop) will pop up an autocompletion menu.
+
+- Registration source: the `BOT_COMMANDS` array in `packages/telegram/src/bot-commands.js`. When adding a new command, update **three places together**: the handler module / the `buildDispatcher()` key / this array — the dispatcher is **not** auto-generated from this array. A unit test guards the drift between the dispatcher key set and `BOT_COMMANDS.command`.
+- If registration fails (network / permission / etc.) the daemon boot continues — the menu is auxiliary, and direct command input keeps working.
+- Registration is idempotent — refreshed on every daemon restart.
+
+Manual registration (if you want to disable auto-registration or preconfigure with a different bot username) is also possible via `/setcommands` in [@BotFather](https://t.me/BotFather).
+
+### `/status` / `/usage` output example (issues #144, #146)
+
+The CLI's desktop boxes (`╭─` / `│` / `╰─`) + 50-column heavy rule break under wrap at mobile widths (~30–40 columns), so the Telegram bot uses `@token-weather/telegram`'s `formatStatusForTelegram` to emit a box-less compact output (line width ≤ 32 columns guideline, timezone omitted).
+
+Issue #146 restored 10-column ASCII progress bars (1/8-precision fractional blocks `█▏▎▍▌▋▊▉` + light shade `░`) on the window lines — ANSI colors are not applied because Telegram's `<pre>` does not support them.
+
+```
+━━ Status ━━
+Codex  enabled
+Claude enabled
+Sync   disabled
+
+━━ Codex ━━
+me@example.com · Pro
+✓ OK (200)
+· primary   ███▊░░░░░░  38%
+  reset 9:42pm
+· secondary ███████▏░░  71%
+  reset Sat 4:42am
+
+━━ Claude ━━
+me@anthropic.example
+✓ OK (200)
+· 5h        █▉░░░░░░░░  19%
+  reset 3pm
+· 7d        ▊░░░░░░░░░   8%
+  reset May 22 3am
+```
+
+Line width: `· ` (2) + label `padEnd(9)` + space + bar (10) + space + pct `padStart(4)` = **27 characters**, well within the 32-column guide. If `usedPercent` is null/NaN, the bar is 10× `░` and pct is `—`.
+
+CLI plain output (`token-weather status` on desktop) and the `--json` contract are unchanged — this is a Telegram-channel-only transformation.
+
+## OS service registration
+
+The last step of `telegram setup` shows a **`Auto-install? [Y/n]`** prompt:
+
+- **Enter / y** (default): token-weather directly writes and activates a systemd unit / launchd plist / Task Scheduler entry (`systemctl --user enable --now` / `launchctl bootstrap` / `schtasks /Create`). On Linux it also runs `loginctl enable-linger` (best-effort).
+- **n**: skip auto-registration → user copies/pastes the manual instructions block below.
+- **systemd / launchctl / schtasks not detected** (WSL / Docker container / Alpine OpenRC etc.): auto-skip + same manual instructions printed.
+- **Path contains whitespace / special characters** (e.g., Windows' `C:\Program Files\nodejs\node.exe`): auto-registration is supported (issue #141). systemd uses `ExecStart="..."` double-quote, launchd plist uses XML entity escape (`& < >` → `&amp; &lt; &gt;`), Windows schtasks uses cmd `\"...\"` — each properly quoted. Windows standard Node install environments can be auto-registered as-is.
+
+To remove later, run `token-weather telegram uninstall-service`. Its scope covers service / linger only (config / auth.json are kept).
+
+### Manual registration (when auto-registration is declined / skipped)
+
+> ⚠ The code blocks below are **structural examples**. Placeholders like `/path/to/node` / `/path/to/token-weather` differ in your environment — **copy the absolute paths from the `telegram setup` output as-is**. Even with whitespace / XML special characters in the path, the setup output already applies OS-specific escapes (`"..."` / `&amp;` / `\"...\"`), so just copy and paste (issue #141).
+
+### Linux (systemd `--user`, no sudo)
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/token-weather-bot.service <<'EOF'
+[Unit]
+Description=Token Weather Telegram bot
+After=network-online.target
+
+[Service]
+ExecStart=/path/to/node /path/to/token-weather telegram start
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now token-weather-bot.service
+# To keep the daemon alive across logouts:
+loginctl enable-linger "$USER"
+```
+
+### macOS (launchd LaunchAgent, no sudo)
+
+After writing `~/Library/LaunchAgents/com.token-weather.bot.plist`:
+
+```bash
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist
+# Stop:
+launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/com.token-weather.bot.plist
+```
+
+The full plist content is whatever `telegram setup` outputs.
+
+### Windows (Task Scheduler, no admin)
+
+```cmd
+schtasks /Create /TN "TokenWeatherBot" /SC ONLOGON /RL LIMITED /TR "\"path\to\node.exe\" \"path\to\token-weather\" telegram start"
+:: Remove:
+schtasks /Delete /TN "TokenWeatherBot" /F
+```
+
+## Security model
+
+### Trust boundaries
+
+- **Stays local** (three separate paths):
+  - **OAuth access / refresh / id tokens** — stored in `~/.config/token-weather/auth.json`. The auth store writes with mode 0600.
+  - **Telegram bot token / allowedUserIds** — under `channels.telegram` in `~/.config/token-weather/config.json`. `telegram setup` applies chmod 600 on a best-effort basis (on OSes where chmod has weak semantics, like Windows, verify via the "config permission" item in `telegram check`).
+  - **Pairing code** — exists only in the terminal and the one-shot pairing daemon's memory during `telegram setup`. Not persisted in config / auth store.
+
+  All three paths are protected by `SENSITIVE_KEYS` redaction — they don't show up in any output (`status --json` / Telegram responses / logs).
+
+- **Goes through Telegram servers**: usage numbers / account labels / email / token expiry / command response bodies / user_id. The README's promise "tokens never leave the external server" is **scoped to OAuth tokens + Telegram bot tokens** — when the bot is active, metadata flows through Telegram infrastructure.
+
+### First-line defenses
+
+- `allowedUserIds` allowlist — even if the bot token is leaked, commands from unregistered users are silently ignored. The bot doesn't even confirm its own existence / activity in response (only a partially masked user_id remains in the logs).
+- Single-instance lock — if another daemon is polling with the same bot token, a 409 Conflict is detected, a friendly notice is printed, and the new instance exits immediately.
+
+### When the bot token is leaked
+
+1. Use `/revoke` in BotFather to invalidate the token immediately (or `/token` to issue a new one).
+2. Update `channels.telegram.botToken` in `~/.config/token-weather/config.json` (or rerun `telegram setup`).
+3. Verify the new token's `getMe` response with `telegram check`.
+
+If the leaked element is a user_id in `allowedUserIds` (shared family / shared account) — remove that user_id from the array and restart the daemon.
+
+### Why the Doctor / auth-list surface is intentionally narrowed
+
+- `/doctor` only exposes the root call — side-effecting options like `--refresh-live` are blocked. Prevents unintended token refresh attempts via remote commands.
+- `/auth_list` also ignores provider filters / `--help`. Only the account list is exposed.
+
+## Limitations / FAQ
+
+### Bot doesn't respond
+
+1. Is the daemon alive? `systemctl --user status token-weather-bot.service` or `ps aux | grep telegram`.
+2. Does the `getMe API` result in `telegram check` show `✓`? If `✗`, suspect token expiry / revoke.
+3. Is your Telegram user_id in `allowedUserIds`? Adding another user means rerunning setup (pairing) or manually editing config and restarting the daemon.
+
+### user_id vs chat_id
+
+token-weather's allowlist is based on `ctx.from.id` (the user's user_id) — the same user can issue commands from DM or group chat. It's not based on `chat.id` (the chat room id), so adding the bot to a group does not let other users in that group issue commands.
+
+### 4096-character limit
+
+The Telegram message limit (4096 characters + HTML entity expansion after escape) is respected with a safety margin via automatic split. If multi-account status output is long, it's split across multiple messages.
+
+### Webhook not supported
+
+Only long-poll is supported. Webhooks (which need a public HTTPS endpoint) are intentionally excluded — impractical for typical local user environments (NAT, dynamic IP).
+
+## See also
+
+- Package: `@token-weather/telegram` (npm)
+- Dependency: `grammy` ^1.42
+- Security reporting: [SECURITY.md](../SECURITY.md)
+- Full API: `import * as telegram from '@token-weather/telegram'` — pairing helpers / OS service templates / handler factories / dispatcher / subcommand entry / formatters / help texts are all exported. For the exact list see [`packages/telegram/src/index.js`](../packages/telegram/src/index.js).

--- a/docs/telegram-bot.en.md
+++ b/docs/telegram-bot.en.md
@@ -33,27 +33,27 @@ token-weather telegram uninstall-service
 
 ## Commands
 
-| Command                                              | Description                                                                                                                                                                                  |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command                                              | Description                                                                                                                                                                                              |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `token-weather telegram setup`                       | Enter bot token → `getMe` validation → **click deep link** or type `/pair <code>` manually → save config (chmod 600) → **OS service auto-register [Y/n]** (falls back to manual instructions on decline) |
-| `token-weather telegram start`                       | Run long-poll daemon in the foreground. Ctrl+C to exit                                                                                                                                       |
-| `token-weather telegram check`                       | Read-only diagnostics of config / token / chmod / linger state                                                                                                                               |
-| `token-weather telegram uninstall-service`           | Remove the OS service registered via `setup` (config / auth.json untouched)                                                                                                                  |
-| `... telegram --help`<br>`... telegram <sub> --help` | Help text for each command                                                                                                                                                                   |
+| `token-weather telegram start`                       | Run long-poll daemon in the foreground. Ctrl+C to exit                                                                                                                                                   |
+| `token-weather telegram check`                       | Read-only diagnostics of config / token / chmod / linger state                                                                                                                                           |
+| `token-weather telegram uninstall-service`           | Remove the OS service registered via `setup` (config / auth.json untouched)                                                                                                                              |
+| `... telegram --help`<br>`... telegram <sub> --help` | Help text for each command                                                                                                                                                                               |
 
 ## Chat commands the bot receives
 
-| Telegram command | Behavior (equivalent to `token-weather <cmd>`)                                                                                            |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `/status`        | Mobile-width-friendly compact plain text (HTML `<pre>` block, ≤ 32 columns, includes progress bar)                                        |
-| `/status --json` | `formatStatusJson` result (top-level `command` = "status")                                                                                |
-| `/usage`         | Alias of status — mobile-friendly compact plain text                                                                                      |
-| `/usage --json`  | `formatStatusJson` result (top-level `command` = "usage")                                                                                 |
-| `/doctor`        | Default `runDoctorRoot` output. Arguments / subcommands blocked                                                                           |
-| `/auth_list`     | All providers' stored accounts + claude import section                                                                                    |
-| `/help`          | Plain-text list of available commands (issue #148)                                                                                        |
+| Telegram command | Behavior (equivalent to `token-weather <cmd>`)                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/status`        | Mobile-width-friendly compact plain text (HTML `<pre>` block, ≤ 32 columns, includes progress bar)                                            |
+| `/status --json` | `formatStatusJson` result (top-level `command` = "status")                                                                                    |
+| `/usage`         | Alias of status — mobile-friendly compact plain text                                                                                          |
+| `/usage --json`  | `formatStatusJson` result (top-level `command` = "usage")                                                                                     |
+| `/doctor`        | Default `runDoctorRoot` output. Arguments / subcommands blocked                                                                               |
+| `/auth_list`     | All providers' stored accounts + claude import section                                                                                        |
+| `/help`          | Plain-text list of available commands (issue #148)                                                                                            |
 | `/start <code>`  | Pairing only (meaningful only during setup). Click the Telegram deep link → bot chat → (Start button if first time) → `/start <code>` is sent |
-| `/pair <code>`   | Pairing only (meaningful only during setup). Manual input fallback                                                                        |
+| `/pair <code>`   | Pairing only (meaningful only during setup). Manual input fallback                                                                            |
 
 Commands that mention another bot (`/status@OtherBot`) are silently ignored — so in group chats, token-weather won't respond to other bots' commands.
 

--- a/packages/agent/test/integration/repo-policy-readme.test.js
+++ b/packages/agent/test/integration/repo-policy-readme.test.js
@@ -83,13 +83,16 @@ describe('repo-policy/readme — 핵심 섹션 존재 (issue #154: 영어 defaul
   }
 });
 
-describe('repo-policy/readme — 외부 문서 링크', () => {
+describe('repo-policy/readme — 외부 문서 링크 (issue #154: 영어 본 정합)', () => {
+  // README.md = 영어 default (Phase 2-1). 영어 본이 있는 외부 docs (Phase 2-2 의
+  // telegram-bot / cli-json-output / provider-notes) 는 .en.md 로, 아직 번역
+  // 안 된 docs (auth-architecture / codebase-guide 등) 는 .md (한글) 그대로.
   const REQUIRED_LINKS = [
     'LICENSE',
     'SECURITY.md',
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
-    'docs/cli-json-output.md',
+    'docs/cli-json-output.en.md',
     'docs/auth-architecture.md',
     'docs/codebase-guide.md',
   ];


### PR DESCRIPTION
## 요약

- Master issue #154 의 **Phase 2-2 — 외부 docs 핵심 3개 영어 번역**.
- 사용자 진입도가 가장 높은 `telegram-bot.md` / `cli-json-output.md` / `provider-notes.md` 의 영어 본 (`.en.md`) 신규.
- npm registry 의 영어 README 에서 외부 docs link 따라가는 영어권 사용자가 한 클릭으로 영어 본 접근 가능.

## 변경 내용

- `docs/telegram-bot.en.md` 신규 (215 줄) — Quick start / 명령 / 채팅 명령 / 자동완성 메뉴 / 출력 예시 / OS service 등록 (자동 + 수동) / 보안 모델 / FAQ
- `docs/cli-json-output.en.md` 신규 (222 줄) — `status --json` stable contract / Top-level shape / field-absence 정책 / providers entry shape / authSource enum / redaction / v0.4.0 alias 제거 / v0.5.0 symmetry migration
- `docs/provider-notes.en.md` 신규 (95 줄) — Codex / Claude 각 provider 의 observed endpoint / client_id / OAuth 흐름 / refresh 동작 / 알려진 limits
- `docs/INDEX.md` 갱신 — 외부 사용자용 표에 '영문' 컬럼 추가. Phase 2-2 의 3개만 영문 link 노출, 나머지 4개는 Phase 2-3 예정 표기
- `.changeset/docs-i18n-external-core.md` — 4 패키지 linked **minor** bump
- prettier 정리 commit 2건 (telegram-bot.en.md + INDEX.md + cli-json-output.en.md 의 표 정렬)

## 변경 이유

PR #156 (Phase 2-1) 에서 README 가 영어 default 로 전환되었지만, 그 README 의 외부 docs 링크 (`docs/cli-json-output.md` 등) 가 한글 본을 가리키고 있어 영어권 사용자가 한글 페이지 진입. 본 PR 로 핵심 3개 docs 의 영어 본 추가 → README 의 link 따라가도 영어 본 (`.en.md`) 으로 한 클릭 가능.

선택 기준: **외부 사용자 진입도 최상위 3개**.
- `telegram-bot.md` — 옵션 패키지 사용자에게 가장 중요한 가이드
- `cli-json-output.md` — 자동화 / 대시보드 통합 사용자가 직접 소비하는 contract 문서
- `provider-notes.md` — OAuth 통합 / observed endpoint 참고 사용자

번역 정책 (CONTRIBUTING §6 + §10 정합):
- source of truth: 한글 (`docs/X.md`). 영문은 번역본.
- 코드 식별자 / 외부 lib name / 경로 / 명령 / JSON shape key / endpoint URL / scope 명 / SENSITIVE_KEYS 항목 — 양쪽 동일.
- 영문 본 상단에 번역 footer (`> Translated from ... last sync 2026-05-20 + CONTRIBUTING §10 ref`).

## 영향 범위

- [ ] `packages/agent`
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (changeset)
- [x] `docs` (3 .en.md 신규 + INDEX.md 갱신)

## 스크린샷 / 데모

각 영문 본 상단 footer 예시:

```
> Translated from [telegram-bot.md](./telegram-bot.md) — last sync 2026-05-20.
> The Korean version is the source of truth; this English version follows it.
> See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
```

INDEX 의 외부 사용자용 표 (Phase 2-2 적용 후):

```
| Document            | 한 줄 요약            | 영문                                       |
| ------------------- | --------------------- | ------------------------------------------ |
| architecture.md     | ...                   | (Phase 2-3 예정)                           |
| auth-architecture.md| ...                   | (Phase 2-3 예정)                           |
| auth-cli.md         | ...                   | (Phase 2-3 예정)                           |
| cli-json-output.md  | ...                   | cli-json-output.en.md                      |
| provider-notes.md   | ...                   | provider-notes.en.md                       |
| telegram-bot.md     | ...                   | telegram-bot.en.md                         |
| typescript-consumers| ...                   | (Phase 2-3 예정)                           |
```

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1116 pass / 0 fail, `npm run lint` clean, `npx prettier --check docs/` 통과
- [x] 필요한 문서 업데이트 반영 — 3개 .en.md + INDEX.md
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only, 코드 / contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 민감값을 redact 했음 — 해당 없음 (docs only, fixture 외 placeholder)

## 리뷰 포인트

- **번역 정확성 (cli-json-output)** — JSON shape contract 문서라 field 이름 / enum value / 예시 코드 정확성이 핵심. v0.4.0 alias 제거 / v0.5.0 symmetry migration 의 before/after 코드 snippet 이 양쪽 정합한지.
- **번역 정확성 (telegram-bot)** — 보안 모델 / 신뢰 경계 섹션이 한글 source 의 의미를 정확히 전달하는지. `chmod 600`, `SENSITIVE_KEYS`, `allowedUserIds` 등 키워드는 원문 그대로.
- **`#보안-모델` anchor 처리** — telegram-bot.en.md 의 trust model summary 에서 `[§Security model](#보안-모델)` 이 한글 anchor 그대로. GitHub 의 markdown anchor 가 한글 헤더에 대해 일관된 slug 를 만들어주므로 영문 본의 `## Security model` 헤더와는 매칭 X. **별도 후속**: 영문 본 anchor 를 `#security-model` 로 갱신 (Phase 2-3 또는 별도 cleanup commit).
- **INDEX 표의 '영문' 컬럼** — Phase 2-2 의 3개만 link, 나머지 4개는 `(Phase 2-3 예정)` 표기. 사용자가 진행 상황 파악 가능.

## 참고 사항

- 관련 master issue: #154
- 다음 PR (Phase 2-3): `auth-architecture.en.md` / `auth-cli.en.md` / `architecture.en.md` / `typescript-consumers.en.md`
- Out of scope:
  - 본 PR 의 anchor 처리 (`#보안-모델` → `#security-model`) 는 cosmetic — 별도 cleanup
  - SECURITY.md 영어화 (Phase 2-4)
  - CONTRIBUTING §10 의 운영 절차 / test 가드 보강 (Phase 2-4)
  - 내부 docs (codebase-guide / release-policy / auth-store-schema / claude-oauth-plan) 한글 유지
