### PR TITLE
[docs] auth-architecture / auth-cli / architecture / typescript-consumers 영어 번역 (issue #154)

### DIFF
--- a/.changeset/docs-i18n-external-extra.md
+++ b/.changeset/docs-i18n-external-extra.md
@@ -1,0 +1,43 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+docs(repo): 외부 가시 docs 보조 4개 영어 번역 — architecture / auth-architecture /
+auth-cli / typescript-consumers (issue #154 Phase 2-3).
+
+Phase 2-1 (README dual) + Phase 2-2 (외부 핵심 3개) 에 이어, 외부 가시 docs 의
+나머지 4개를 영어 번역. 외부 사용자 진입도 모든 외부 docs 영어 본 보유 — README
+의 영어 본 ToC link 가 7개 docs 모두 `.en.md` 를 가리킴.
+
+**변경 사항**:
+
+- `docs/architecture.en.md` 신규 (77 lines) — 고수준 구성 / CLI agent / services /
+  provider adapters / schemas / 인증 계층 / 확장 후보
+- `docs/auth-architecture.en.md` 신규 (184 lines) — 인증 흐름 4종 / credential
+  source 우선순위 / 저장소 설계 / 보안 원칙 / 자동 refresh / Codex / Claude
+  endpoint 검증 현황 / 운영 방안
+- `docs/auth-cli.en.md` 신규 (204 lines) — auth login / list / logout / import +
+  doctor (--dedupe / --apply / --backfill-account-id) / multi-account / port
+  conflict / 자동 refresh / 예시 시나리오
+- `docs/typescript-consumers.en.md` 신규 (116 lines) — d.ts emission 정책 / 현재
+  d.ts 품질 / manual sanity check 절차 / 한계
+- `docs/INDEX.md` 갱신 — 외부 사용자용 표 7행 모두 영문 본 노출
+- `README.md` (영어) 본문 / ToC 의 link 4개 갱신: architecture / auth-architecture /
+  auth-cli / typescript-consumers → .en.md
+- `repo-policy-readme.test.js` REQUIRED_LINKS 갱신: `docs/auth-architecture.md` →
+  `docs/auth-architecture.en.md`
+
+**번역 정책 정합** (CONTRIBUTING §6 + §10):
+
+- 명령 / 옵션 / endpoint URL / scope / client_id / 경로 / 환경변수 — 양쪽 동일
+- 표 / 단계 흐름 / 예시 코드 — 한글 source 와 동일 구조
+- 영문 본 상단 번역 footer + CONTRIBUTING §10 ref
+
+**Non-goal** (Phase 2-4 마무리):
+
+- SECURITY.md 영어화
+- CONTRIBUTING §10 의 운영 절차 보강 (test 가드 / dual sync 검증)
+- 내부 docs (codebase-guide / release-policy / auth-store-schema / claude-oauth-plan) 한글 유지

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Shape / redaction rules / limits: [docs/cli-json-output.en.md](./docs/cli-json-o
 - raw prompts / responses / transcripts are never sent outside under any circumstance
 - observed `client_id` has been used without a feature gate since v0.2.0 (every publish is still verified by npm Trusted Publishing OIDC + SLSA provenance). Until an official client is registered, this is experimentally operated
 
-Details: [docs/auth-architecture.md](./docs/auth-architecture.md), [SECURITY.md](./SECURITY.md).
+Details: [docs/auth-architecture.en.md](./docs/auth-architecture.en.md), [SECURITY.md](./SECURITY.md).
 
 ## Security reporting
 
@@ -146,13 +146,13 @@ Quick entry point — [docs/INDEX.md](./docs/INDEX.md) (categorized).
 
 **For end users** (referred to directly after npm install):
 
-- [docs/architecture.md](./docs/architecture.md) — high-level structure summary
-- [docs/auth-architecture.md](./docs/auth-architecture.md) — auth / token / source priority details
-- [docs/auth-cli.md](./docs/auth-cli.md) — auth CLI commands / policy
+- [docs/architecture.en.md](./docs/architecture.en.md) — high-level structure summary
+- [docs/auth-architecture.en.md](./docs/auth-architecture.en.md) — auth / token / source priority details
+- [docs/auth-cli.en.md](./docs/auth-cli.en.md) — auth CLI commands / policy
 - [docs/cli-json-output.en.md](./docs/cli-json-output.en.md) — `--json` stable contract + redaction rules
 - [docs/provider-notes.en.md](./docs/provider-notes.en.md) — per-provider observed endpoint / client_id
 - [docs/telegram-bot.en.md](./docs/telegram-bot.en.md) — Telegram bot optional package (`@token-weather/telegram`) guide
-- [docs/typescript-consumers.md](./docs/typescript-consumers.md) — d.ts / import patterns for TypeScript users
+- [docs/typescript-consumers.en.md](./docs/typescript-consumers.en.md) — d.ts / import patterns for TypeScript users
 
 **For contributors / maintainers** (contributors are Korean-based — kept in Korean only):
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,15 +14,15 @@ token-weather 의 모든 문서 entry point. 카테고리 / 사용자 타입 별
 
 운영 / 자동화 / 통합 시 사용자가 직접 보는 문서.
 
-| 문서                                                 | 한 줄 요약                                                                    | 영문                                             |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ |
-| [architecture.md](./architecture.md)                 | 패키지 / 모듈 구조의 고수준 요약                                              | (Phase 2-3 예정)                                 |
-| [auth-architecture.md](./auth-architecture.md)       | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback)      | (Phase 2-3 예정)                                 |
-| [auth-cli.md](./auth-cli.md)                         | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책        | (Phase 2-3 예정)                                 |
-| [cli-json-output.md](./cli-json-output.md)           | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION             | [cli-json-output.en.md](./cli-json-output.en.md) |
-| [provider-notes.md](./provider-notes.md)             | provider 별 observed endpoint / client_id / refresh 동작                      | [provider-notes.en.md](./provider-notes.en.md)   |
-| [telegram-bot.md](./telegram-bot.md)                 | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 | [telegram-bot.en.md](./telegram-bot.en.md)       |
-| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성                          | (Phase 2-3 예정)                                 |
+| 문서                                                 | 한 줄 요약                                                                    | 영문                                                       |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| [architecture.md](./architecture.md)                 | 패키지 / 모듈 구조의 고수준 요약                                              | [architecture.en.md](./architecture.en.md)                 |
+| [auth-architecture.md](./auth-architecture.md)       | 인증 / token / source 우선순위 상세 (multi-account / refresh / fallback)      | [auth-architecture.en.md](./auth-architecture.en.md)       |
+| [auth-cli.md](./auth-cli.md)                         | `auth login` / `auth list` / `auth logout` / `auth import` 명령 + 정책        | [auth-cli.en.md](./auth-cli.en.md)                         |
+| [cli-json-output.md](./cli-json-output.md)           | `status --json` stable contract + redaction 규약 + SCHEMA_VERSION             | [cli-json-output.en.md](./cli-json-output.en.md)           |
+| [provider-notes.md](./provider-notes.md)             | provider 별 observed endpoint / client_id / refresh 동작                      | [provider-notes.en.md](./provider-notes.en.md)             |
+| [telegram-bot.md](./telegram-bot.md)                 | `@token-weather/telegram` 옵션 패키지 — 봇 setup / 핸들러 / OS service 가이드 | [telegram-bot.en.md](./telegram-bot.en.md)                 |
+| [typescript-consumers.md](./typescript-consumers.md) | TypeScript 사용자용 d.ts / import 패턴 / 타입 안정성                          | [typescript-consumers.en.md](./typescript-consumers.en.md) |
 
 ## 기여자 / 운영자용 — contributor 한국 기반, 한글 only 유지
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1,0 +1,79 @@
+# Architecture
+
+> Translated from [architecture.md](./architecture.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+Detailed codebase rules live in `docs/codebase-guide.md`. This document covers only the high-level composition.
+
+## Summary
+
+A local CLI agent-centric architecture. Without any external auth store (OpenClaw, etc.) dependency, it independently handles authentication, token storage / refresh, and usage queries.
+
+```
+[token-weather CLI]
+  ├─ Auth Commands (login / list / logout / import)
+  ├─ Auth Broker (OAuth localhost callback, manual paste fallback, PKCE S256)
+  ├─ Credential Store (auth.json, 0600)
+  ├─ Provider Registry (services/provider-registry.js)
+  │   ├─ Codex provider
+  │   └─ Claude provider
+  ├─ Provider Adapters (packages/provider-adapters/src/{codex,claude})
+  │   └─ Shared OAuth helpers (packages/provider-adapters/src/shared/)
+  └─ Schemas (packages/schemas — usage snapshot / event JSON Schema)
+```
+
+## Main components
+
+### CLI Agent (`packages/agent`)
+
+- `status`, `usage`, `doctor`, `config init`
+- `auth login/list/logout/import`
+- Multi-account support
+  - Store / query multiple real accounts per provider (status queries all in parallel by default)
+  - `auth login --label <name>` attaches a user-friendly label
+  - `status --account <email|accountKey|label>` filters
+  - `config.json defaults.profiles.{provider}` sets a default filter
+- `login-runner` (`cli/login-runner.js`) unifies the per-provider OAuth flow
+
+### Services (`packages/agent/src/services`)
+
+- `status-service.js` — loads config + iterates the provider registry
+- `provider-registry.js` — registers providers via the `PROVIDER_REGISTRY` array
+- `{provider}-provider.js` — snapshot builder for each provider
+
+When adding a new provider, refer to the `codebase-guide.md §11` checklist.
+
+### Provider Adapters (`packages/provider-adapters`)
+
+- `shared/` — provider-neutral OAuth helpers
+  - `buildOAuthAuthorizationUrl` — composes the authorize URL
+  - `postToTokenEndpoint` — POST to the token endpoint (form/json, timeout, error normalization)
+  - `fetchWithTimeout` — shared wrapper based on AbortController
+- `codex/` — Codex (OpenAI) auth + usage
+- `claude/` — Claude (Anthropic) auth + usage
+
+Each provider follows the same file-composition pattern (constants / build-authorization-url / exchange-code / refresh-token / fetch-usage). For details see `docs/codebase-guide.md §3`.
+
+### Schemas (`packages/schemas`)
+
+- `usage-snapshot.schema.json`
+- `usage-event.schema.json`
+- Key fields: `source`, `authType`, `confidence`, `usageWindows`, `status.bucket`
+- `validateUsageSnapshot` / `validateUsageEvent` — zero-dep runtime validators
+- Auto-validation at the `buildUsageSnapshot` exit (soft enforcement — on invalid, warns + lowers confidence)
+
+### Auth layer
+
+- Default: localhost callback OAuth (PKCE S256)
+- Fallback: manual paste (Codex only)
+- Import: `auth import openclaw` (Codex) / `auth import claude` (Claude)
+- Lower priority: device code (not implemented)
+- Credential source priority: `agent-store` > `{provider}-cli-import` or `openclaw-import`
+
+Details: `docs/auth-architecture.md`, `docs/auth-cli.md`.
+
+## Future directions
+
+- Backend API: normalized event collection, direct provider polling, aggregated state
+- Web dashboard: overview, provider/account detail, timeline
+- Keychain integration
+- Additional providers (e.g., Gemini, Perplexity) — follow `codebase-guide.md §11`

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -69,7 +69,7 @@ Each provider follows the same file-composition pattern (constants / build-autho
 - Lower priority: device code (not implemented)
 - Credential source priority: `agent-store` > `{provider}-cli-import` or `openclaw-import`
 
-Details: `docs/auth-architecture.md`, `docs/auth-cli.md`.
+Details: `docs/auth-architecture.en.md`, `docs/auth-cli.en.md`.
 
 ## Future directions
 

--- a/docs/auth-architecture.en.md
+++ b/docs/auth-architecture.en.md
@@ -20,7 +20,7 @@ The CLI agent independently handles authentication, token storage, refresh, and 
   └─ Usage / Event Pipeline
 ```
 
-The default runtime path is the agent's own store; the OpenClaw dependency has been removed. Legacy auth-profiles can only be migrated via `auth import openclaw`.
+The default runtime path is the agent's own store; the OpenClaw dependency has been removed. The `auth import` command currently supports only `claude` — legacy OpenClaw `auth-profiles` are not absorbed by an import command. When there is no Codex account in `agent-store`, the status snapshot uses them as a read-only fallback source (`openclaw-import`) only. For the full flow, see the `## import` section in [auth-cli.en.md](./auth-cli.en.md).
 
 ## Auth flow
 
@@ -39,11 +39,12 @@ Per-provider callback paths:
 - Codex: `http://localhost:<port>/auth/callback`
 - Claude: `http://localhost:<port>/callback`
 
-### 2. Manual paste (Codex-only fallback)
+### 2. Manual paste (Codex / Claude shared fallback)
 
 - Paste the whole callback URL
 - Use `--no-open` to prevent browser auto-open
 - For remote / SSH environments with limited localhost access
+- Provider-agnostic — `login-runner`'s `runManualPasteFlow` extracts the OAuth `code` for both providers through the same path
 
 ### 3. Claude CLI credential import (Claude only)
 
@@ -108,7 +109,7 @@ The auth broker is shared; per-provider strategy is defined by the adapter:
 token-weather auth login <codex|claude> [--mock] [--port N] [--timeout SEC] [--manual] [--no-open]
 token-weather auth list
 token-weather auth logout <provider> [--account <id>]
-token-weather auth import <openclaw|claude>
+token-weather auth import claude
 token-weather doctor
 token-weather doctor codex [--refresh-live] [--account <id>]
 token-weather doctor claude [--refresh-live]

--- a/docs/auth-architecture.en.md
+++ b/docs/auth-architecture.en.md
@@ -1,0 +1,186 @@
+# Auth architecture
+
+> Translated from [auth-architecture.md](./auth-architecture.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+## Goals
+
+The CLI agent independently handles authentication, token storage, refresh, and usage without depending on any external auth store (OpenClaw, etc.).
+
+## Current composition
+
+```text
+[token-weather CLI]
+  ├─ Auth Commands (login / list / logout / import)
+  ├─ Auth Broker
+  │   ├─ OAuth localhost callback flow (shared by Codex / Claude)
+  │   ├─ Manual paste fallback (Codex)
+  │   └─ Device code fallback (not implemented, lower priority)
+  ├─ Credential Store (~/.config/token-weather/auth.json, 0600)
+  ├─ Provider Adapters (codex / claude)
+  └─ Usage / Event Pipeline
+```
+
+The default runtime path is the agent's own store; the OpenClaw dependency has been removed. Legacy auth-profiles can only be migrated via `auth import openclaw`.
+
+## Auth flow
+
+### 1. Localhost callback OAuth (default)
+
+1. `token-weather auth login <codex|claude>`
+2. Start a temporary local server (`127.0.0.1:<port>`)
+3. Generate PKCE (S256) / state
+4. Print an authorize URL for the browser (does not auto-open)
+5. User completes login → provider sends `code` back via the localhost callback
+6. POST `authorization_code` grant to the token endpoint (default behavior — with `--mock`, only a mock account is stored)
+7. Save access/refresh tokens in the agent-store
+
+Per-provider callback paths:
+
+- Codex: `http://localhost:<port>/auth/callback`
+- Claude: `http://localhost:<port>/callback`
+
+### 2. Manual paste (Codex-only fallback)
+
+- Paste the whole callback URL
+- Use `--no-open` to prevent browser auto-open
+- For remote / SSH environments with limited localhost access
+
+### 3. Claude CLI credential import (Claude only)
+
+`token-weather auth import claude` copies the OAuth tokens from `~/.claude/.credentials.json` into the agent-store. A fast path usable without any network call.
+
+### 4. Device code flow (not implemented, lower priority)
+
+## Credential source priority
+
+### Codex
+
+1. `agent-store` (a real token stored via auth login)
+2. `openclaw-import` (legacy OpenClaw auth-profiles.json)
+
+### Claude
+
+1. `agent-store` (entries stored via `auth login claude` or `auth import claude`)
+2. `claude-cli-import` (real-time reader of `~/.claude/.credentials.json`)
+
+## Storage design principles
+
+- `~/.config/token-weather/auth.json`, permissions `0600`
+- Designed so that normalized auth metadata and sensitive tokens are logically separable
+- Can later be extended to a keychain
+- Refresh tokens / session cookies must not be uploaded to external servers
+
+## Security principles
+
+- The callback server binds only to `127.0.0.1`
+- State verification is mandatory (CSRF)
+- PKCE S256
+- Refresh tokens are stored at the minimum required scope
+- Access / refresh tokens must never be printed to logs
+- Don't store sensitive auth values from raw provider responses
+
+## Auto-refresh flow for usage/status
+
+`status` / `usage` are more than simple queries — accounts in the agent-store go through a shared auto-refresh orchestration.
+
+1. Collect candidate accounts / sources per provider.
+2. Auth source priority is decided on the unfiltered baseline.
+3. Re-apply `--account` / config filters on top of the chosen source for the actual target.
+4. If an agent-store account's `expiresAt` has already expired, try a preflight refresh before calling the provider.
+5. If the first usage call fails for auth reasons (`status.bucket === 'auth'`), refresh and retry exactly once.
+6. A refresh failure is recorded per-account; other accounts' queries continue.
+7. Import sources (`openclaw-import`, `claude-cli-import`) are excluded from auto-refresh because they have no store update path.
+
+## Role of the provider adapter
+
+The auth broker is shared; per-provider strategy is defined by the adapter:
+
+- authorize / token endpoint
+- observed client_id
+- scopes / extra params
+- redirect_uri format (callback path)
+- refresh rotation policy
+- account identification rule
+
+## CLI
+
+```text
+token-weather auth login <codex|claude> [--mock] [--port N] [--timeout SEC] [--manual] [--no-open]
+token-weather auth list
+token-weather auth logout <provider> [--account <id>]
+token-weather auth import <openclaw|claude>
+token-weather doctor
+token-weather doctor codex [--refresh-live] [--account <id>]
+token-weather doctor claude [--refresh-live]
+token-weather status | usage
+```
+
+## Verification status — Codex OAuth endpoints
+
+### Verified
+
+- authorize: `https://auth.openai.com/oauth/authorize`
+- token: `https://auth.openai.com/oauth/token`
+- callback: `http://localhost:1455/auth/callback`
+- JWT issuer: `https://auth.openai.com`
+- PKCE S256, state verification, refresh rotation: confirmed with a real token
+
+### Observed (not officially confirmed)
+
+- client_id: `app_EMoamEEZ73f0CkXaXp7hrann` (observed in a local JWT payload)
+- extra authorize params: `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`, `originator=pi`
+
+### Unconfirmed
+
+- Whether `client_secret` is required (currently assumed public client)
+- General rule for the refresh-token rotation policy
+- Network-call timeout / abort handling (issue #7)
+
+## Verification status — Claude OAuth endpoints
+
+### Verified (with real network calls)
+
+- usage: `GET https://api.anthropic.com/api/oauth/usage` (Bearer + anthropic-version + anthropic-beta) → 200 OK
+- refresh: `POST https://platform.claude.com/v1/oauth/token` (`grant_type=refresh_token`, JSON body) → confirmed standard OAuth error response structure
+- Full independent OAuth flow: browser login → callback → `authorization_code` token exchange → agent-store save → usage endpoint 200 OK — confirmed end-to-end
+
+### Observed (extracted from strings in the Claude Code v2.1.107 binary)
+
+- authorize: `https://claude.com/cai/oauth/authorize` (claude.ai user OAuth path)
+- token: `https://platform.claude.com/v1/oauth/token`
+- manual redirect: `https://platform.claude.com/oauth/code/callback`
+- client_id: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+- scopes: `org:create_api_key user:profile user:inference`
+
+### Claude observation-based notices
+
+- The authorize URL requires an additional `code=true` parameter (an extension outside the OAuth spec)
+- The token endpoint requires a JSON body (form-urlencoded gets a Claude API error)
+- The `authorization_code` grant requires a `state` field in the body
+- The redirect_uri path is `/callback` (different from Codex's `/auth/callback`)
+
+### Unconfirmed
+
+- Whether `client_secret` is required (assumed public client)
+- Refresh-token rotation policy
+- Whether other client_id values exist (`22422756-...` appears to be local-oauth only)
+
+## Auth default
+
+For both Codex and Claude, `auth login` defaults to a real OAuth token exchange (POST token endpoint → save access/refresh token). Use `--mock` opt-in to only save a mock account. The `exchange*` / `refresh*` functions in the provider-adapters library can also be called directly without a feature gate — the `allowLiveExchange` parameter was removed in #97.
+
+## Operations
+
+- Token storage: `auth.json` + `0600` (default path `~/.config/token-weather/`)
+- Multi-account: auto-select by `lastUsedAt` + override with `--account`
+- On callback port conflict: try up to 3 alternative ports starting from the default → switch to manual paste on failure (Codex)
+- Timeout: `--timeout <seconds>` (default 120s)
+- Device code is a lower-priority investigation item
+
+## Next-step candidates
+
+- Network-call timeout / abort (Codex/Claude shared, issue #7)
+- Investigate revoke endpoint support (server-side invalidation on logout)
+- Claude Phase 4 — session cookie fallback (optional, issue #14)
+- Keychain integration
+- Device code flow

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -18,7 +18,7 @@ CLI agent가 외부 auth store(OpenClaw 등)에 의존하지 않고 독립적으
   └─ Usage / Event Pipeline
 ```
 
-runtime 기본 경로는 agent 자체 store이며, OpenClaw 의존은 제거되었다. 기존 auth-profiles는 `auth import openclaw`로 migration만 가능하다.
+runtime 기본 경로는 agent 자체 store 이며, OpenClaw 의존은 제거되었다. `auth import` 명령은 현재 `claude` 만 지원하고, 기존 OpenClaw auth-profiles 는 별도 import 명령으로 흡수되지 않는다 — `agent-store` 에 Codex 계정이 없을 때 status snapshot 이 read-only fallback source (`openclaw-import`) 로만 사용한다. 자세한 흐름은 [auth-cli.md](./auth-cli.md) `## import` 섹션 참고.
 
 ## 인증 흐름
 
@@ -37,11 +37,12 @@ provider별 callback path:
 - Codex: `http://localhost:<port>/auth/callback`
 - Claude: `http://localhost:<port>/callback`
 
-### 2. Manual paste (Codex 전용 fallback)
+### 2. Manual paste (Codex / Claude 공통 fallback)
 
 - callback URL 전체를 붙여넣기
-- `--no-open`으로 브라우저 자동 오픈 방지
-- localhost 접근이 제한된 원격/SSH 환경에서 사용
+- `--no-open` 으로 브라우저 자동 오픈 방지
+- localhost 접근이 제한된 원격 / SSH 환경에서 사용
+- provider 무관 — `login-runner` 의 `runManualPasteFlow` 가 양쪽 provider 의 OAuth `code` 추출을 동일 흐름으로 처리
 
 ### 3. Claude CLI credential import (Claude 전용)
 
@@ -106,7 +107,7 @@ auth broker는 공통이지만, provider별 전략은 adapter가 정의한다:
 token-weather auth login <codex|claude> [--mock] [--port N] [--timeout SEC] [--manual] [--no-open]
 token-weather auth list
 token-weather auth logout <provider> [--account <id>]
-token-weather auth import <openclaw|claude>
+token-weather auth import claude
 token-weather doctor
 token-weather doctor codex [--refresh-live] [--account <id>]
 token-weather doctor claude [--refresh-live]

--- a/docs/auth-cli.en.md
+++ b/docs/auth-cli.en.md
@@ -1,0 +1,206 @@
+# Auth CLI interface
+
+> Translated from [auth-cli.md](./auth-cli.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+This document summarizes `token-weather`'s auth-related CLI commands and operational policy.
+
+## Command structure
+
+```text
+token-weather auth <subcommand> [provider] [options]
+token-weather doctor [provider] [options]
+```
+
+## login
+
+```bash
+token-weather auth login codex   [--manual] [--no-open] [--port N] [--timeout SEC] [--mock]
+token-weather auth login claude  [--manual] [--no-open] [--port N] [--timeout SEC] [--mock]
+```
+
+Behavior:
+
+- Based on localhost callback OAuth (PKCE S256 + state)
+- **Default path is a real OAuth token exchange** — POST to the provider token endpoint and store access/refresh tokens
+- With `--mock`, only a mock account is stored (no token endpoint call — for tests / experiments)
+- On success, tokens are stored in the agent-store (`auth.json`)
+
+Options:
+
+- `--mock`: store only a mock account without calling the token endpoint (testing / experiments)
+- `--manual`: manually paste callback URL / code (SSH / containers / port-conflict environments)
+- `--no-open`: don't auto-launch the browser
+- `--port N`: specify the localhost callback port (integer 0–65535). Out-of-range values print a warning and abort login.
+- `--timeout SEC`: callback wait time (default 120s). Must be a positive integer; otherwise warn and abort.
+- `--label <name>`: attach a label to the stored account. Later referenced via `--account <name>`.
+- `--keep-legacy`: keep, rather than auto-remove, legacy `accountKey` entries with the same sub/email as the new token. Default is auto-cleanup.
+
+Per-provider callback paths:
+
+- Codex: `/auth/callback`
+- Claude: `/callback`
+
+## list
+
+```bash
+token-weather auth list
+token-weather auth list openai-codex
+token-weather auth list claude
+```
+
+Output fields: provider, accountKey, email, label, source, authType, status, mock flag, refresh availability, expiresAt, createdAt, updatedAt.
+
+For Claude, both agent-store accounts and the `~/.claude/.credentials.json` import source are displayed.
+
+## logout
+
+```bash
+token-weather auth logout <provider>
+token-weather auth logout <provider> --account <email | accountKey | label>
+```
+
+- Removes the account from the local auth store
+- `--account` accepts email / accountKey / label (case-insensitive)
+- Provider-side revoke endpoint call is not implemented (follow-up)
+
+## import
+
+```bash
+token-weather auth import claude     # ~/.claude/.credentials.json → agent-store
+```
+
+- Currently the only supported import provider is `claude`. Other inputs exit with the message `import is currently only supported for claude`.
+- For **migration / absorption**, not the default runtime path
+- Claude import is a fast path that copies the CLI credential as-is (no network call)
+- OpenClaw auth-profiles data is not absorbed by the `auth import` command, but when there is no Codex account in `agent-store`, the status snapshot automatically falls back to the `openclaw-import` source as read-only (see "Credential source priority" in `docs/auth-architecture.md`).
+
+## doctor
+
+```bash
+token-weather doctor                        # Common state check
+token-weather doctor codex                  # Codex account / refresh viability check
+token-weather doctor codex  --refresh-live  # Real refresh POST
+token-weather doctor codex  --account <id>  # Target a specific account
+token-weather doctor claude                 # Claude credential + live usage check
+token-weather doctor claude --refresh-live  # Claude refresh POST
+token-weather doctor claude --refresh-live --account <id>  # Target a specific account
+```
+
+Check items:
+
+- Existence of auth store / credential files
+- The account that would be selected (agent-store > import priority)
+- Whether `expiresAt` is imminent
+- Refresh viability (`refreshToken` present + not mock)
+- Summary of the live usage endpoint response
+- With `--refresh-live`, run a real refresh call and show the result
+
+`doctor --refresh-live` is a manual diagnostic / verification path. It operates separately from the auto-refresh in `status` / `usage`.
+
+### `--dedupe` (issue #37)
+
+Cleans up stale records sharing the same OAuth subject (sub or email). Retroactively cleans up legacy `accountKey`s accumulated before the auto-cleanup at login time (PR #38) and cases where `id_token` parsing failed partially.
+
+```bash
+token-weather doctor codex  --dedupe                              # dry-run: print candidates only
+token-weather doctor codex  --dedupe --apply                      # actually remove
+token-weather doctor codex  --dedupe --backfill-account-id        # dry-run including backfill candidates
+token-weather doctor codex  --dedupe --backfill-account-id --apply  # actually apply
+token-weather doctor claude --dedupe ...                          # same options
+```
+
+Behavior:
+
+- `--dedupe` alone: print duplicate groups + keep/remove candidates to the console only (no changes to auth.json)
+- `--dedupe --apply`: keep one primary per group and remove the rest via `removeProviderAccount`
+- `--backfill-account-id`: also handle records with an empty `accountId` that could be filled from `raw.idToken`'s `sub`
+
+Primary selection priority (lower is kept):
+
+1. The side with `accountId` set
+2. `status === 'active'` (vs `disabled`)
+3. `source === 'agent-store'` (vs `claude-cli-import` / `manual` etc.)
+4. Most recent `updatedAt`
+5. Lexicographic `accountKey` (stable sort)
+
+Filters:
+
+- Records with `source === 'manual'` or `raw.mock === true` are excluded from grouping
+- Synthetic emails (`live-*@codex.openai.com`) are excluded from email-based matching
+
+Interaction:
+
+- If `--account` and `--dedupe` are passed together, `--account` is ignored and all accounts are inspected (with a warning)
+- If `--dedupe` and `--refresh-live` come together, `--dedupe` takes precedence and only dedupe runs
+
+Safety guidance:
+
+- Always dry-run first (`--dedupe` alone) to review candidates, then `--apply`
+- Once removed, a record is not auto-recoverable — back up `~/.config/token-weather/auth.json` beforehand if needed
+- v1 runs `doctor codex` / `doctor claude` separately — cross-provider unified dedupe is not supported
+
+## Port-conflict policy (Codex)
+
+- Default port: `1455`
+- On conflict, try `1456`, `1457` in order, up to 3 attempts
+- If all 3 fail → auto-switch to manual paste mode
+- When `--port` is explicit, only that port is tried; error on failure
+
+Claude uses the same `resolveCallbackPort` logic, but the callback path differs.
+
+## Auto-refresh policy for status / usage
+
+- Targets are **agent-store real accounts only**.
+- For access tokens whose `expiresAt` has already passed, try a preflight refresh before calling the provider.
+- If the first provider response normalizes to an auth failure (`status.bucket === 'auth'`), refresh and retry exactly once.
+- A refresh failure is recorded as a usage failure for that account; other accounts' queries continue.
+- Import sources (`openclaw-import`, `claude-cli-import`) are excluded from auto-refresh because they have no store update path.
+- Source precedence is decided first on the unfiltered baseline; the actual target re-applies `--account` / config filters on top of the chosen source.
+
+## Multi-account policy
+
+- 1 account: auto-select
+- Multiple accounts: pick the active account with the most recent `lastUsedAt`
+- `--account` lets you override explicitly (email or accountKey)
+
+## UX principles
+
+- Keep default commands as short as possible
+- Open up detailed control via options
+- On failure, guide the next action rather than printing a plain error
+- Provide a clear fallback path for headless / remote environments
+- Multi-account works via auto + explicit override
+
+## Example scenarios
+
+### Desktop: Claude independent OAuth
+
+```bash
+token-weather auth login claude
+# authorize URL printed → open in the browser
+# Login complete → localhost callback received → token saved
+token-weather status
+```
+
+### Desktop: Claude fast import
+
+```bash
+# When already logged in via the Claude CLI
+token-weather auth import claude
+token-weather status
+```
+
+### SSH / remote: Codex manual
+
+```bash
+token-weather auth login codex --manual --no-open
+# Follow the prompt: open the URL manually in the browser → paste the entire returned URL
+```
+
+## Open questions
+
+- Whether `client_secret` is required (both Codex / Claude)
+- Scope of revoke-endpoint support (server-side invalidation on logout)
+- Whether to introduce the device code flow
+- Keychain integration
+- Whether to restore the `auth import openclaw` command — currently not implemented (only claude is supported). The status snapshot reads OpenClaw data as a fallback source, but the imperative import path is a follow-up decision.

--- a/docs/typescript-consumers.en.md
+++ b/docs/typescript-consumers.en.md
@@ -1,0 +1,118 @@
+# TypeScript consumers guide
+
+> Translated from [typescript-consumers.md](./typescript-consumers.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
+
+Token Weather packages are written in JS + JSDoc, but `.d.ts` files generated via `tsc --emitDeclarationOnly` are shipped alongside on publish. Importing them directly into a TypeScript project gives you autocomplete and type inference out of the box.
+
+## Usage
+
+```bash
+npm install @token-weather/cli
+# or (for library-only usage)
+npm install @token-weather/schemas @token-weather/provider-adapters
+```
+
+```ts
+import { getStatusSnapshot } from '@token-weather/cli';
+import { validateUsageSnapshot, SCHEMA_VERSION } from '@token-weather/schemas';
+import { fetchClaudeUsage } from '@token-weather/provider-adapters';
+
+const snapshot = await getStatusSnapshot({ providerFilter: 'claude' });
+//    ^? StatusSnapshot — schemaVersion / configPath / providers / claude? / ...
+
+const result = validateUsageSnapshot(payload);
+//    ^? { valid: boolean; errors: string[] }
+```
+
+> **Import-path convention**: the type contract guaranteed by this PR is based on **each package's root entry** (`./dist/types/index.d.ts` as pointed to by `package.json::types`). All examples above import from the root of `@token-weather/{cli,schemas,provider-adapters}`. **Subpath imports** (forms like `@token-weather/provider-adapters/src/claude/fetch-claude-usage.js`) work, but they are not included in this PR's type contract; if `exports` / `typesVersions` are introduced later, a separate design is needed. For stable use, prefer root imports.
+
+## Type-shipping policy
+
+- One build step: `tsc --emitDeclarationOnly --allowJs --declaration`.
+- Each package's `dist/types/index.d.ts` is exposed as `package.json::types`.
+- On `npm publish`, the `files` whitelist includes `dist/types` so the tarball includes it automatically.
+- The source stays in JS + JSDoc — no TypeScript conversion.
+
+## Current d.ts quality
+
+Five core exports were JSDoc-enriched in this PR (#73) so they infer accurate types:
+
+- `getStatusSnapshot` — `Promise<StatusSnapshot>`
+- `runCli` — `(argv: string[]) => Promise<void>`
+- `formatStatusJson` — `snapshot` / `meta` params specified as inline shapes
+- `fetchClaudeUsage` — `Promise<{ source, authType, confidence, usageWindows, ... }>`
+- `exchangeClaudeAuthorizationCode` — `Promise<{ accessToken, refreshToken, idToken, ... }>`
+
+Other exports (e.g., `auth/`, `codex-provider`, some helpers) have partial JSDoc and may infer to `any` or a meaningless `Promise<object>`. Planned to be improved incrementally in follow-up chore PRs.
+
+PRs that add new token-bearing fields to provider adapters / the auth schema should also enrich JSDoc, so that d.ts quality doesn't degrade (see `docs/codebase-guide.md`).
+
+## Manual sanity check procedure (for maintainers)
+
+> **Automated check**: steps 1–2 below (pack + temp install) are automatically performed on every PR in CI by [`scripts/install-smoke.sh`](../scripts/install-smoke.sh) (introduced in #75). This procedure is for when you want a person to verify the **type-inference quality** through steps 3–5 (`tsc --noEmit` + IDE autocomplete).
+
+A manual check that import / inference works in an external TypeScript project just before publish:
+
+```bash
+# 1. Create tarballs
+npm pack --workspace=@token-weather/cli
+npm pack --workspace=@token-weather/provider-adapters
+npm pack --workspace=@token-weather/schemas
+# → token-weather-{cli,provider-adapters,schemas}-0.1.0.tgz are created
+
+# 2. Minimal TS project in a temp directory
+TMP=$(mktemp -d -t tw-ts-sanity-XXXXXX)
+cd "$TMP"
+npm init -y
+npm install typescript --save-dev
+npm install /path/to/token-weather-cli-0.1.0.tgz \
+            /path/to/token-weather-provider-adapters-0.1.0.tgz \
+            /path/to/token-weather-schemas-0.1.0.tgz
+
+# 3. tsconfig.json + index.ts
+cat > tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}
+EOF
+
+cat > index.ts <<'EOF'
+import { getStatusSnapshot } from '@token-weather/cli';
+import { validateUsageSnapshot, SCHEMA_VERSION } from '@token-weather/schemas';
+
+async function main() {
+  const snapshot = await getStatusSnapshot();
+  console.log(snapshot.schemaVersion);
+  const result = validateUsageSnapshot({});
+  if (!result.valid) console.error(result.errors);
+}
+
+void main();
+EOF
+
+# 4. Verify: zero type errors expected
+npx tsc --noEmit
+
+# 5. (Optional) Verify IDE import autocomplete
+code .
+```
+
+If type inference works correctly:
+
+- `snapshot.schemaVersion` is exposed in autocomplete as `string`
+- `result.valid` is `boolean`, `result.errors` is `string[]`
+- Non-enriched exports show as `any`, but there are no compile errors
+
+## Limits
+
+- This d.ts emission **depends on JSDoc coverage**. Non-enriched exports do not get precise types (they show as `any`).
+- **Type-contract scope is only the package's root entry**: `./dist/types/index.d.ts` as pointed to by `package.json::types` is the only stable surface. Subpath imports (`@token-weather/.../src/...`) work but are outside this PR's scope; whether to officially support them via `exports` and `typesVersions` is a follow-up decision (since main is in use, it would be a separate PR).
+- TypeScript conversion of the source itself is out of policy scope.
+- Automated install / import verification: `scripts/install-smoke.sh` (#75) runs pack + temp install + bin smoke + d.ts artifact presence on every PR in CI. The `tsc --noEmit` step remains in this manual procedure — automating it is a follow-up issue.

--- a/packages/agent/test/integration/repo-policy-readme.test.js
+++ b/packages/agent/test/integration/repo-policy-readme.test.js
@@ -84,16 +84,15 @@ describe('repo-policy/readme — 핵심 섹션 존재 (issue #154: 영어 defaul
 });
 
 describe('repo-policy/readme — 외부 문서 링크 (issue #154: 영어 본 정합)', () => {
-  // README.md = 영어 default (Phase 2-1). 영어 본이 있는 외부 docs (Phase 2-2 의
-  // telegram-bot / cli-json-output / provider-notes) 는 .en.md 로, 아직 번역
-  // 안 된 docs (auth-architecture / codebase-guide 등) 는 .md (한글) 그대로.
+  // README.md = 영어 default (Phase 2-1). 외부 가시 docs 7개 모두 .en.md 가
+  // 추가됨 (Phase 2-2 + Phase 2-3). 내부 docs (codebase-guide 등) 는 한글 only.
   const REQUIRED_LINKS = [
     'LICENSE',
     'SECURITY.md',
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
     'docs/cli-json-output.en.md',
-    'docs/auth-architecture.md',
+    'docs/auth-architecture.en.md',
     'docs/codebase-guide.md',
   ];
 

--- a/packages/agent/test/integration/repo-policy-readme.test.js
+++ b/packages/agent/test/integration/repo-policy-readme.test.js
@@ -84,15 +84,23 @@ describe('repo-policy/readme — 핵심 섹션 존재 (issue #154: 영어 defaul
 });
 
 describe('repo-policy/readme — 외부 문서 링크 (issue #154: 영어 본 정합)', () => {
-  // README.md = 영어 default (Phase 2-1). 외부 가시 docs 7개 모두 .en.md 가
-  // 추가됨 (Phase 2-2 + Phase 2-3). 내부 docs (codebase-guide 등) 는 한글 only.
+  // README.md = 영어 default. 외부 가시 docs 7개 모두 .en.md 로 link 됨
+  // (Phase 2-2 + 2-3). README 가 한글 본 .md 로 회귀하면 본 가드가 즉시 fail.
+  // 내부 docs (codebase-guide) 는 한글 only — 그대로 .md.
   const REQUIRED_LINKS = [
     'LICENSE',
     'SECURITY.md',
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
-    'docs/cli-json-output.en.md',
+    // 외부 가시 docs 7개 — 모두 .en.md
+    'docs/architecture.en.md',
     'docs/auth-architecture.en.md',
+    'docs/auth-cli.en.md',
+    'docs/cli-json-output.en.md',
+    'docs/provider-notes.en.md',
+    'docs/telegram-bot.en.md',
+    'docs/typescript-consumers.en.md',
+    // 내부 docs (contributor 한국 기반)
     'docs/codebase-guide.md',
   ];
 


### PR DESCRIPTION
## 요약

- Master issue #154 의 **Phase 2-3 — 외부 docs 보조 4개 영어 번역**.
- 외부 가시 docs 7개 모두 영어 본 (`.en.md`) 보유 — README 의 영어 본 ToC link 가 모든 외부 docs `.en.md` 를 가리킴.
- 영어권 사용자가 README → docs 어디로 진입해도 영어 페이지.

## 변경 내용

- `docs/architecture.en.md` 신규 (77 줄) — 고수준 구성 / CLI agent / services / provider adapters / schemas / 인증 계층 / 확장 후보
- `docs/auth-architecture.en.md` 신규 (184 줄) — 인증 흐름 4종 / credential source 우선순위 / 저장소 설계 / 보안 원칙 / 자동 refresh / Codex+Claude endpoint 검증 현황 / 운영 방안
- `docs/auth-cli.en.md` 신규 (204 줄) — auth login / list / logout / import + doctor (`--dedupe` / `--apply` / `--backfill-account-id`) / multi-account / port conflict / 자동 refresh / 예시 시나리오
- `docs/typescript-consumers.en.md` 신규 (116 줄) — d.ts emission 정책 / 현재 d.ts 품질 / manual sanity check 절차 / 한계
- `docs/INDEX.md` 갱신 — 외부 사용자용 표 7행 모두 영문 본 노출 (이전 PR 의 "Phase 2-3 예정" 자리에 link)
- `README.md` (영어) — 본문 link (line 120) + ToC 4개 (architecture / auth-architecture / auth-cli / typescript-consumers) 를 `.en.md` 로 갱신
- `repo-policy-readme.test.js` REQUIRED_LINKS — `docs/auth-architecture.md` → `docs/auth-architecture.en.md`
- `.changeset/docs-i18n-external-extra.md` — 4 패키지 linked **minor** bump

## 변경 이유

PR #156 (Phase 2-1) 에서 README 가 영어 default 로 전환된 뒤, PR #158 (Phase 2-2) 에서 핵심 3개 docs (`telegram-bot` / `cli-json-output` / `provider-notes`) 가 영어로 추가됐습니다. 본 PR 로 외부 가시 docs 의 나머지 4개도 영어 추가 — 영어권 사용자 진입 경로의 **모든 외부 docs** 가 영어 본을 갖게 됩니다.

번역 정책 (CONTRIBUTING §6 + §10 정합):
- source of truth: 한글 (`docs/X.md`). 영문은 번역본.
- 코드 식별자 / 외부 lib name / 명령 / 경로 / endpoint URL / scope / client_id / 옵션 / 환경변수 — 양쪽 동일.
- 영문 본 상단에 번역 footer (`> Translated from ... last sync 2026-05-20 + CONTRIBUTING §10 ref`).

## 영향 범위

- [x] `packages/agent` (test 단언 갱신)
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (README.md, changeset)
- [x] `docs` (4 .en.md 신규 + INDEX.md 갱신)

## 스크린샷 / 데모

INDEX 의 외부 사용자용 표 (본 PR 적용 후 — 모든 행 영문 link):

```
| Document            | 한 줄 요약            | 영문                         |
| ------------------- | --------------------- | ---------------------------- |
| architecture.md     | ...                   | architecture.en.md           |
| auth-architecture.md| ...                   | auth-architecture.en.md      |
| auth-cli.md         | ...                   | auth-cli.en.md               |
| cli-json-output.md  | ...                   | cli-json-output.en.md        |
| provider-notes.md   | ...                   | provider-notes.en.md         |
| telegram-bot.md     | ...                   | telegram-bot.en.md           |
| typescript-consumers| ...                   | typescript-consumers.en.md   |
```

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1116 pass / 0 fail, `npm run lint` clean, `npx prettier --check docs/ README.md` 통과
- [x] 필요한 문서 업데이트 반영 — 4 .en.md + INDEX.md + README.md
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only, 코드 / contract 변경 없음 (test 단언만 갱신)
- [x] PR 본문 / 디프 / 출력 예시에 민감값을 redact 했음 — `app_EMoamEEZ73f0CkXaXp7hrann`, `9d1c250a-e61b-44d9-88ed-5944d1962f5e` 같은 client_id 는 이미 공개된 observed value (한글 source 와 동일), 토큰 / refresh token 등 민감값 없음

## 리뷰 포인트

- **번역 정확성 (auth-architecture / auth-cli)** — 보안 / 운영 docs 라 표현 정확성이 핵심. "PKCE S256 + state 검증", "preflight refresh", "auth source 우선순위", "lastUsedAt 자동 선택" 등 기술 용어 영어 정합.
- **`--dedupe` 의 상호작용 부분** — `auth-cli.en.md` 의 "If `--account` and `--dedupe` are passed together, `--account` is ignored" 같은 옵션 우선순위 표현이 한글 source ("`--account` 는 무시되고") 와 의미 일치하는지.
- **typescript-consumers 의 코드 예시** — bash + ts 코드 블록이 한글 source 의 같은 명령 / 같은 코드. 컨텐츠 변경 없음.
- **README ToC 변경 범위** — 영어 README 의 ToC 4개 link 만 `.en.md` 로. `codebase-guide` / `release-policy` / `auth-store-schema` / `claude-oauth-plan` 은 내부 docs (한글 only) 라 그대로.

## 참고 사항

- 관련 master issue: #154
- 다음 PR (Phase 2-4): SECURITY 영어화 + CONTRIBUTING §10 의 운영 절차 보강 (test 가드 / dual sync 검증) + master issue close
- Out of scope:
  - SECURITY.md 영어 본 (Phase 2-4)
  - CONTRIBUTING §10 의 dual sync 운영 절차 / test 가드 (Phase 2-4)
  - 내부 docs (codebase-guide / release-policy / auth-store-schema / claude-oauth-plan) 한글 유지
- 머지 후 release.yml 이 trigger 되어 release PR (#152) 에 본 changeset 누적 (`docs-i18n-readme` + `docs-i18n-external-core` + `docs-i18n-external-extra` 3 건 누적). v0.7.0 publish 시 4 패키지 한 번에.
