### PR TITLE
[docs] SECURITY 영어화 + CONTRIBUTING §10 + i18n drift 가드 — i18n roadmap 마무리 (closes #154)

### DIFF
--- a/.changeset/docs-i18n-meta.md
+++ b/.changeset/docs-i18n-meta.md
@@ -1,8 +1,8 @@
 ---
-'@token-weather/cli': minor
-'@token-weather/provider-adapters': minor
-'@token-weather/schemas': minor
-'@token-weather/telegram': minor
+'@token-weather/cli': patch
+'@token-weather/provider-adapters': patch
+'@token-weather/schemas': patch
+'@token-weather/telegram': patch
 ---
 
 docs(repo): i18n 메타 정비 마무리 — SECURITY 영어 default + CONTRIBUTING §10 정식 +

--- a/.changeset/docs-i18n-meta.md
+++ b/.changeset/docs-i18n-meta.md
@@ -1,0 +1,48 @@
+---
+'@token-weather/cli': minor
+'@token-weather/provider-adapters': minor
+'@token-weather/schemas': minor
+'@token-weather/telegram': minor
+---
+
+docs(repo): i18n 메타 정비 마무리 — SECURITY 영어 default + CONTRIBUTING §10 정식 +
+dual sync test 가드 (issue #154 Phase 2-4).
+
+Phase 2-1 (README dual) / 2-2 (외부 docs 3개) / 2-3 (외부 docs 4개) 에 이어
+i18n roadmap 의 마지막 단계 — 메타 파일 정합 + drift 방어막.
+
+**변경 사항**:
+
+- `SECURITY.md` → `SECURITY.ko.md` rename + `SECURITY.md` 영어 신규 + 양쪽 dual
+  language 링크. 외부 보안 신고 (GitHub Security Advisory) 진입 시 영어 default.
+- `CONTRIBUTING.md §10` skeleton → 정식 본:
+  - dual 대상 파일 분류 (README/SECURITY 영문 default + 외부 docs 7 영문 추가 +
+    한글 only 분류)
+  - 기본 원칙 (source of truth / drift 방지 / 불변 요소 / 번역 footer /
+    상호 링크 / dual sync 검증) 명확화
+  - 번역 작업 흐름 (AI draft + 사람 review + footer last sync 갱신)
+  - 의미적 정합 fix (source outdated 발견 시 한글 + 영문 동시 갱신)
+  - CLI 평문 / `--json` / changeset 정책 분리 ref
+- 새 test `packages/agent/test/integration/repo-policy-i18n.test.js` (40 test):
+  - dual 대상 파일 존재 (16 파일)
+  - 상단 dual language 링크 + globe 글리프
+  - 영문 본 번역 footer + last sync 날짜
+  - README 영어 본 link 가 외부 docs 7개 모두 `.en.md`
+  - 한글 source 의 한글 헤더 (역번역 회귀 차단)
+
+**i18n roadmap 종료** (issue #154):
+
+- ✅ README dual (영문 default + .ko.md)
+- ✅ SECURITY dual (영문 default + .ko.md)
+- ✅ 외부 docs 7개 영문 본 추가
+- ✅ CONTRIBUTING §10 정식 정책
+- ✅ repo-policy-i18n test 가드 (drift 방어막)
+- ✅ docs/INDEX.md 카테고리별 entry point
+
+**Non-goal** (별도 후속 / Out of scope):
+
+- Docusaurus / VitePress 기반 독립 docs 사이트
+- 자동 번역 CI (AI 호출)
+- 다른 언어 (일본어 / 중국어 등) — 영어 dual 후 별도 사이클
+- 내부 docs (codebase-guide / release-policy / auth-store-schema /
+  claude-oauth-plan) 영어화 — contributor 한국 기반 유지

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,16 +167,61 @@ PR을 제출하시면 본인의 기여(코드, 문서, 설정 등)가 동일하�
 
 다른 라이선스로 기여하고자 하는 경우, PR 본문에 명시해 주시면 별도로 검토합니다.
 
-## 10. i18n / 다국어 docs (issue #154 부터)
+## 10. i18n / 다국어 docs (issue #154)
 
-외부 가시 docs 는 영문/한글 dual 로 유지된다. README 가 첫 적용 (Phase 2-1) — `README.md` = 영어 default, `README.ko.md` = 한글 원본. 외부 가시 `docs/*.md` 는 Phase 2-2 / 2-3 에서 `.en.md` 가 순차 추가될 예정. 내부 docs (codebase-guide / release-policy / auth-store-schema / claude-oauth-plan) 는 contributor 한국 기반이라 한글 only 유지.
+외부 가시 docs 는 영문 / 한글 dual 로 유지된다. 영어가 npm registry / GitHub landing 의 default, 한글은 source of truth. 내부 docs (contributor / 운영자용) 는 contributor 한국 기반이라 한글 only 유지.
 
-기본 원칙:
+### dual 대상 파일
 
-- **source of truth**: 한글 (`README.ko.md`, `docs/X.md`). 영문은 번역본.
+**영문 default + 한글 보존** (사용자 / 기여자 진입 친화):
+
+- `README.md` (영어) + `README.ko.md` (한글)
+- `SECURITY.md` (영어) + `SECURITY.ko.md` (한글)
+
+**한글 default + 영문 추가** (`docs/X.md` + `docs/X.en.md`, 7개):
+
+- `docs/architecture.{md,en.md}`
+- `docs/auth-architecture.{md,en.md}`
+- `docs/auth-cli.{md,en.md}`
+- `docs/cli-json-output.{md,en.md}`
+- `docs/provider-notes.{md,en.md}`
+- `docs/telegram-bot.{md,en.md}`
+- `docs/typescript-consumers.{md,en.md}`
+
+**한글 only 유지** (외부 사용자 가시도 낮음 / contributor 한국 기반):
+
+- `CONTRIBUTING.md`, `CHANGELOG.md`
+- `docs/codebase-guide.md`, `docs/release-policy.md`, `docs/auth-store-schema.md`, `docs/claude-oauth-plan.md`
+- `docs/INDEX.md` (한글이 default, 외부 docs 영문 link 컬럼으로 노출)
+- `.changeset/*.md` (release-policy §3)
+- `CODE_OF_CONDUCT.md` 는 영어 표준 텍스트 — 그대로 유지
+
+### 기본 원칙
+
+- **source of truth**: 한글. 영문은 번역본 — README / SECURITY 는 영어 파일명이 `.md` 지만 의미상 한글이 원본.
 - **drift 방지**: 한글 변경 시 영문 동시 갱신 의무. **같은 PR 에 양쪽 변경 포함** — 별도 PR 로 split 금지.
-- **불변 요소**: 코드 식별자 / 외부 lib name / 경로 / 명령 예시 / changeset 본문 / d.ts 시그니처 — 양쪽 동일.
-- **번역 footer**: 영문 본 상단에 `> Translated from [X.ko.md](./X.ko.md) — last sync YYYY-MM-DD` 형식.
-- **dual sync 검증**: Phase 2-4 에서 repo policy test 로 가드 (`README.ko.md` 존재 / 상호 링크 / 한글 섹션 / 양쪽 본문 길이 균형 등).
+- **불변 요소**: 코드 식별자 / 외부 lib name / 경로 / 명령 예시 / changeset 본문 / d.ts 시그니처 / endpoint URL / scope / client_id — 양쪽 동일.
+- **번역 footer**: 영문 본 상단에 `> Translated from [X.ko.md](./X.ko.md) — last sync YYYY-MM-DD` (또는 `docs/X.md`) 형식. 한글 변경 PR 마다 sync 날짜 갱신.
+- **상호 링크**: dual 파일 둘 다 상단에 `🌐 [English](./X.md) · [한국어](./X.ko.md)` 형식 dual link (`docs/*.en.md` / `.md` 도 동일 패턴).
+- **dual sync 검증**: `packages/agent/test/integration/repo-policy-i18n.test.js` 가 영문 본 존재 / 상호 link / 번역 footer 존재 / dual 파일 정합을 검사. 한쪽만 변경한 PR 은 본 test 가 잡는다.
 
-본 절은 **skeleton** — Phase 2-4 에서 i18n drift 정책 / test 가드 / dual sync 운영 절차가 정식 보강된다. dual 대상 분류 / 외부 docs 영문 진행 상황은 [docs/INDEX.md](./docs/INDEX.md) + 진행 중인 i18n master issue 참고.
+### 번역 작업 흐름
+
+1. **한글 source 변경 PR** 작성 시 영문 본도 같은 PR 안에서 갱신.
+2. AI 번역 도구 (Claude API 등) 로 1차 draft 가능 — 코드 식별자 / 옵션 / 경로 등 불변 요소가 그대로 유지되는지 사람이 review.
+3. 영문 본의 번역 footer `last sync` 날짜를 변경 시점으로 갱신.
+4. `repo-policy-i18n.test.js` 통과 확인.
+
+### `auth import` / `manual paste` 같은 의미적 정합
+
+번역 시 한글 source 의 표현이 outdated 라면 source 도 동시 정정. self-review / 외부 review 가 양쪽 mismatch 를 발견하면, **한글 source + 영문 본 + 관련 코드 docstring** 까지 한 commit 에 갱신 (CONTRIBUTING §6 의 "외부 식별자 원문 유지" + §4 의 "1 PR 1 주제" 와 양립).
+
+### CLI / `--json` / changeset 정책 정합
+
+- CLI 평문 (`token-weather status` desktop) 의 한글 / 영어 출력은 본 §10 의 대상이 아님. 평문 출력 언어 정책은 [docs/codebase-guide.md](./docs/codebase-guide.md) 참고 (현재 영어 default — issue #116).
+- `--json` 출력은 stable contract 라 본 §10 무관 — schema bump 정책은 [docs/release-policy.md](./docs/release-policy.md) §3.
+- changeset 본문은 한 언어 (한글) 유지 — release-policy §3 정합. 사용자 가시 변경 요약이 양쪽 언어로 노출될 필요 없음.
+
+### dual 대상 / 진행 상황 추적
+
+[docs/INDEX.md](./docs/INDEX.md) 의 "외부 사용자용" 표가 카테고리별 entry point + 각 docs 의 dual 상태. 새 외부 docs 추가 시 INDEX 의 표에 행 추가하고 영문 본도 같은 PR 에 포함.

--- a/SECURITY.ko.md
+++ b/SECURITY.ko.md
@@ -1,0 +1,77 @@
+# 보안 정책
+
+🌐 [English](./SECURITY.md) · **한국어**
+
+> 이 파일이 한글 원본입니다. 영문 번역본 ([SECURITY.md](./SECURITY.md)) 은 본 파일을 따라 갱신됩니다. i18n drift 정책은 [CONTRIBUTING.md §10](./CONTRIBUTING.md) 참고.
+
+이 도구는 OAuth access token / refresh token / id token 같은 자격증명을 로컬에서 다룹니다. 보안 이슈는 공개 이슈 트래커가 아닌 비공개 채널로 신고해 주세요.
+
+## 지원 버전
+
+| Version | Supported |
+| ------- | --------- |
+| `0.1.x` | ✅        |
+| 그 이전 | ❌        |
+
+## 비공개 신고 채널
+
+GitHub Security Advisory를 통해 비공개로 신고해 주세요.
+
+- 신고 페이지: https://github.com/LLagoon3/token-weather/security/advisories/new
+- 평균 응답 SLA: 영업일 기준 5일 이내 1차 답변
+- 심각도가 높은 경우(원격 토큰 유출, 자격증명 노출 등) 우선 대응
+
+## 토큰을 실수로 공개 위치에 첨부했을 때
+
+GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, refresh token, id token, session cookie, account key가 그대로 들어간 경우:
+
+1. 즉시 해당 위치에서 토큰을 삭제(또는 issue/PR을 비공개로 전환)합니다.
+2. 해당 자격증명을 즉시 **revoke** 합니다.
+   - Codex (OpenAI): https://platform.openai.com/account/api-keys 또는 chatgpt.com 세션 로그아웃
+   - Claude (Anthropic): https://console.anthropic.com 또는 Claude CLI 재로그인
+3. `token-weather auth logout <provider>`로 로컬 store에서도 제거 후 재로그인합니다.
+
+토큰 복구 / 자동 revoke 기능은 제공하지 않습니다 (provider revoke endpoint 미통합 상태).
+
+## 새 토큰성 필드를 추가할 때 (메인테이너 / 기여자용)
+
+`status --json` 출력은 토큰 키 blacklist 기반 redaction을 적용합니다 (`docs/cli-json-output.md` §한계 참고). 새 토큰 필드를 provider adapter / auth schema에 추가하는 PR에서는 다음을 함께 수행해야 합니다.
+
+- `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 새 키 등록
+- `--json` 출력 회귀 테스트(가짜 토큰 주입 → JSON에 누출 없음 검증) 추가
+
+이 절차를 빠뜨리면 외부 소비자에게 그대로 노출될 수 있습니다.
+
+## Telegram 봇 통합의 위협 모델 (`@token-weather/telegram` 사용 시)
+
+옵션 패키지 `@token-weather/telegram` 을 활성화하면 token-weather 의 신뢰 경계가 확장됩니다. 활성화 전에 다음을 확인해 주세요. 상세 보안 모델은 [docs/telegram-bot.md §보안 모델](./docs/telegram-bot.md#보안-모델).
+
+### 신뢰 경계
+
+- **로컬 only** (저장 위치 별로 분리):
+  - OAuth access / refresh / id token: `~/.config/token-weather/auth.json` 에 저장. auth store 가 mode 0600 으로 write.
+  - Telegram bot token / allowedUserIds: `~/.config/token-weather/config.json` 의 `channels.telegram` 아래에 저장. `telegram setup` 이 chmod 600 을 best-effort 로 적용.
+  - 페어링 코드: setup 중 터미널 + 1회용 pairing daemon 메모리에만 존재. config / auth store 에 저장하지 않음.
+
+  세 경로 모두 `SENSITIVE_KEYS` redaction 으로 어떤 출력에도 노출되지 않음.
+
+- **Telegram 서버 경유 (신규)**: 사용량 숫자 / 계정 label / email / 명령 응답 본문 / 사용자 user_id. 봇 활성화 시 README 의 "로컬 only" 약속은 **OAuth 토큰 + 봇 토큰 한정** 으로 정밀화됨.
+
+### 봇 토큰 / 채널 단의 1차 방어막
+
+- `channels.telegram.allowedUserIds` allowlist — 등록되지 않은 user_id 의 메시지는 silent ignore (응답 / 로그 마스킹). 봇 토큰이 누설되어도 명령 표면이 즉시 열리지 않음.
+- 단일 인스턴스 lock — 같은 봇 토큰으로 다른 daemon 이 polling 중이면 409 Conflict 감지 후 종료. 의도치 않은 두 번째 daemon 실수 회피.
+- 노출 명령 표면 축소 — `/doctor` 는 root 호출만, `/auth_list` 도 인자 차단. 원격 명령으로 부수효과 있는 호출 (token refresh-live 등) 트리거 불가.
+
+### 봇 토큰 누설 시 절차
+
+1. BotFather (`@BotFather`) 에 `/revoke` → 즉시 토큰 무효화 (또는 `/token` 으로 재발급).
+2. 로컬 `config.channels.telegram.botToken` 갱신 — `token-weather telegram setup` 재실행이 가장 안전.
+3. `token-weather telegram check` 로 `getMe API` 가 새 토큰으로 `✓` 응답하는지 확인.
+4. `~/.config/token-weather/config.json` 의 권한이 `chmod 600` 인지 확인 — `telegram check` 의 "config 권한" 항목.
+
+### 추가 신고 시나리오
+
+- 본인이 아닌 user_id 가 `allowedUserIds` 에 추가됨을 발견 → 즉시 array 에서 제거 + daemon 재시작 (`systemctl --user restart token-weather-bot.service` 또는 stop → start).
+- 봇이 본인 명령에 응답하지 않는데 다른 사용자에게는 응답함 → 봇 토큰 또는 allowlist 조작 의심. BotFather 토큰 revoke + 신고.
+- daemon 로그에 본인 user_id 가 아닌 마스킹된 id (`xxx****yy`) 가 `미허용 user_id 거부` 로 반복 등장 → 봇 토큰이 외부에 알려진 정황. 토큰 revoke 권장.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,73 +1,77 @@
-# 보안 정책
+# Security policy
 
-이 도구는 OAuth access token / refresh token / id token 같은 자격증명을 로컬에서 다룹니다. 보안 이슈는 공개 이슈 트래커가 아닌 비공개 채널로 신고해 주세요.
+🌐 **English** · [한국어](./SECURITY.ko.md)
 
-## 지원 버전
+> Translated from [SECURITY.ko.md](./SECURITY.ko.md) — last sync 2026-05-21. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](./CONTRIBUTING.md) for the i18n drift policy.
+
+This tool handles credentials such as OAuth access / refresh / id tokens locally. Please report security issues via a private channel, not the public issue tracker.
+
+## Supported versions
 
 | Version | Supported |
 | ------- | --------- |
 | `0.1.x` | ✅        |
-| 그 이전 | ❌        |
+| Older   | ❌        |
 
-## 비공개 신고 채널
+## Private reporting channel
 
-GitHub Security Advisory를 통해 비공개로 신고해 주세요.
+Please report privately through GitHub Security Advisory.
 
-- 신고 페이지: https://github.com/LLagoon3/token-weather/security/advisories/new
-- 평균 응답 SLA: 영업일 기준 5일 이내 1차 답변
-- 심각도가 높은 경우(원격 토큰 유출, 자격증명 노출 등) 우선 대응
+- Report page: https://github.com/LLagoon3/token-weather/security/advisories/new
+- Average response SLA: a first reply within 5 business days
+- High-severity (remote token leakage, credential exposure, etc.) gets priority handling
 
-## 토큰을 실수로 공개 위치에 첨부했을 때
+## When a token has accidentally been posted in a public place
 
-GitHub Issue / PR / 외부 채널(Slack, 이메일 본문 등)에 access token, refresh token, id token, session cookie, account key가 그대로 들어간 경우:
+If an access token, refresh token, id token, session cookie, or account key has been pasted as-is into a GitHub Issue / PR / external channel (Slack, email body, etc.):
 
-1. 즉시 해당 위치에서 토큰을 삭제(또는 issue/PR을 비공개로 전환)합니다.
-2. 해당 자격증명을 즉시 **revoke** 합니다.
-   - Codex (OpenAI): https://platform.openai.com/account/api-keys 또는 chatgpt.com 세션 로그아웃
-   - Claude (Anthropic): https://console.anthropic.com 또는 Claude CLI 재로그인
-3. `token-weather auth logout <provider>`로 로컬 store에서도 제거 후 재로그인합니다.
+1. Immediately remove the token from that location (or make the issue/PR private).
+2. **Revoke** the credential right away.
+   - Codex (OpenAI): https://platform.openai.com/account/api-keys or log out of chatgpt.com sessions
+   - Claude (Anthropic): https://console.anthropic.com or re-login via the Claude CLI
+3. Run `token-weather auth logout <provider>` to remove it from the local store as well, then re-login.
 
-토큰 복구 / 자동 revoke 기능은 제공하지 않습니다 (provider revoke endpoint 미통합 상태).
+Token recovery / automatic revoke is not provided (provider revoke endpoints are not integrated yet).
 
-## 새 토큰성 필드를 추가할 때 (메인테이너 / 기여자용)
+## When adding a new token-bearing field (maintainers / contributors)
 
-`status --json` 출력은 토큰 키 blacklist 기반 redaction을 적용합니다 (`docs/cli-json-output.md` §한계 참고). 새 토큰 필드를 provider adapter / auth schema에 추가하는 PR에서는 다음을 함께 수행해야 합니다.
+The `status --json` output applies redaction based on a token-key blacklist (see `docs/cli-json-output.en.md` §Limits). When adding a new token field to a provider adapter / auth schema, the PR should also:
 
-- `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`에 새 키 등록
-- `--json` 출력 회귀 테스트(가짜 토큰 주입 → JSON에 누출 없음 검증) 추가
+- Register the new key in `packages/agent/src/cli/status-json.js::SENSITIVE_KEYS`
+- Add a `--json` output regression test (inject a fake token → verify no leakage in the JSON)
 
-이 절차를 빠뜨리면 외부 소비자에게 그대로 노출될 수 있습니다.
+Skipping this can expose tokens to external consumers as-is.
 
-## Telegram 봇 통합의 위협 모델 (`@token-weather/telegram` 사용 시)
+## Telegram bot integration threat model (when using `@token-weather/telegram`)
 
-옵션 패키지 `@token-weather/telegram` 을 활성화하면 token-weather 의 신뢰 경계가 확장됩니다. 활성화 전에 다음을 확인해 주세요. 상세 보안 모델은 [docs/telegram-bot.md §보안 모델](./docs/telegram-bot.md#보안-모델).
+Activating the optional `@token-weather/telegram` package expands token-weather's trust boundary. Please review the following before activation. The full security model is in [docs/telegram-bot.en.md §Security model](./docs/telegram-bot.en.md#security-model).
 
-### 신뢰 경계
+### Trust boundaries
 
-- **로컬 only** (저장 위치 별로 분리):
-  - OAuth access / refresh / id token: `~/.config/token-weather/auth.json` 에 저장. auth store 가 mode 0600 으로 write.
-  - Telegram bot token / allowedUserIds: `~/.config/token-weather/config.json` 의 `channels.telegram` 아래에 저장. `telegram setup` 이 chmod 600 을 best-effort 로 적용.
-  - 페어링 코드: setup 중 터미널 + 1회용 pairing daemon 메모리에만 존재. config / auth store 에 저장하지 않음.
+- **Local only** (split by storage location):
+  - OAuth access / refresh / id tokens: stored in `~/.config/token-weather/auth.json`. The auth store writes with mode 0600.
+  - Telegram bot token / allowedUserIds: stored under `channels.telegram` in `~/.config/token-weather/config.json`. `telegram setup` applies chmod 600 on a best-effort basis.
+  - Pairing code: exists only in the terminal and the one-shot pairing daemon's memory during setup. Not persisted to config / auth store.
 
-  세 경로 모두 `SENSITIVE_KEYS` redaction 으로 어떤 출력에도 노출되지 않음.
+  All three paths are protected by `SENSITIVE_KEYS` redaction — they don't appear in any output.
 
-- **Telegram 서버 경유 (신규)**: 사용량 숫자 / 계정 label / email / 명령 응답 본문 / 사용자 user_id. 봇 활성화 시 README 의 "로컬 only" 약속은 **OAuth 토큰 + 봇 토큰 한정** 으로 정밀화됨.
+- **Flows through Telegram servers (newly added)**: usage numbers / account labels / email / command response bodies / user_id. When the bot is active, the README's "local only" promise is **narrowed to OAuth tokens + bot tokens**.
 
-### 봇 토큰 / 채널 단의 1차 방어막
+### First-line defenses at the bot token / channel level
 
-- `channels.telegram.allowedUserIds` allowlist — 등록되지 않은 user_id 의 메시지는 silent ignore (응답 / 로그 마스킹). 봇 토큰이 누설되어도 명령 표면이 즉시 열리지 않음.
-- 단일 인스턴스 lock — 같은 봇 토큰으로 다른 daemon 이 polling 중이면 409 Conflict 감지 후 종료. 의도치 않은 두 번째 daemon 실수 회피.
-- 노출 명령 표면 축소 — `/doctor` 는 root 호출만, `/auth_list` 도 인자 차단. 원격 명령으로 부수효과 있는 호출 (token refresh-live 등) 트리거 불가.
+- `channels.telegram.allowedUserIds` allowlist — messages from unregistered user_ids are silently ignored (responses / logs are masked). Even if the bot token leaks, the command surface does not immediately open up.
+- Single-instance lock — if another daemon is already polling with the same bot token, a 409 Conflict is detected and the new instance exits. Avoids accidentally running a second daemon.
+- Reduced command surface exposure — `/doctor` exposes only the root call, `/auth_list` blocks arguments. Side-effecting calls (e.g., token refresh-live) cannot be triggered remotely.
 
-### 봇 토큰 누설 시 절차
+### When a bot token is leaked
 
-1. BotFather (`@BotFather`) 에 `/revoke` → 즉시 토큰 무효화 (또는 `/token` 으로 재발급).
-2. 로컬 `config.channels.telegram.botToken` 갱신 — `token-weather telegram setup` 재실행이 가장 안전.
-3. `token-weather telegram check` 로 `getMe API` 가 새 토큰으로 `✓` 응답하는지 확인.
-4. `~/.config/token-weather/config.json` 의 권한이 `chmod 600` 인지 확인 — `telegram check` 의 "config 권한" 항목.
+1. In BotFather (`@BotFather`), run `/revoke` to invalidate the token immediately (or `/token` to issue a new one).
+2. Update the local `config.channels.telegram.botToken` — rerunning `token-weather telegram setup` is the safest path.
+3. Verify the `getMe API` responds `✓` with the new token via `token-weather telegram check`.
+4. Confirm `~/.config/token-weather/config.json` is `chmod 600` — see the "config permission" item in `telegram check`.
 
-### 추가 신고 시나리오
+### Additional reportable scenarios
 
-- 본인이 아닌 user_id 가 `allowedUserIds` 에 추가됨을 발견 → 즉시 array 에서 제거 + daemon 재시작 (`systemctl --user restart token-weather-bot.service` 또는 stop → start).
-- 봇이 본인 명령에 응답하지 않는데 다른 사용자에게는 응답함 → 봇 토큰 또는 allowlist 조작 의심. BotFather 토큰 revoke + 신고.
-- daemon 로그에 본인 user_id 가 아닌 마스킹된 id (`xxx****yy`) 가 `미허용 user_id 거부` 로 반복 등장 → 봇 토큰이 외부에 알려진 정황. 토큰 revoke 권장.
+- You find a user_id you don't recognize in `allowedUserIds` → immediately remove it from the array and restart the daemon (`systemctl --user restart token-weather-bot.service` or stop → start).
+- The bot doesn't respond to your commands but responds to someone else → suspect bot-token or allowlist tampering. Revoke the BotFather token and report.
+- The daemon log repeatedly shows a masked id (`xxx****yy`) that is not yours under "rejected unregistered user_id" → indicates the bot token may be known externally. Revoking the token is recommended.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -1,5 +1,7 @@
 # Architecture
 
+🌐 **English** · [한국어](./architecture.md)
+
 > Translated from [architecture.md](./architecture.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 Detailed codebase rules live in `docs/codebase-guide.md`. This document covers only the high-level composition.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # 아키텍처
 
+🌐 [English](./architecture.en.md) · **한국어**
+
 Codebase 상세 규칙은 `docs/codebase-guide.md`. 본 문서는 고수준 구성만.
 
 ## 요약

--- a/docs/auth-architecture.en.md
+++ b/docs/auth-architecture.en.md
@@ -1,5 +1,7 @@
 # Auth architecture
 
+🌐 **English** · [한국어](./auth-architecture.md)
+
 > Translated from [auth-architecture.md](./auth-architecture.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 ## Goals

--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -1,5 +1,7 @@
 # 인증 아키텍처
 
+🌐 [English](./auth-architecture.en.md) · **한국어**
+
 ## 목표
 
 CLI agent가 외부 auth store(OpenClaw 등)에 의존하지 않고 독립적으로 인증, 토큰 저장, 갱신, 사용을 처리한다.

--- a/docs/auth-cli.en.md
+++ b/docs/auth-cli.en.md
@@ -1,5 +1,7 @@
 # Auth CLI interface
 
+🌐 **English** · [한국어](./auth-cli.md)
+
 > Translated from [auth-cli.md](./auth-cli.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 This document summarizes `token-weather`'s auth-related CLI commands and operational policy.

--- a/docs/auth-cli.md
+++ b/docs/auth-cli.md
@@ -1,5 +1,7 @@
 # Auth CLI 인터페이스
 
+🌐 [English](./auth-cli.en.md) · **한국어**
+
 `token-weather`의 인증 관련 CLI 명령 집합과 운영 정책을 정리한다.
 
 ## 명령 구조

--- a/docs/cli-json-output.en.md
+++ b/docs/cli-json-output.en.md
@@ -1,5 +1,7 @@
 # CLI JSON output (`--json`)
 
+🌐 **English** · [한국어](./cli-json-output.md)
+
 > Translated from [cli-json-output.md](./cli-json-output.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 The `status` / `usage` commands emit a single normalized JSON line to stdout when given the `--json` flag. This is a specification so that automation / dashboards / backend collectors can consume the output directly without re-parsing text formatting.

--- a/docs/cli-json-output.md
+++ b/docs/cli-json-output.md
@@ -1,5 +1,7 @@
 # CLI JSON 출력 (`--json`)
 
+🌐 [English](./cli-json-output.en.md) · **한국어**
+
 `status` / `usage` 커맨드는 `--json` 플래그로 정규화된 JSON 한 줄을 stdout에 출력한다. 자동화 / 대시보드 / 백엔드 수집기가 텍스트 포매팅을 다시 파싱하지 않고 직접 소비할 수 있도록 한 명세다.
 
 이 문서는 출력 shape의 **stable contract**다. 변경 시 schema bump이 필요하다(현재 `schemaVersion`은 `packages/schemas`와 공유 — string semver, [docs/release-policy.md §3](./release-policy.md) 참고).

--- a/docs/provider-notes.en.md
+++ b/docs/provider-notes.en.md
@@ -1,5 +1,7 @@
 # Provider notes
 
+🌐 **English** · [한국어](./provider-notes.md)
+
 > Translated from [provider-notes.md](./provider-notes.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 ## OpenAI Codex

--- a/docs/provider-notes.md
+++ b/docs/provider-notes.md
@@ -1,5 +1,7 @@
 # Provider 메모
 
+🌐 [English](./provider-notes.en.md) · **한국어**
+
 ## OpenAI Codex
 
 - Endpoint: `https://chatgpt.com/backend-api/wham/usage`

--- a/docs/telegram-bot.en.md
+++ b/docs/telegram-bot.en.md
@@ -1,5 +1,7 @@
 # Telegram bot integration
 
+🌐 **English** · [한국어](./telegram-bot.md)
+
 > Translated from [telegram-bot.md](./telegram-bot.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 The `@token-weather/telegram` package provides a long-poll daemon that exposes token-weather's `status` / `usage` / `doctor` / `auth list` commands over Telegram. Run the bot locally, and you can send commands from your phone or another desktop and get immediate responses.

--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -1,5 +1,7 @@
 # Telegram 봇 통합
 
+🌐 [English](./telegram-bot.en.md) · **한국어**
+
 `@token-weather/telegram` 패키지는 token-weather 의 `status` / `usage` / `doctor` / `auth list` 명령을 Telegram 채팅으로 원격 호출하는 long-poll daemon 을 제공합니다. 로컬에서 봇을 띄우면 핸드폰 / 다른 데스크탑에서 봇에게 명령을 보내 즉시 응답을 받을 수 있습니다.
 
 > **신뢰 모델 요약**: 봇 토큰 / OAuth 토큰은 **로컬 파일에만 저장** 됩니다. 다만 사용량 / 계정 label / 명령 응답 본문은 Telegram 서버를 경유합니다. 자세한 보안 모델은 [§보안 모델](#보안-모델) 참고.

--- a/docs/typescript-consumers.en.md
+++ b/docs/typescript-consumers.en.md
@@ -1,5 +1,7 @@
 # TypeScript consumers guide
 
+🌐 **English** · [한국어](./typescript-consumers.md)
+
 > Translated from [typescript-consumers.md](./typescript-consumers.md) — last sync 2026-05-20. The Korean version is the source of truth; this English version follows it. See [CONTRIBUTING.md §10](../CONTRIBUTING.md) for the i18n drift policy.
 
 Token Weather packages are written in JS + JSDoc, but `.d.ts` files generated via `tsc --emitDeclarationOnly` are shipped alongside on publish. Importing them directly into a TypeScript project gives you autocomplete and type inference out of the box.

--- a/docs/typescript-consumers.md
+++ b/docs/typescript-consumers.md
@@ -1,5 +1,7 @@
 # TypeScript 사용자용 가이드
 
+🌐 [English](./typescript-consumers.en.md) · **한국어**
+
 Token Weather 패키지는 JS+JSDoc 소스로 작성되었지만, publish 시 `tsc --emitDeclarationOnly`로 생성한 `.d.ts`가 함께 동봉됩니다. TypeScript 프로젝트에서 그대로 import하면 자동완성·타입 추론이 동작합니다.
 
 ## 사용

--- a/packages/agent/test/integration/repo-policy-i18n.test.js
+++ b/packages/agent/test/integration/repo-policy-i18n.test.js
@@ -61,8 +61,16 @@ describe('repo-policy/i18n — dual 대상 파일 존재 (issue #154 §10)', () 
 
 describe('repo-policy/i18n — 양쪽 파일 상단 dual language 링크 (CONTRIBUTING §10)', () => {
   const PAIRS = [
+    // 영문 default + 한글 보존 (root)
     { en: 'README.md', ko: 'README.ko.md', enRef: 'README.md', koRef: 'README.ko.md' },
     { en: 'SECURITY.md', ko: 'SECURITY.ko.md', enRef: 'SECURITY.md', koRef: 'SECURITY.ko.md' },
+    // 한글 default + 영문 추가 (docs/*) — Codex review PR #160 P2 nit 1
+    ...EXTERNAL_DOCS.map((name) => ({
+      en: `docs/${name}.en.md`,
+      ko: `docs/${name}.md`,
+      enRef: `${name}.en.md`,
+      koRef: `${name}.md`,
+    })),
   ];
 
   for (const { en, ko, enRef, koRef } of PAIRS) {

--- a/packages/agent/test/integration/repo-policy-i18n.test.js
+++ b/packages/agent/test/integration/repo-policy-i18n.test.js
@@ -1,0 +1,133 @@
+/**
+ * Repo-level i18n drift 가드.
+ *
+ * issue #154 의 Phase 2 결과 (README / SECURITY dual + 외부 docs 7 개 영문 본)
+ * 가 PR / commit 으로 우발적으로 깨지는 회귀를 잡는다. CONTRIBUTING §10 의 dual
+ * 정책과 정합.
+ *
+ * 검사 항목:
+ *   1. dual 대상 파일 존재 (README.ko.md, SECURITY.ko.md, docs/*.en.md 7 개)
+ *   2. 양쪽 파일 상단의 dual language 링크 + 번역 footer
+ *   3. README 영어 본의 docs link 가 외부 가시 docs 7개 모두 `.en.md` 정합
+ *   4. 한글 source 의 한글 헤더 존재 (drift 방어막)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+}
+
+function exists(rel) {
+  return fs.existsSync(path.join(REPO_ROOT, rel));
+}
+
+// 외부 가시 docs 7개 — CONTRIBUTING §10 의 "한글 default + 영문 추가" 카테고리
+const EXTERNAL_DOCS = [
+  'architecture',
+  'auth-architecture',
+  'auth-cli',
+  'cli-json-output',
+  'provider-notes',
+  'telegram-bot',
+  'typescript-consumers',
+];
+
+describe('repo-policy/i18n — dual 대상 파일 존재 (issue #154 §10)', () => {
+  it('README 양쪽 (.md + .ko.md) 존재', () => {
+    assert.ok(exists('README.md'), 'README.md (영어 default)');
+    assert.ok(exists('README.ko.md'), 'README.ko.md (한글 source)');
+  });
+
+  it('SECURITY 양쪽 (.md + .ko.md) 존재', () => {
+    assert.ok(exists('SECURITY.md'), 'SECURITY.md (영어 default)');
+    assert.ok(exists('SECURITY.ko.md'), 'SECURITY.ko.md (한글 source)');
+  });
+
+  for (const name of EXTERNAL_DOCS) {
+    it(`docs/${name} 양쪽 (.md + .en.md) 존재`, () => {
+      assert.ok(exists(`docs/${name}.md`), `docs/${name}.md (한글 source)`);
+      assert.ok(exists(`docs/${name}.en.md`), `docs/${name}.en.md (영문 번역)`);
+    });
+  }
+});
+
+describe('repo-policy/i18n — 양쪽 파일 상단 dual language 링크 (CONTRIBUTING §10)', () => {
+  const PAIRS = [
+    { en: 'README.md', ko: 'README.ko.md', enRef: 'README.md', koRef: 'README.ko.md' },
+    { en: 'SECURITY.md', ko: 'SECURITY.ko.md', enRef: 'SECURITY.md', koRef: 'SECURITY.ko.md' },
+  ];
+
+  for (const { en, ko, enRef, koRef } of PAIRS) {
+    it(`${en} (영어 default) 상단에 한국어 본 링크 포함`, () => {
+      const body = read(en);
+      assert.match(body, /🌐/, 'globe 글리프로 시작하는 dual link');
+      assert.ok(body.includes(`(./${koRef})`), `한국어 본 (${koRef}) 링크`);
+    });
+
+    it(`${ko} (한글 source) 상단에 영어 본 링크 포함`, () => {
+      const body = read(ko);
+      assert.match(body, /🌐/, 'globe 글리프로 시작하는 dual link');
+      assert.ok(body.includes(`(./${enRef})`), `영어 본 (${enRef}) 링크`);
+    });
+  }
+});
+
+describe('repo-policy/i18n — 영문 본 번역 footer (CONTRIBUTING §10)', () => {
+  const EN_BODIES = [
+    { rel: 'README.md', src: 'README.ko.md' },
+    { rel: 'SECURITY.md', src: 'SECURITY.ko.md' },
+    ...EXTERNAL_DOCS.map((name) => ({ rel: `docs/${name}.en.md`, src: `${name}.md` })),
+  ];
+
+  for (const { rel, src } of EN_BODIES) {
+    it(`${rel} 가 "Translated from ${src}" footer 포함`, () => {
+      const body = read(rel);
+      // "Translated from [X](./X)" 또는 "Translated from X" 모두 매치
+      const re = new RegExp(`Translated from .*${src.replace(/\./g, '\\.')}`);
+      assert.match(body, re, `번역 footer (last sync + CONTRIBUTING §10 ref)`);
+    });
+
+    it(`${rel} 가 last sync 날짜 포함`, () => {
+      const body = read(rel);
+      assert.match(body, /last sync \d{4}-\d{2}-\d{2}/i, 'YYYY-MM-DD 형식 last sync');
+    });
+  }
+});
+
+describe('repo-policy/i18n — README 영어 본의 외부 docs link 가 .en.md 정합', () => {
+  const README_EN = read('README.md');
+
+  for (const name of EXTERNAL_DOCS) {
+    it(`README 가 docs/${name}.en.md 링크 포함 (한글 .md 가 아닌)`, () => {
+      const escaped = `docs/${name}.en.md`.replace(/\./g, '\\.').replace(/\//g, '\\/');
+      const re = new RegExp(`\\(\\.\\/${escaped}\\)`);
+      assert.match(README_EN, re, `${name} 영문 본 링크 (회귀 시 한글 .md 로 돌아가지 않도록)`);
+    });
+  }
+});
+
+describe('repo-policy/i18n — 한글 source 의 한글 헤더 (drift 방어막)', () => {
+  it('README.ko.md 가 한글 핵심 섹션 헤더 포함', () => {
+    const body = read('README.ko.md');
+    // CONTRIBUTING §10 의 source of truth 가 한글이므로 한글 헤더가 사라지면
+    // sync 가 잘못된 방향 (영어 → 한글 역번역) 으로 흘러간 신호.
+    const REQUIRED = ['## 지원 provider', '## 명령', '## 보안', '## 라이선스'];
+    for (const heading of REQUIRED) {
+      assert.match(body, new RegExp(`^${heading.replace(/\//g, '\\/')}`, 'm'), heading);
+    }
+  });
+
+  it('SECURITY.ko.md 가 한글 핵심 섹션 헤더 포함', () => {
+    const body = read('SECURITY.ko.md');
+    assert.match(body, /## 지원 버전/m);
+    assert.match(body, /## 비공개 신고 채널/m);
+  });
+});


### PR DESCRIPTION
## 요약

- Master issue #154 의 **Phase 2-4 — i18n roadmap 마무리**.
- SECURITY 영어 default 전환 + CONTRIBUTING §10 skeleton 을 정식 본으로 보강 + dual sync drift 가드 (40 test) 신규.
- 본 PR 머지로 issue #154 의 모든 단계 완료. `Closes #154`.

## 변경 내용

- **SECURITY dual 전환**:
  - `SECURITY.md` → `SECURITY.ko.md` rename (git mv, history 보존)
  - `SECURITY.md` 신규 — 영어 번역 (Translated from SECURITY.ko.md, last sync 2026-05-21)
  - 양쪽 상단 dual language 링크 (`🌐 English · 한국어`) + 번역 정책 footer
  - 영문 본문의 cross-ref `.md` → `.en.md`
- **CONTRIBUTING §10 skeleton → 정식 본**:
  - dual 대상 파일 분류 (영문 default + 한글 보존 / 한글 default + 영문 추가 / 한글 only / 표준 영어)
  - 기본 원칙 6 항목 (source of truth / drift 방지 / 불변 요소 / 번역 footer / 상호 링크 / dual sync 검증)
  - 번역 작업 흐름 + AI draft + 사람 review 정책
  - 의미적 정합 fix 정책 (한글 source outdated 발견 시 동시 갱신)
  - CLI 평문 / `--json` / changeset 정책 분리 ref
- **`packages/agent/test/integration/repo-policy-i18n.test.js` 신규 (40 test)**:
  - dual 대상 파일 존재 (16 파일)
  - 양쪽 dual language 링크 + globe 글리프
  - 영문 본 번역 footer + last sync 날짜
  - README 영어 본의 외부 docs link `.en.md` 회귀 가드 (7개)
  - 한글 source 의 한글 헤더 (역번역 회귀 차단)
- `.changeset/docs-i18n-meta.md` — 4 패키지 linked **minor** bump

## 변경 이유

PR #156 / #158 / #159 로 외부 가시 docs 전반의 dual 전환은 끝났지만, drift 방지 정책이 skeleton 상태로 남아있어 외부 contributor 가 어떤 의무가 있는지 모호했음. 본 PR 로:

1. **SECURITY 도 영어 default 로 전환** — GitHub Security Advisory 진입 시 영어 표시
2. **CONTRIBUTING §10 정식 본** — 양쪽 sync 의무를 명확히 문서화
3. **자동 가드** — 향후 PR 에서 한쪽만 변경하면 test 실패. drift 즉시 검출

## i18n roadmap 종료

| Phase | 상태 | PR |
|---|---|---|
| Phase 0 — Audit | ✅ | (plan 안에서) |
| Phase 1 — 한글 구조 보강 | ✅ | #155 |
| Phase 2-1 — README dual | ✅ | #156 |
| Phase 2-2 — 외부 docs 핵심 3개 | ✅ | #158 |
| Phase 2-3 — 외부 docs 보조 4개 | ✅ | #159 |
| **Phase 2-4 — SECURITY + §10 + test 가드** | 🟡 본 PR | #160 |
| Phase 3 — master issue close | ⏳ 본 PR 머지 직후 | (코멘트로) |

머지 후 master issue #154 의 progress 코멘트 + close 자동 진행.

## 영향 범위

- [x] `packages/agent` (test 가드 신규)
- [ ] `packages/schemas`
- [ ] `packages/provider-adapters`
- [ ] `packages/telegram`
- [x] `repo` (SECURITY.md, SECURITY.ko.md, CONTRIBUTING.md, changeset)
- [ ] `docs`

## 스크린샷 / 데모

`SECURITY.md` (영어) 상단:

```markdown
# Security policy

🌐 **English** · [한국어](./SECURITY.ko.md)

> Translated from [SECURITY.ko.md](./SECURITY.ko.md) — last sync 2026-05-21.
> The Korean version is the source of truth; this English version follows it.
> See [CONTRIBUTING.md §10](./CONTRIBUTING.md) for the i18n drift policy.
```

i18n test 결과 (`repo-policy-i18n.test.js`):

```
✔ dual 대상 파일 존재 (issue #154 §10) — 9 cases
✔ 양쪽 파일 상단 dual language 링크 — 4 cases
✔ 영문 본 번역 footer — 18 cases
✔ README 영어 본의 외부 docs link .en.md 정합 — 7 cases
✔ 한글 source 의 한글 헤더 (drift 방어막) — 2 cases
총 40 test pass
```

## 테스트 / 확인

- [x] 관련 스크립트 또는 기능을 로컬에서 확인 — `npm test` 1161 pass / 0 fail (이전 1121 + 신규 40), `npm run lint` clean, prettier 통과
- [x] 필요한 문서 업데이트 반영 — SECURITY 양쪽 + CONTRIBUTING §10
- [x] schema / provider / CLI 영향 범위를 직접 점검 — docs only + test 신규, 코드 / contract 변경 없음
- [x] PR 본문 / 디프 / 출력 예시에 access token / refresh token / id token / accountKey 같은 민감값을 redact 했음 — 해당 없음 (보안 문서지만 절차 안내, 실제 토큰 없음)

## 리뷰 포인트

- **번역 정확성 (SECURITY)** — 보안 신고 절차 / 토큰 누설 시 복구 / Telegram 위협 모델의 핵심 의미가 영문 본과 한글 본에서 동일한지. 특히 BotFather `/revoke` 흐름 / chmod 600 / SENSITIVE_KEYS 같은 핵심 keyword 가 양쪽 동일.
- **CONTRIBUTING §10 dual 분류** — 각 파일이 "영문 default + 한글 보존" / "한글 default + 영문 추가" / "한글 only" 중 어디에 속하는지가 의도와 일치하는지. CODE_OF_CONDUCT 표준 영어 처리도 OK 인지.
- **`repo-policy-i18n.test.js` 의 검사 범위** — 5 describe 블록이 i18n drift 가능한 회귀 시나리오를 충분히 커버하는지. 누락된 가드 (예: 양쪽 본문 길이 균형 / 양쪽 ToC 정합 등) 가 있다면 별도 follow-up issue.
- **`Closes #154`** — 본 PR 머지로 master issue 자동 close. dev → main FF sync 다음 cycle 의 release PR 에 누적 changeset 4 건 (`docs-i18n-readme` + `docs-i18n-external-core` + `docs-i18n-external-extra` + `docs-i18n-meta`) 모아 v0.7.0 publish.

## 참고 사항

- 관련 master issue: #154 — 본 PR 머지로 close
- Out of scope (별도 후속 / 보류):
  - Docusaurus / VitePress 기반 독립 docs 사이트 (현재 분량 / 사용자 규모 대비 over-engineering)
  - 자동 번역 CI (Claude API 호출) — AI draft 는 사람 review 정책 유지
  - 다른 언어 (일본어 / 중국어 등) — 영어 dual 후 별도 사이클
  - 내부 docs (codebase-guide / release-policy / auth-store-schema / claude-oauth-plan) 영어화 — contributor 한국 기반 유지

Closes #154
